### PR TITLE
Fixed mob kill zone for quest 1604

### DIFF
--- a/game-server/data/handlers/quest/heiron/_1604ToCatchASpy.java
+++ b/game-server/data/handlers/quest/heiron/_1604ToCatchASpy.java
@@ -75,7 +75,7 @@ public class _1604ToCatchASpy extends AbstractQuestHandler {
 			return false;
 		}
 
-		if (PositionUtil.getDistance(env.getVisibleObject(), 717.78f, 623.50f, 130) < 30) {
+		if (PositionUtil.getDistance(env.getVisibleObject(), 685.7317f, 652.7245f, 130) < 30) {
 			((Npc) env.getVisibleObject()).getController().die(player);
 			qs.setQuestVarById(0, qs.getQuestVarById(0) + 1);
 			qs.setStatus(QuestStatus.REWARD);


### PR DESCRIPTION
Fixed the position of killing monsters, as monsters in the original position would be killed by NPCs, resulting in mission failure.