### PR TITLE
Possible fix for AutoGroupService and SM Dispell

### DIFF
--- a/game-server/src/com/aionemu/gameserver/controllers/effect/EffectController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/effect/EffectController.java
@@ -552,6 +552,10 @@ public class EffectController {
 				if (targetSlot == SkillTargetSlot.DEBUFF && !effect.getEffector().equals(ef.getEffector()))
 					continue;
 
+				// remove only skill that can be dispelled by the effector ( SM debuffs )
+				if(targetSlot == SkillTargetSlot.DEBUFF && effect.getEffector().equals(ef.getEffector()) && !ef.canBeDispelled())
+					continue;
+
 				switch (dispelCat) {
 					case ALL:
 					case BUFF:// DispelBuffCounterAtkEffect

--- a/game-server/src/com/aionemu/gameserver/model/autogroup/AutoHarmonyInstance.java
+++ b/game-server/src/com/aionemu/gameserver/model/autogroup/AutoHarmonyInstance.java
@@ -68,19 +68,42 @@ public class AutoHarmonyInstance extends AutoInstance {
 	@Override
 	public void onEnterInstance(Player player) {
 		super.onEnterInstance(player);
+
 		if (player.isInGroup()) {
 			return;
 		}
+
 		int playerId = player.getObjectId();
 		Map.Entry<Integer, List<AGPlayer>> groupEntry = getGroupEntry(playerId);
-		if (groupEntry == null)
+
+		if (groupEntry == null) {
 			return;
+		}
 
 		HarmonyArenaScore score = (HarmonyArenaScore) instance.getInstanceHandler().getInstanceScore();
 		List<Player> players = findPlayersInInstance(groupEntry.getValue());
 		players.remove(player);
 
-		if (players.isEmpty()) { // Create Group
+		int maxPlayersPerGroup = 3;
+		int currentGroupSize = players.size();
+
+		if (players.isEmpty() || currentGroupSize < maxPlayersPerGroup) {
+			if (players.isEmpty()) {
+				PlayerGroup newGroup = PlayerGroupService.createGroup(player, player, TeamType.AUTO_GROUP, 0);
+				int groupId = newGroup.getObjectId();
+				if (!instance.isRegistered(groupId)) {
+					instance.register(groupId);
+					HarmonyGroupReward reward = new HarmonyGroupReward(groupEntry.getKey(), 12000, (byte) 7, groupId);
+					reward.addPlayer(registeredAGPlayers.get(player.getObjectId()));
+					score.addHarmonyGroup(reward);
+				}
+			} else {
+				PlayerGroup pg = players.get(0).getPlayerGroup();
+				PlayerGroupService.addPlayer(pg, player);
+				HarmonyGroupReward reward = score.getGroupReward(pg.getLeader().getObjectId());
+				reward.addPlayer(registeredAGPlayers.get(player.getObjectId()));
+			}
+		} else {
 			PlayerGroup newGroup = PlayerGroupService.createGroup(player, player, TeamType.AUTO_GROUP, 0);
 			int groupId = newGroup.getObjectId();
 			if (!instance.isRegistered(groupId)) {
@@ -89,11 +112,6 @@ public class AutoHarmonyInstance extends AutoInstance {
 				reward.addPlayer(registeredAGPlayers.get(player.getObjectId()));
 				score.addHarmonyGroup(reward);
 			}
-		} else { // Add To Group
-			PlayerGroup pg = players.getFirst().getPlayerGroup();
-			PlayerGroupService.addPlayer(pg, player);
-			HarmonyGroupReward reward = score.getGroupReward(pg.getLeader().getObjectId());
-			reward.addPlayer(registeredAGPlayers.get(player.getObjectId()));
 		}
 
 		if (!instance.isRegistered(playerId)) {
@@ -143,10 +161,17 @@ public class AutoHarmonyInstance extends AutoInstance {
 	}
 
 	private AGQuestion canAddParty(List<AGPlayer> group, LookingForParty lfp) {
-		if (group.size() + lfp.getMemberObjectIds().size() > 3)
+		if (group.size() + lfp.getMemberObjectIds().size() > 3) {
 			return AGQuestion.FAILED;
-		if (!group.isEmpty() && group.getFirst().getRace() != lfp.getRace())
+		}
+
+		if (!group.isEmpty() && group.size() == 3) {
 			return AGQuestion.FAILED;
+		}
+
+		if (!group.isEmpty() && group.get(0).getRace() != lfp.getRace()) {
+			return AGQuestion.FAILED;
+		}
 
 		for (int objectId : lfp.getMemberObjectIds()) {
 			AGPlayer agp = AutoGroupUtility.getNewAutoGroupPlayer(objectId);
@@ -155,6 +180,7 @@ public class AutoHarmonyInstance extends AutoInstance {
 				registeredAGPlayers.put(objectId, agp);
 			}
 		}
+
 		return instance != null ? AGQuestion.ADDED : registeredAGPlayers.size() == getMaxPlayers() ? AGQuestion.READY : AGQuestion.ADDED;
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/services/AutoGroupService.java
+++ b/game-server/src/com/aionemu/gameserver/services/AutoGroupService.java
@@ -5,6 +5,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import com.aionemu.gameserver.configs.main.AutoGroupConfig;
 import com.aionemu.gameserver.model.ChatType;
+import com.aionemu.gameserver.model.Race;
 import com.aionemu.gameserver.model.autogroup.*;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.model.team.alliance.PlayerAllianceService;
@@ -18,6 +19,7 @@ import com.aionemu.gameserver.services.instance.PeriodicInstanceManager;
 import com.aionemu.gameserver.services.instance.PvPArenaService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
 import com.aionemu.gameserver.utils.ThreadPoolManager;
+import com.aionemu.gameserver.world.World;
 import com.aionemu.gameserver.world.WorldMapInstance;
 
 /**
@@ -44,6 +46,27 @@ public class AutoGroupService {
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_CANT_INSTANCE_ALREADY_REGISTERED(agt.getTemplate().getInstanceMapId()));
 				return;
 			}
+
+			// Verifica se há um player registrado com o mesmo MAC address
+			String playerMac = player.getClientConnection().getMacAddress();
+			String playerIp = player.getClientConnection().getIP();
+			boolean isMacAlreadyRegistered = false;
+			for (Player p : World.getInstance().getAllPlayers()) {
+				String pMac = p.getClientConnection().getMacAddress();
+				String pIp = p.getClientConnection().getIP();
+				if(pMac.equals(playerMac) && playerIp.equals(pIp)){
+					lfp = getSearchEntry(p.getObjectId(), lfps);
+					if (lfp != null) {
+						isMacAlreadyRegistered = true;
+					}
+				}
+			}
+
+			if (isMacAlreadyRegistered) {
+				PacketSendUtility.sendMessage(player, "It is not allowed to apply with two accounts!");
+				return;
+			}
+
 			lfp = new LookingForParty(player, ert, maskId);
 			lfps.add(lfp);
 
@@ -53,6 +76,10 @@ public class AutoGroupService {
 				PacketSendUtility.broadcastToWorld(
 					new SM_MESSAGE(0, null, player.getRace().getL10n() + " have registered for " + agt.getL10n() + ".", ChatType.BRIGHT_YELLOW_CENTER),
 					p -> p.getRace() != player.getRace() && agt.isInLvlRange(p.getLevel()));
+			}else if( AutoGroupConfig.ANNOUNCE_BATTLEGROUND_REGISTRATIONS && (agt.isHarmonyArena() || agt.isPvPSoloArena()) ){
+				PacketSendUtility.broadcastToWorld(
+					new SM_MESSAGE(0, null, "Players have registered for " + agt.getL10n() + ".", ChatType.BRIGHT_YELLOW_CENTER),
+					p -> agt.isInLvlRange(p.getLevel()));
 			}
 
 			if (!checkInstancesForOpenQuickEntries(lfp, maskId))
@@ -64,86 +91,235 @@ public class AutoGroupService {
 		List<LookingForParty> queuedParties = lookingParties.get(maskId);
 		if (queuedParties == null || queuedParties.isEmpty())
 			return;
+
 		AutoGroupType agt = AutoGroupType.getAGTByMaskId(maskId);
 		if (agt == null)
 			return;
+
 		synchronized (queuedParties) {
 			queuedParties.sort(null);
 
 			for (int i = 0; i < queuedParties.size(); i++) {
 				AutoInstance autoInstance = agt.createAutoInstance();
-				LookingForParty lfp = queuedParties.get(i);
-				AGQuestion question = autoInstance.addLookingForParty(lfp);
+				Map<Race, Integer> raceCount = new HashMap<>();
+				raceCount.put(Race.ELYOS, 0);
+				raceCount.put(Race.ASMODIANS, 0);
+
+				LookingForParty firstParty = queuedParties.get(i);
+				AGQuestion question = autoInstance.addLookingForParty(firstParty);
 				if (question == AGQuestion.FAILED)
 					continue;
+
 				List<LookingForParty> filteredParties = new ArrayList<>();
-				filteredParties.add(lfp);
+				filteredParties.add(firstParty);
+				raceCount.put(firstParty.getRace(), raceCount.get(firstParty.getRace()) + firstParty.getMemberObjectIds().size());
+
+				boolean allowSameRace = agt.isHarmonyArena() || agt.isPvPSoloArena() || agt.isGloryArena() || agt.isPvPFFAArena() || agt.isTrainingPvPFFAArena() || agt.isTrainingPvPSoloArena() || agt.isTrainingHarmonyArena();
+
 				if (question != AGQuestion.READY) {
 					for (int j = i + 1; j < queuedParties.size(); j++) {
-						lfp = queuedParties.get(j);
-						question = autoInstance.addLookingForParty(lfp);
+						LookingForParty secondParty = queuedParties.get(j);
+
+						Race secondRace = secondParty.getRace();
+						int secondGroupSize = secondParty.getMemberObjectIds().size();
+
+						if(!allowSameRace) {
+							if (raceCount.get(secondRace) + secondGroupSize > autoInstance.getMaxPlayers() / 2) {
+								continue;
+							}
+						}else{
+							if (raceCount.get(secondRace) + secondGroupSize > autoInstance.getMaxPlayers()) {
+								continue;
+							}
+						}
+
+						if (!allowSameRace && firstParty.getRace() == secondRace) {
+							continue;
+						}
+
+						question = autoInstance.addLookingForParty(secondParty);
 						if (question != AGQuestion.FAILED) {
-							filteredParties.add(lfp);
-							if (question == AGQuestion.READY)
+							filteredParties.add(secondParty);
+							raceCount.put(secondRace, raceCount.get(secondRace) + secondGroupSize);
+
+							if (question == AGQuestion.READY) {
 								break;
+							}
 						}
 					}
 				}
+
 				if (question == AGQuestion.READY) {
-					createNewInstance(autoInstance, agt, filteredParties, maskId);
-					break;
+					int totalPlayers = filteredParties.stream()
+						.mapToInt(p -> p.getMemberObjectIds().size())
+						.sum();
+
+					if (totalPlayers == autoInstance.getMaxPlayers()) {
+						createNewInstance(autoInstance, agt, filteredParties, maskId);
+						break;
+					}
 				}
 			}
 		}
 	}
 
 	private void createNewInstance(AutoInstance autoInstance, AutoGroupType agt, List<LookingForParty> filteredParties, int maskId) {
-		WorldMapInstance instance = InstanceService.getNextAvailableInstance(agt.getTemplate().getInstanceMapId(), 0, agt.getDifficultId(), null,
-			autoInstance.getMaxPlayers(), false);
+		WorldMapInstance instance = InstanceService.getNextAvailableInstance(
+			agt.getTemplate().getInstanceMapId(),
+			0,
+			agt.getDifficultId(),
+			null,
+			autoInstance.getMaxPlayers(),
+			false
+		);
 		autoInstance.onInstanceCreate(instance);
 		autoInstances.put(instance, autoInstance);
+
+		Map<Race, Integer> raceCount = new HashMap<>();
+		raceCount.put(Race.ELYOS, 0);
+		raceCount.put(Race.ASMODIANS, 0);
+
 		for (LookingForParty lfp : filteredParties) {
-			removeSearchEntry(lfp);
-			lfp.setStartEnterTime();
-			lfp.getMemberObjectIds().forEach(id -> {
-				searchAndRemoveAdditionalRegistrations(id);
-				AutoGroupUtility.sendWindowToPlayerIfOnline(id, maskId, 4);
-			});
+			Race groupRace = lfp.getRace();
+			raceCount.put(groupRace, raceCount.get(groupRace) + lfp.getMemberObjectIds().size());
+		}
+
+		boolean allowSameRace = agt.isHarmonyArena() || agt.isPvPSoloArena() || agt.isGloryArena() || agt.isPvPFFAArena() || agt.isTrainingPvPFFAArena() || agt.isTrainingPvPSoloArena() || agt.isTrainingHarmonyArena();
+		int totalPlayers = raceCount.values().stream().mapToInt(Integer::intValue).sum();
+
+		if ((allowSameRace || raceCount.size() > 1) && totalPlayers == autoInstance.getMaxPlayers()) {
+			for (LookingForParty lfp : filteredParties) {
+				acceptGroupEntry(lfp, maskId, raceCount);
+			}
+		} else {
+			autoInstances.remove(instance);
 		}
 	}
 
 	private boolean checkInstancesForOpenQuickEntries(LookingForParty lfp, int maskId) {
-		if (lfp.getEntryRequestType() != EntryRequestType.QUICK_GROUP_ENTRY || lfp.isOnStartEnterTask())
+		if (lfp.getEntryRequestType() != EntryRequestType.QUICK_GROUP_ENTRY || lfp.isOnStartEnterTask()) {
 			return false;
+		}
+
 		for (AutoInstance autoInstance : autoInstances.values()) {
-			if (autoInstance.getAutoGroupType().getTemplate().getMaskId() == maskId && autoInstance.addLookingForParty(lfp) == AGQuestion.ADDED) {
-				removeSearchEntry(lfp);
-				lfp.setStartEnterTime();
-				AutoGroupUtility.sendWindowToPlayerIfOnline(lfp.getLeaderObjId(), maskId, 4);
-				searchAndRemoveAdditionalRegistrations(lfp.getLeaderObjId());
+			if (autoInstance.getAutoGroupType().getTemplate().getMaskId() != maskId) {
+				continue;
+			}
+
+			Map<Race, Integer> raceCount = new HashMap<>();
+			raceCount.put(Race.ELYOS, 0);
+			raceCount.put(Race.ASMODIANS, 0);
+
+			if (autoInstance.getInstance() != null) {
+				for (Player player : autoInstance.getInstance().getPlayersInside()) {
+					Race playerRace = player.getRace();
+					raceCount.put(playerRace, raceCount.get(playerRace) + 1);
+				}
+			}
+
+			AutoGroupType agt = autoInstance.getAutoGroupType();
+			boolean allowSameRace = agt.isHarmonyArena() || agt.isPvPSoloArena() || agt.isGloryArena() || agt.isPvPFFAArena() || agt.isTrainingPvPFFAArena() || agt.isTrainingPvPSoloArena() || agt.isTrainingHarmonyArena();
+			Race lfpRace = lfp.getRace();
+			int lfpGroupSize = lfp.getMemberObjectIds().size();
+
+			if(!allowSameRace) {
+				if (raceCount.get(lfpRace) + lfpGroupSize > autoInstance.getMaxPlayers() / 2) {
+					continue;
+				}
+			}else{
+				if (raceCount.get(lfpRace) + lfpGroupSize > autoInstance.getMaxPlayers()) {
+					continue;
+				}
+			}
+
+			if (!allowSameRace && raceCount.values().stream().allMatch(count -> count == 0)) {
+
+				continue;
+			}
+
+			AGQuestion question = autoInstance.addLookingForParty(lfp);
+			if (question == AGQuestion.READY) {
+
+				acceptGroupEntry(lfp, maskId, raceCount);
 				return true;
+			} else if (question != AGQuestion.FAILED) {
+				raceCount.put(lfpRace, raceCount.get(lfpRace) + lfpGroupSize);
 			}
 		}
 		return false;
 	}
 
 	private void checkQueueForQuickEntries(AutoInstance autoInstance) {
+		Map<Race, Integer> raceCount = new HashMap<>();
+		raceCount.put(Race.ELYOS, 0);
+		raceCount.put(Race.ASMODIANS, 0);
+
+		for (Player player : autoInstance.getInstance().getPlayersInside()) {
+			Race playerRace = player.getRace();
+			raceCount.put(playerRace, raceCount.get(playerRace) + 1);
+		}
+
 		int maskId = autoInstance.getAutoGroupType().getTemplate().getMaskId();
 		List<LookingForParty> parties = lookingParties.get(maskId);
-		if (parties == null || parties.isEmpty())
+		if (parties == null || parties.isEmpty()) {
 			return;
+		}
+
+		AutoGroupType agt = autoInstance.getAutoGroupType();
+		boolean allowSameRace = agt.isHarmonyArena() || agt.isPvPSoloArena() || agt.isGloryArena() || agt.isPvPFFAArena() || agt.isTrainingPvPFFAArena() || agt.isTrainingPvPSoloArena() || agt.isTrainingHarmonyArena();
+
 		synchronized (parties) {
+			List<LookingForParty> filteredParties = new ArrayList<>();
+
 			for (LookingForParty lfp : parties) {
-				if (lfp.getEntryRequestType() == EntryRequestType.QUICK_GROUP_ENTRY && !lfp.isOnStartEnterTask()
-					&& autoInstance.addLookingForParty(lfp) == AGQuestion.ADDED) {
-					removeSearchEntry(lfp);
-					lfp.setStartEnterTime();
-					AutoGroupUtility.sendWindowToPlayerIfOnline(lfp.getLeaderObjId(), maskId, 4);
-					searchAndRemoveAdditionalRegistrations(lfp.getLeaderObjId());
+				Race race = lfp.getRace();
+				int groupSize = lfp.getMemberObjectIds().size();
+
+				if(!allowSameRace) {
+					if (raceCount.get(race) + groupSize > autoInstance.getMaxPlayers() / 2) {
+						continue;
+					}
+				}else{
+					if (raceCount.get(race) + groupSize > autoInstance.getMaxPlayers()) {
+						continue;
+					}
+				}
+
+				if (!allowSameRace && filteredParties.stream().anyMatch(p -> p.getRace() == race)) {
+					continue;
+				}
+
+				filteredParties.add(lfp);
+				raceCount.put(race, raceCount.get(race) + groupSize);
+
+				int totalPlayers = filteredParties.stream()
+					.mapToInt(p -> p.getMemberObjectIds().size())
+					.sum();
+
+				if (totalPlayers == autoInstance.getMaxPlayers()) {
+					createNewInstance(autoInstance, autoInstance.getAutoGroupType(), filteredParties, maskId);
 					return;
 				}
 			}
 		}
+	}
+
+	private void acceptGroupEntry(LookingForParty lfp, int maskId, Map<Race, Integer> sentPlayers) {
+		List<Integer> memberIds = lfp.getMemberObjectIds();
+		Race groupRace = null;
+		removeSearchEntry(lfp);
+		lfp.setStartEnterTime();
+		for (int id : memberIds) {
+			Player player = World.getInstance().getPlayer(id);
+			if (player == null) {
+				continue;
+			}
+			groupRace = player.getRace();
+			searchAndRemoveAdditionalRegistrations(id);
+			AutoGroupUtility.sendWindowToPlayerIfOnline(id, maskId, 4);
+		}
+
+		sentPlayers.put(groupRace, sentPlayers.get(groupRace) + memberIds.size());
 	}
 
 	private void searchAndRemoveAdditionalRegistrations(int objectId) {

--- a/game-server/src/com/aionemu/gameserver/services/AutoGroupService.java
+++ b/game-server/src/com/aionemu/gameserver/services/AutoGroupService.java
@@ -47,26 +47,6 @@ public class AutoGroupService {
 				return;
 			}
 
-			// Verifica se há um player registrado com o mesmo MAC address
-			String playerMac = player.getClientConnection().getMacAddress();
-			String playerIp = player.getClientConnection().getIP();
-			boolean isMacAlreadyRegistered = false;
-			for (Player p : World.getInstance().getAllPlayers()) {
-				String pMac = p.getClientConnection().getMacAddress();
-				String pIp = p.getClientConnection().getIP();
-				if(pMac.equals(playerMac) && playerIp.equals(pIp)){
-					lfp = getSearchEntry(p.getObjectId(), lfps);
-					if (lfp != null) {
-						isMacAlreadyRegistered = true;
-					}
-				}
-			}
-
-			if (isMacAlreadyRegistered) {
-				PacketSendUtility.sendMessage(player, "It is not allowed to apply with two accounts!");
-				return;
-			}
-
 			lfp = new LookingForParty(player, ert, maskId);
 			lfps.add(lfp);
 

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
@@ -1087,6 +1087,25 @@ public class Effect implements StatOwner {
 		return 10;
 	}
 
+	public boolean canBeDispelled()
+	{
+		if (skillTemplate.getGroup() != null) {
+			switch (skillTemplate.getGroup()) {
+				case "EL_ENFEEBLEMENT":
+				case "EL_MANAREVERSE":
+				case "EL_HELLPAIN":
+					return true;
+			}
+		}
+		if (skillTemplate.getStack() != null) {
+			if (skillTemplate.getStack().equals("EL_MANAREVERSE_SYS")) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	public int getPower() {
 		return power;
 	}


### PR DESCRIPTION
There is a problem that when 2 groups of the same race applyed at Idgel Dome (exemple), it was poping the Enter for them, and when entering, they were at the same side, like a group of 12, or sometimes 8 in one instance and 4 on another instance.
The fix ive made, now its validating Arenas and PVP DG, if allow same race, the amount of players need to pop enter.
1 possible problem: After the changes, on Harmony happened to send 1 player of the group (3 members group) to a instance alone, while the rest of the group went to the correct instance against the other group.

Tested on Terath Dredg, Idgel Dome, Kamar, Discipline, Harmony.

SM Dispell:
https://aioncodex.com/5x/skill/3574/?sl=1
This skill, Infernal Pain and Magic Implosion, have a tag (can be dispelled), what it means? if the SM dispell a taget, and the target had only 2 buffs (the magic implosion remove 3 buffs), if the target had only 2 buffs and a debuff like Infernal Pain. The result would be the 2 buffs removed and the Infernal Pain removed. If was 2 buffs and Erosion, the Erosion cannot be removed. and the result would be only 2 buffs of the target removed.

Today its removing even Erosion, so i made a validation to check the STACK/GROUP of only these skills (Infernal Pain, Shackle of Vulnerability and Magic Implosion).