### PR TITLE
Fix elemental defend while moving: constant value instead percent

### DIFF
--- a/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
+++ b/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
@@ -600,7 +600,7 @@ public class StatFunctions {
 					case MAGICAL_ATTACK:
 						return value * 1.1f; // verified on 4.6 PTS
 					case MAGICAL_DEFEND:
-						return value - 50;
+						return value - 50; // verified on 4.6 PTS
 					case PHYSICAL_DEFENSE:
 						return value * 0.8f;
 				}

--- a/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
+++ b/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
@@ -600,6 +600,7 @@ public class StatFunctions {
 					case MAGICAL_ATTACK:
 						return value * 1.1f; // verified on 4.6 PTS
 					case MAGICAL_DEFEND:
+						return value - 50;
 					case PHYSICAL_DEFENSE:
 						return value * 0.8f;
 				}


### PR DESCRIPTION
### Summary
This pull request fixes an incorrect calculation of elemental defense reduction when the attacker is moving forward.

Currently, elemental defense is reduced by a percentage, while according to game mechanics it should be reduced by a fixed value. This leads to incorrect damage scaling in multiple edge cases and deviates from retail behavior.

---

### Problem Description

**Expected behavior (ER):**  
When the attacked moves forward, the target’s elemental defense should be reduced by **50 flat points**.

**Actual behavior (AR):**  
Elemental defense is reduced by **20%**, which produces incorrect results.

This causes several issues:

- If the target has **0 elemental defense**, moving forward does not increase damage at all  
  (`0 * 0.8 = 0`), while it should effectively become **-50**.

- If the target is affected by debuffs such as *Spiritmaster’s 'Shackle of Vulnerability'*  
  (e.g. **-200 elemental defense**), moving forward increases elemental defense to **-160**,  
  resulting in **lower damage** instead of higher damage  
  (`-200 * 0.8 = -160`).

These behaviors are clearly incorrect and contradict both in-game expectations and retail mechanics.
---

### Reference
This issue was previously documented with video evidence on a Java-based server build.  
The same problem appears to exist in most Java Aion server implementations.

Forum post (with videos and comparison to EuroAion 4.6 PTS):  
https://forum.aiondestiny.net/index.php?/topic/24301-%D0%BD%D0%B5%D0%B2%D0%B5%D1%80%D0%BD%D1%8B%D0%B9-%D1%80%D0%B0%D1%81%D1%87%D0%B5%D1%82-%D1%81%D1%82%D0%B8%D1%85%D0%B8%D0%B9%D0%BD%D0%BE%D0%B9-%D0%B7%D0%B0%D1%89%D0%B8%D1%82%D1%8B-%D0%BF%D1%80%D0%B8-%D0%B4%D0%B2%D0%B8%D0%B6%D0%B5%D0%BD%D0%B8%D0%B8-%D0%B2%D0%BF%D0%B5%D1%80%D0%B5%D0%B4/

---

### Known Limitations

This pull request **does not cover the following cases**, as addressing them would require a larger refactoring:

1. Elemental defense **should not be reduced** by forward movement bonuses for skills with interval-based damage (e.g. `SpellATK`).
2. Movement bonuses **should not apply** to skills of type `DispelBuffCounterATK` (Magic Implosion for ex.), `ProcATK_Instant` (godstones, apply lethal venom for ex), `DelayedSpellATK_Instant` (Magma burst for ex)  . These skills should deal the same damage regardless of whether the attacker is moving forward, backward, or standing still. 