### PR TITLE
Refactor NPC dialog handling and quest event processing

### DIFF
--- a/game-server/src/com/aionemu/gameserver/controllers/NpcController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/NpcController.java
@@ -263,14 +263,10 @@ public class NpcController extends CreatureController<Npc> {
 
 	@Override
 	public void onDialogSelect(int dialogActionId, int prevDialogId, Player player, int questId, int extendedRewardIndex) {
-		if (!PositionUtil.isInTalkRange(player, getOwner())) {
-			// TODO remove this call and return unconditionally once logging has clarified wtf it is trying to solve 
-			if (QuestEngine.getInstance().onDialog(new QuestEnv(getOwner(), player, questId, dialogActionId)))
-				log.warn(player + " talked to " + getOwner() + " out of range, but QuestEngine.onDialog returned true");
-			else
-				return;
-		}
-		if (!getOwner().getAi().onDialogSelect(player, dialogActionId, questId, extendedRewardIndex)) {
+		if (
+			!QuestEngine.getInstance().onDialog(new QuestEnv(getOwner(), player, questId, dialogActionId)) &&
+			!getOwner().getAi().onDialogSelect(player, dialogActionId, questId, extendedRewardIndex)
+		) {
 			DialogService.onDialogSelect(dialogActionId, player, getOwner(), questId, extendedRewardIndex);
 		}
 	}

--- a/game-server/src/com/aionemu/gameserver/controllers/NpcController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/NpcController.java
@@ -263,8 +263,10 @@ public class NpcController extends CreatureController<Npc> {
 
 	@Override
 	public void onDialogSelect(int dialogActionId, int prevDialogId, Player player, int questId, int extendedRewardIndex) {
+		if (!PositionUtil.isInTalkRange(player, getOwner())) {
+			return;
+		}
 		if (
-			!QuestEngine.getInstance().onDialog(new QuestEnv(getOwner(), player, questId, dialogActionId)) &&
 			!getOwner().getAi().onDialogSelect(player, dialogActionId, questId, extendedRewardIndex)
 		) {
 			DialogService.onDialogSelect(dialogActionId, player, getOwner(), questId, extendedRewardIndex);

--- a/game-server/src/com/aionemu/gameserver/controllers/NpcController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/NpcController.java
@@ -263,12 +263,9 @@ public class NpcController extends CreatureController<Npc> {
 
 	@Override
 	public void onDialogSelect(int dialogActionId, int prevDialogId, Player player, int questId, int extendedRewardIndex) {
-		if (!PositionUtil.isInTalkRange(player, getOwner())) {
+		if (!PositionUtil.isInTalkRange(player, getOwner()))
 			return;
-		}
-		if (
-			!getOwner().getAi().onDialogSelect(player, dialogActionId, questId, extendedRewardIndex)
-		) {
+		if (!getOwner().getAi().onDialogSelect(player, dialogActionId, questId, extendedRewardIndex)) {
 			DialogService.onDialogSelect(dialogActionId, player, getOwner(), questId, extendedRewardIndex);
 		}
 	}

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/AbstractQuestHandler.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/AbstractQuestHandler.java
@@ -91,13 +91,7 @@ public abstract class AbstractQuestHandler {
 	public abstract void register();
 
 	public boolean onDialogEvent(QuestEnv env) {
-		int dialogActionId = env.getDialogActionId();
-		if (dialogActionId >= SELECT1 && dialogActionId <= SELECT15_4_4_4_4) {
-			// simple "next page" event (action ID = next dialog page ID), but there are some quests where this default behavior does not apply (e.g.
-			// 4074)
-			return false;
-		}
-		switch (dialogActionId) {
+		switch (env.getDialogActionId()) {
 			case ASK_QUEST_ACCEPT: // show quest accept dialog (coming from pre-conversation)
 				sendDialogPacket(env, DialogPage.ASK_QUEST_ACCEPT_WINDOW.id(), questId);
 				return true;

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/AbstractQuestHandler.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/AbstractQuestHandler.java
@@ -95,8 +95,7 @@ public abstract class AbstractQuestHandler {
 		if (dialogActionId >= SELECT1 && dialogActionId <= SELECT15_4_4_4_4) {
 			// simple "next page" event (action ID = next dialog page ID), but there are some quests where this default behavior does not apply (e.g.
 			// 4074)
-			PacketSendUtility.sendPacket(env.getPlayer(), new SM_DIALOG_WINDOW(env.getVisibleObject().getObjectId(), dialogActionId));
-			return true;
+			return false;
 		}
 		switch (dialogActionId) {
 			case ASK_QUEST_ACCEPT: // show quest accept dialog (coming from pre-conversation)

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/AbstractQuestHandler.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/AbstractQuestHandler.java
@@ -95,7 +95,7 @@ public abstract class AbstractQuestHandler {
 		if (dialogActionId >= SELECT1 && dialogActionId <= SELECT15_4_4_4_4) {
 			// simple "next page" event (action ID = next dialog page ID), but there are some quests where this default behavior does not apply (e.g.
 			// 4074)
-			sendDialogPacket(env, dialogActionId, questId);
+			PacketSendUtility.sendPacket(env.getPlayer(), new SM_DIALOG_WINDOW(env.getVisibleObject().getObjectId(), dialogActionId));
 			return true;
 		}
 		switch (dialogActionId) {

--- a/game-server/src/com/aionemu/gameserver/services/DialogService.java
+++ b/game-server/src/com/aionemu/gameserver/services/DialogService.java
@@ -65,6 +65,12 @@ public class DialogService {
 			mailbox.mailBoxState = PlayerMailboxState.CLOSED;
 	}
 
+	private static boolean handleQuestDialog(Player player, Npc npc, int questId, int dialogActionId, int extendedRewardIndex) {
+		QuestEnv env = new QuestEnv(npc, player, questId, dialogActionId);
+		env.setExtendedRewardIndex(extendedRewardIndex);
+		return QuestEngine.getInstance().onDialog(env);
+	}
+	
 	public static void onDialogSelect(int dialogActionId, Player player, Npc npc, int questId, int extendedRewardIndex) {
 		int targetObjectId = npc.getObjectId();
 
@@ -271,17 +277,14 @@ public class DialogService {
 					HousingService.getInstance().recreatePlayerStudio(player);
 					break;
 				default:
-					// action id = next page id
+					if (handleQuestDialog(player, npc, questId, dialogActionId, extendedRewardIndex)) {
+						break;	
+					}
 					PacketSendUtility.sendPacket(player, new SM_DIALOG_WINDOW(targetObjectId, dialogActionId));
 					break;
 			}
 		} else {
-			QuestEnv env = new QuestEnv(npc, player, questId, dialogActionId);
-			env.setExtendedRewardIndex(extendedRewardIndex);
-			if (QuestEngine.getInstance().onDialog(env))
-				return;
-			// action id = next page id
-			PacketSendUtility.sendPacket(player, new SM_DIALOG_WINDOW(targetObjectId, dialogActionId, questId));
+			handleQuestDialog(player, npc, questId, dialogActionId, extendedRewardIndex);
 		}
 	}
 

--- a/game-server/src/com/aionemu/gameserver/services/DialogService.java
+++ b/game-server/src/com/aionemu/gameserver/services/DialogService.java
@@ -65,12 +65,6 @@ public class DialogService {
 			mailbox.mailBoxState = PlayerMailboxState.CLOSED;
 	}
 
-	private static boolean handleQuestDialog(Player player, Npc npc, int questId, int dialogActionId, int extendedRewardIndex) {
-		QuestEnv env = new QuestEnv(npc, player, questId, dialogActionId);
-		env.setExtendedRewardIndex(extendedRewardIndex);
-		return QuestEngine.getInstance().onDialog(env);
-	}
-	
 	public static void onDialogSelect(int dialogActionId, Player player, Npc npc, int questId, int extendedRewardIndex) {
 		int targetObjectId = npc.getObjectId();
 
@@ -277,18 +271,21 @@ public class DialogService {
 					HousingService.getInstance().recreatePlayerStudio(player);
 					break;
 				default:
-					if (handleQuestDialog(player, npc, questId, dialogActionId, extendedRewardIndex)) {
-						break;	
-					}
-					PacketSendUtility.sendPacket(player, new SM_DIALOG_WINDOW(targetObjectId, dialogActionId));
+					handleQuestDialogueOrSendNextPage(dialogActionId, player, npc, questId, extendedRewardIndex);
 					break;
 			}
 		} else {
-			if(handleQuestDialog(player, npc, questId, dialogActionId, extendedRewardIndex)) {
-				return;
-			}
-			PacketSendUtility.sendPacket(player, new SM_DIALOG_WINDOW(targetObjectId, dialogActionId, questId));
+			handleQuestDialogueOrSendNextPage(dialogActionId, player, npc, questId, extendedRewardIndex);
 		}
+	}
+
+	private static void handleQuestDialogueOrSendNextPage(int dialogActionId, Player player, Npc npc, int questId, int extendedRewardIndex) {
+		QuestEnv env = new QuestEnv(npc, player, questId, dialogActionId);
+		env.setExtendedRewardIndex(extendedRewardIndex);
+		if (QuestEngine.getInstance().onDialog(env))
+			return;
+		// action id = next page id
+		PacketSendUtility.sendPacket(player, new SM_DIALOG_WINDOW(npc.getObjectId(), dialogActionId, questId));
 	}
 
 	private static void sendDialogWindow(int dialogActionId, final Player player, Npc npc) {

--- a/game-server/src/com/aionemu/gameserver/services/DialogService.java
+++ b/game-server/src/com/aionemu/gameserver/services/DialogService.java
@@ -284,7 +284,10 @@ public class DialogService {
 					break;
 			}
 		} else {
-			handleQuestDialog(player, npc, questId, dialogActionId, extendedRewardIndex);
+			if(handleQuestDialog(player, npc, questId, dialogActionId, extendedRewardIndex)) {
+				return;
+			}
+			PacketSendUtility.sendPacket(player, new SM_DIALOG_WINDOW(targetObjectId, dialogActionId, questId));
 		}
 	}
 


### PR DESCRIPTION
# PR Title
Refactor NPC dialog handling and fix "load fail!" error on certain NPCs

## Description
This update simplifies and streamlines NPC dialog interaction logic, removes unnecessary calls to `QuestEngine.onDialog`, and consolidates duplicated quest handling code.  
Additionally, it fixes the issue where certain NPCs (e.g., *Ancient Crown Administration Officer*, *Ancient Goblet Administration Officer*) displayed a `load fail!` message when interacted with.

## Main Changes
- **`NpcController`**:  
  - Removed redundant `QuestEngine.onDialog` call when out of range.  
  - Simplified position check with an early return if the player is not in talk range.  
  - Retained AI dialog handling and ensured consistent call to `DialogService.onDialogSelect`.

- **`AbstractQuestHandler`**:  
  - Replaced `sendDialogPacket` with a direct `PacketSendUtility.sendPacket` call to `SM_DIALOG_WINDOW`.

- **Dialog handling refactor**:  
  - Introduced `handleQuestDialog` helper method to centralize quest environment creation and processing.  
  - Updated multiple dialog interaction flows to use the new helper method, removing duplicated `QuestEnv` creation.  
  - Ensured consistent handling of `extendedRewardIndex` in all dialog paths.

## Motivation

<img width="783" height="884" alt="image" src="https://github.com/user-attachments/assets/334783bf-33f7-46b8-a68e-6ddf6ec698e4" />

Previously, some NPCs triggered a `load fail!` error due to redundant or incorrect dialog event handling.  
This refactor removes unnecessary calls, ensures consistent quest dialog processing, and fixes the dialog display for affected NPCs, allowing their HTML pages to load properly without breaking interactions.
