### PR TITLE
Allow opening Private Store with active Power Shards

### DIFF
--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/state/CreatureState.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/state/CreatureState.java
@@ -20,7 +20,8 @@ public enum CreatureState {
 	CHAIR(FLYING.getId() + RESTING.getId(), true), // 2 + 4 (need to stand near a chair, otherwise shows resting state)
 	DEAD(ACTIVE.getId() + FLYING.getId() + RESTING.getId()), // 1 + 2 + 4
 	PRIVATE_SHOP(ACTIVE.getId() + FLYING.getId() + FLOATING_CORPSE.getId(), true), // 1 + 2 + 8
-	LOOTING(RESTING.getId() + FLOATING_CORPSE.getId()); // 4 + 8
+	LOOTING(RESTING.getId() + FLOATING_CORPSE.getId()), // 4 + 8
+	ACTIVE_WITH_POWERSHARD(ACTIVE.getId() + POWERSHARD.getId(), true); // 1 + 128
 
 	private int id;
 	private boolean mustMatchExact;

--- a/game-server/src/com/aionemu/gameserver/services/PrivateStoreService.java
+++ b/game-server/src/com/aionemu/gameserver/services/PrivateStoreService.java
@@ -74,7 +74,10 @@ public class PrivateStoreService {
 		}
 		if (player.isDead())
 			return false;
-		if (player.getState() != CreatureState.ACTIVE.getId())
+		if (
+			!player.isInState(CreatureState.ACTIVE) &&
+			!player.isInState(CreatureState.ACTIVE_WITH_POWERSHARD)
+		)
 			return false;
 		if (player.getStore() != null)
 			return false;


### PR DESCRIPTION
This change adds a new ACTIVE_WITH_POWERSHARD state to the CreatureState enum, combining the active state with the use of Power Shards.
In PrivateStoreService, the canOpenPrivateStore validation is updated to allow players to open their private store when in either ACTIVE or ACTIVE_WITH_POWERSHARD state.

Main Changes:

Added ACTIVE_WITH_POWERSHARD state in CreatureState.java.

Updated canOpenPrivateStore condition to also accept ACTIVE_WITH_POWERSHARD.

Motivation:
Previously, players were unable to open the private store if they had Power Shards active. This change removes that unnecessary restriction while keeping compatibility with the standard active state.