### PR TITLE
Fix revision distance rule apply: only for players

### DIFF
--- a/game-server/src/com/aionemu/gameserver/skillengine/properties/FirstTargetRangeProperty.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/properties/FirstTargetRangeProperty.java
@@ -2,7 +2,6 @@ package com.aionemu.gameserver.skillengine.properties;
 
 import com.aionemu.gameserver.geoEngine.collision.IgnoreProperties;
 import com.aionemu.gameserver.model.gameobjects.Creature;
-import com.aionemu.gameserver.model.gameobjects.SummonedObject;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.skillengine.effect.AbnormalState;
@@ -44,10 +43,8 @@ public class FirstTargetRangeProperty {
 		if (castState != CastState.CAST_START && !(effector instanceof Player)) // NPCs don't cancel skills once started, could be abused -> no range or geo to check
 			return true;
 
-		// on end cast check add revision distance value
-		boolean isPlayerTarget =
-			firstTarget instanceof Player || firstTarget instanceof SummonedObject<?> summoned && summoned.getCreator() instanceof Player;
-		if (castState == CastState.CAST_END && isPlayerTarget) {
+		// on end cast check add revision distance value (only for pvp targets, checked on 4.6 PTS)
+		if (castState == CastState.CAST_END && firstTarget.getMaster() instanceof Player) {
 			firstTargetRange += properties.getRevisionDistance();
 		}
 

--- a/game-server/src/com/aionemu/gameserver/skillengine/properties/FirstTargetRangeProperty.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/properties/FirstTargetRangeProperty.java
@@ -44,7 +44,7 @@ public class FirstTargetRangeProperty {
 			return true;
 
 		// on end cast check add revision distance value
-		if (castState == CastState.CAST_END)
+		if (castState == CastState.CAST_END && firstTarget instanceof Player)
 			firstTargetRange += properties.getRevisionDistance();
 
 		// Add Weapon Range to distance

--- a/game-server/src/com/aionemu/gameserver/skillengine/properties/FirstTargetRangeProperty.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/properties/FirstTargetRangeProperty.java
@@ -2,6 +2,7 @@ package com.aionemu.gameserver.skillengine.properties;
 
 import com.aionemu.gameserver.geoEngine.collision.IgnoreProperties;
 import com.aionemu.gameserver.model.gameobjects.Creature;
+import com.aionemu.gameserver.model.gameobjects.SummonedObject;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.skillengine.effect.AbnormalState;
@@ -44,8 +45,11 @@ public class FirstTargetRangeProperty {
 			return true;
 
 		// on end cast check add revision distance value
-		if (castState == CastState.CAST_END && firstTarget instanceof Player)
+		boolean isPlayerTarget =
+			firstTarget instanceof Player || firstTarget instanceof SummonedObject<?> summoned && summoned.getCreator() instanceof Player;
+		if (castState == CastState.CAST_END && isPlayerTarget) {
 			firstTargetRange += properties.getRevisionDistance();
+		}
 
 		// Add Weapon Range to distance
 		if (properties.isAddWeaponRange())


### PR DESCRIPTION
### Summary
Limit revision distance mechanics to player targets only.

Revision distance is no longer applied when casting spells on NPC targets.

### Additional Notes
Revision distance is now applied to player targets and player-owned summons.

It is currently unclear whether this mechanic should also apply to summons
created by NPCs. No change was made for NPC-owned summons until this behavior
is confirmed.