### PR TITLE
Fix movement modifiers applied to unsupported damage effects

### DIFF
--- a/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
@@ -314,7 +314,7 @@ public class AttackUtil {
 				damageMultiplier = shouldIncreaseByOneTimeBoost ? effector.getObserveController().getBaseMagicalDamageMultiplier() : 1f;
 				damage = StatFunctions.calculateMagicalSkillDamage(effector, effected, damage, (int) bonus, element, true, true);
 			}
-			if (template.shouldApplyAttackerMovementModifier()){
+			if (template.shouldApplyAttackerMovementModifier()) {
 				damage = StatFunctions.adjustStatByMovementModifier(effector, isPhysical ? StatEnum.PHYSICAL_ATTACK : StatEnum.MAGICAL_ATTACK, damage);
 			}
 			damage *= damageMultiplier;

--- a/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
@@ -230,7 +230,6 @@ public class AttackUtil {
 		// define values
 		ActionModifier modifier = template.getActionModifiers(effect);
 		SkillElement element = template.getElement();
-		Func func = template.getMode();
 		int randomDamageType = template instanceof SkillAttackInstantEffect skillAttackInstantEffect ? skillAttackInstantEffect.getRnddmg() : 0;
 		int critAddDmg = template.getCritAddDmg2() + template.getCritAddDmg1() * effect.getSkillLevel();
 		boolean useTemplateDmg = isUseTemplateDmg(effect, template);
@@ -289,11 +288,9 @@ public class AttackUtil {
 			damage += res.getExactDamage();
 		}
 		// add skill damage
-		if (func != null) {
-			switch (func) {
-				case ADD -> damage += skillDamage;
-				case PERCENT -> damage += baseAttack * skillDamage / 100f;
-			}
+		switch (template.getMode()) {
+			case ADD -> damage += skillDamage;
+			case PERCENT -> damage += baseAttack * skillDamage / 100f;
 		}
 
 		// add bonus damage

--- a/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
@@ -224,13 +224,13 @@ public class AttackUtil {
 		};
 	}
 
-	public static void calculateSkillResult(Effect effect, int skillDamage, EffectTemplate template, boolean ignoreShield) {
+	public static void calculateSkillResult(Effect effect, int skillDamage, DamageEffect template, boolean ignoreShield) {
 		Creature effector = effect.getEffector();
 		Creature effected = effect.getEffected();
 		// define values
 		ActionModifier modifier = template.getActionModifiers(effect);
 		SkillElement element = template.getElement();
-		Func func = template instanceof DamageEffect damageEffect ? damageEffect.getMode() : Func.ADD;
+		Func func = template.getMode();
 		int randomDamageType = template instanceof SkillAttackInstantEffect skillAttackInstantEffect ? skillAttackInstantEffect.getRnddmg() : 0;
 		int critAddDmg = template.getCritAddDmg2() + template.getCritAddDmg1() * effect.getSkillLevel();
 		boolean useTemplateDmg = isUseTemplateDmg(effect, template);
@@ -318,7 +318,9 @@ public class AttackUtil {
 				damageMultiplier = shouldIncreaseByOneTimeBoost ? effector.getObserveController().getBaseMagicalDamageMultiplier() : 1f;
 				damage = StatFunctions.calculateMagicalSkillDamage(effector, effected, damage, (int) bonus, element, true, true);
 			}
-			damage = StatFunctions.adjustStatByMovementModifier(effector, isPhysical ? StatEnum.PHYSICAL_ATTACK : StatEnum.MAGICAL_ATTACK, damage);
+			if (template.shouldApplyMovementModifier()){
+				damage = StatFunctions.adjustStatByMovementModifier(effector, isPhysical ? StatEnum.PHYSICAL_ATTACK : StatEnum.MAGICAL_ATTACK, damage);
+			}
 			damage *= damageMultiplier;
 		}
 

--- a/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
@@ -19,7 +19,6 @@ import com.aionemu.gameserver.model.templates.item.ItemAttackType;
 import com.aionemu.gameserver.model.templates.item.enums.ItemGroup;
 import com.aionemu.gameserver.model.templates.item.enums.ItemSubType;
 import com.aionemu.gameserver.model.templates.npc.NpcTemplate;
-import com.aionemu.gameserver.skillengine.change.Func;
 import com.aionemu.gameserver.skillengine.effect.*;
 import com.aionemu.gameserver.skillengine.effect.modifier.ActionModifier;
 import com.aionemu.gameserver.skillengine.model.Effect;
@@ -315,7 +314,7 @@ public class AttackUtil {
 				damageMultiplier = shouldIncreaseByOneTimeBoost ? effector.getObserveController().getBaseMagicalDamageMultiplier() : 1f;
 				damage = StatFunctions.calculateMagicalSkillDamage(effector, effected, damage, (int) bonus, element, true, true);
 			}
-			if (template.shouldApplyMovementModifier()){
+			if (template.shouldApplyAttackerMovementModifier()){
 				damage = StatFunctions.adjustStatByMovementModifier(effector, isPhysical ? StatEnum.PHYSICAL_ATTACK : StatEnum.MAGICAL_ATTACK, damage);
 			}
 			damage *= damageMultiplier;

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/DamageEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/DamageEffect.java
@@ -59,4 +59,23 @@ public abstract class DamageEffect extends EffectTemplate {
 	public boolean isShared() {
 		return shared;
 	}
+	
+	/**
+	 * Determines whether movement-based modifiers should be applied
+	 * to this damage effect during damage calculation.
+	 *
+	 * <p>Movement-based modifiers may vary depending on the attacker's
+	 * movement state (e.g. standing, moving forward, or moving backward).
+	 * This method only defines whether such modifiers are applicable to
+	 * the effect at all.</p>
+	 *
+	 * <p>Specific {@link DamageEffect} implementations may override this
+	 * method to exclude themselves from movement-based damage adjustments.</p>
+	 *
+	 * @return {@code true} if movement-based modifiers should be applied,
+	 *         {@code false} otherwise
+	 */
+	public boolean shouldApplyMovementModifier() {
+		return true;
+	}
 }

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/DamageEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/DamageEffect.java
@@ -75,7 +75,7 @@ public abstract class DamageEffect extends EffectTemplate {
 	 * @return {@code true} if movement-based modifiers should be applied,
 	 *         {@code false} otherwise
 	 */
-	public boolean shouldApplyMovementModifier() {
+	public boolean shouldApplyAttackerMovementModifier() {
 		return true;
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/DelayedSpellAttackInstantEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/DelayedSpellAttackInstantEffect.java
@@ -40,4 +40,9 @@ public class DelayedSpellAttackInstantEffect extends DamageEffect {
 	@Override
 	public void calculateDamage(Effect effect) {
 	}
+
+	@Override
+	public boolean shouldApplyMovementModifier() {
+		return false;
+	}
 }

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/DelayedSpellAttackInstantEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/DelayedSpellAttackInstantEffect.java
@@ -40,9 +40,4 @@ public class DelayedSpellAttackInstantEffect extends DamageEffect {
 	@Override
 	public void calculateDamage(Effect effect) {
 	}
-
-	@Override
-	public boolean shouldApplyMovementModifier() {
-		return false;
-	}
 }

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/DispelBuffCounterAtkEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/DispelBuffCounterAtkEffect.java
@@ -47,6 +47,11 @@ public class DispelBuffCounterAtkEffect extends DamageEffect {
 	}
 
 	@Override
+	public boolean shouldApplyMovementModifier() {
+		return false;
+	}
+
+	@Override
 	public void endEffect(Effect effect) {
 		effect.getEffected().getEffectController().resetDesignatedDispelEffect(effect);
 		super.endEffect(effect);

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/DispelBuffCounterAtkEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/DispelBuffCounterAtkEffect.java
@@ -47,7 +47,7 @@ public class DispelBuffCounterAtkEffect extends DamageEffect {
 	}
 
 	@Override
-	public boolean shouldApplyMovementModifier() {
+	public boolean shouldApplyAttackerMovementModifier() {
 		return false;
 	}
 

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/NoReduceSpellATKInstantEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/NoReduceSpellATKInstantEffect.java
@@ -35,7 +35,7 @@ public class NoReduceSpellATKInstantEffect extends DamageEffect {
 	}
 
 	@Override
-	public boolean shouldApplyMovementModifier() {
+	public boolean shouldApplyAttackerMovementModifier() {
 		return false;
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/NoReduceSpellATKInstantEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/NoReduceSpellATKInstantEffect.java
@@ -33,4 +33,9 @@ public class NoReduceSpellATKInstantEffect extends DamageEffect {
 
 		AttackUtil.calculateSkillResult(effect, valueWithDelta, this, false);
 	}
+
+	@Override
+	public boolean shouldApplyMovementModifier() {
+		return false;
+	}
 }

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/ProcAtkInstantEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/ProcAtkInstantEffect.java
@@ -22,7 +22,7 @@ public class ProcAtkInstantEffect extends DamageEffect {
 	}
 
 	@Override
-	public boolean shouldApplyMovementModifier() {
+	public boolean shouldApplyAttackerMovementModifier() {
 		return false;
 	}
 

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/ProcAtkInstantEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/ProcAtkInstantEffect.java
@@ -22,6 +22,11 @@ public class ProcAtkInstantEffect extends DamageEffect {
 	}
 
 	@Override
+	public boolean shouldApplyMovementModifier() {
+		return false;
+	}
+
+	@Override
 	protected int calculateBaseValue(Effect effect) {
 		if (delta == 1 && effect.getSkillTemplate().isProvoked())
 			return value;


### PR DESCRIPTION
### Summary
Fixes incorrect application of movement-based damage modifiers.

### Details
Movement modifiers are now applied only to damage effects that explicitly
support movement-based scaling. Effects such as `DispelBuffCounterATK`, `DelayedSpellATK_Instant` , `ProcATK_Instant`  `NoReduceSpellATK_Instant`  are correctly excluded. (There may actually be more effects.) Tested on 4.6 PTS.

This change addresses a limitation mentioned in a previous pull request:
[Fix elemental defend while moving: constant value instead percent](https://github.com/beyond-aion/aion-server/pull/93)