### PR TITLE
Rework Siege Shield Logic

### DIFF
--- a/game-server/src/com/aionemu/gameserver/model/siege/SiegeShield.java
+++ b/game-server/src/com/aionemu/gameserver/model/siege/SiegeShield.java
@@ -14,12 +14,11 @@ import com.aionemu.gameserver.world.zone.ZoneInstance;
 import com.aionemu.gameserver.world.zone.handler.ZoneHandler;
 
 /**
- * Shields have material ID 11 in geo.
- * 
- * @author Rolandas
+ * @author SVDNESS
+ * @version 4.8 [JDK 25]
  */
-public class SiegeShield implements ZoneHandler {
 
+public class SiegeShield implements ZoneHandler {
 	private final Map<Integer, ActionObserver> observed = new ConcurrentHashMap<>();
 	private final Spatial geometry;
 	private int siegeLocationId;
@@ -37,41 +36,57 @@ public class SiegeShield implements ZoneHandler {
 		return geometry;
 	}
 
-	@Override
-	public void onEnterZone(Creature creature, ZoneInstance zone) {
-		if (creature instanceof Player player && (isEnabled || siegeLocationId == 0)) {
-			FortressLocation loc = SiegeService.getInstance().getFortress(siegeLocationId);
-			if (loc == null || loc.getRace() != SiegeRace.getByRace(player.getRace())) {
-				ActionObserver actionObserver = ShieldService.getInstance().createShieldObserver(this, creature);
-				if (actionObserver != null) {
-					creature.getObserveController().addObserver(actionObserver);
-					observed.put(creature.getObjectId(), actionObserver);
-				}
-			}
-		}
-	}
+	    @Override
+    public void onEnterZone(Creature creature, ZoneInstance zone) {
+        if (!(creature instanceof Player player)) {
+            return;
+        }
+        if (!isEnabled) {
+            return;
+        }
+        var loc = SiegeService.getInstance().getFortress(siegeLocationId);
+        if (loc == null || loc.getRace() != SiegeRace.getByRace(player.getRace())) {
+            var actionObserver = ShieldService.getInstance().createShieldObserver(this, creature);
+            if (actionObserver != null) {
+                creature.getObserveController().addObserver(actionObserver);
+                observed.put(creature.getObjectId(), actionObserver);
+            }
+        }
+    }
 
 	@Override
 	public void onLeaveZone(Creature creature, ZoneInstance zone) {
-		ActionObserver actionObserver = observed.remove(creature.getObjectId());
+		var actionObserver = observed.remove(creature.getObjectId());
 		if (actionObserver != null)
 			creature.getObserveController().removeObserver(actionObserver);
 	}
 
-	public void setEnabled(boolean enable) {
-		isEnabled = enable;
-		if (geometry != null && geometry.getParent() instanceof DespawnableNode despawnableNode) {
-			despawnableNode.setActive(1, enable);
-		}
-	}
+   public void setEnabled(boolean enable) {
+        if (isEnabled == enable) {
+            return;
+        }
+        isEnabled = enable;
+        if (!enable) {
+            clearObservers();
+        }
+        if (geometry != null && geometry.getParent() instanceof DespawnableNode despawnableNode) {
+            despawnableNode.setActive(1, enable);
+        }
+    }
 
-	public boolean isEnabled() {
-		return isEnabled;
-	}
-
-	public int getSiegeLocationId() {
-		return siegeLocationId;
-	}
+     //Insurance just in case.
+	   public void clearObservers() {
+        if (observed.isEmpty()) {
+            return;
+        }
+        observed.forEach((objectId, obs) -> {
+            var obj = World.getInstance().findVisibleObject(objectId);
+            if (obj instanceof Creature creature) {
+                creature.getObserveController().removeObserver(obs);
+            }
+        });
+        observed.clear();
+    }
 
 	public void setSiegeLocationId(int siegeLocationId) {
 		this.siegeLocationId = siegeLocationId;
@@ -84,5 +99,4 @@ public class SiegeShield implements ZoneHandler {
 	public String toString() {
 		return "LocId=" + siegeLocationId + "; Name=" + geometry.getName() + "; Bounds=" + geometry.getWorldBound();
 	}
-
 }

--- a/game-server/src/com/aionemu/gameserver/model/siege/SiegeShield.java
+++ b/game-server/src/com/aionemu/gameserver/model/siege/SiegeShield.java
@@ -1,17 +1,18 @@
 package com.aionemu.gameserver.model.siege;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import com.aionemu.gameserver.controllers.observer.ActionObserver;
-import com.aionemu.gameserver.geoEngine.scene.DespawnableNode;
-import com.aionemu.gameserver.geoEngine.scene.Spatial;
 import com.aionemu.gameserver.model.gameobjects.Creature;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
+import com.aionemu.gameserver.geoEngine.scene.DespawnableNode;
+import com.aionemu.gameserver.geoEngine.scene.Spatial;
 import com.aionemu.gameserver.services.ShieldService;
 import com.aionemu.gameserver.services.SiegeService;
+import com.aionemu.gameserver.world.World;
 import com.aionemu.gameserver.world.zone.ZoneInstance;
 import com.aionemu.gameserver.world.zone.handler.ZoneHandler;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author SVDNESS

--- a/game-server/src/com/aionemu/gameserver/model/siege/SiegeShield.java
+++ b/game-server/src/com/aionemu/gameserver/model/siege/SiegeShield.java
@@ -1,25 +1,25 @@
 package com.aionemu.gameserver.model.siege;
 
-import com.aionemu.gameserver.controllers.observer.ActionObserver;
-import com.aionemu.gameserver.model.gameobjects.Creature;
-import com.aionemu.gameserver.model.gameobjects.player.Player;
-import com.aionemu.gameserver.geoEngine.scene.DespawnableNode;
-import com.aionemu.gameserver.geoEngine.scene.Spatial;
-import com.aionemu.gameserver.services.ShieldService;
-import com.aionemu.gameserver.services.SiegeService;
-import com.aionemu.gameserver.world.World;
-import com.aionemu.gameserver.world.zone.ZoneInstance;
-import com.aionemu.gameserver.world.zone.handler.ZoneHandler;
-
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * @author SVDNESS
- * @version 4.8 [JDK 25]
- */
+import com.aionemu.gameserver.controllers.observer.ActionObserver;
+import com.aionemu.gameserver.geoEngine.scene.DespawnableNode;
+import com.aionemu.gameserver.geoEngine.scene.Spatial;
+import com.aionemu.gameserver.model.gameobjects.Creature;
+import com.aionemu.gameserver.model.gameobjects.player.Player;
+import com.aionemu.gameserver.services.ShieldService;
+import com.aionemu.gameserver.services.SiegeService;
+import com.aionemu.gameserver.world.zone.ZoneInstance;
+import com.aionemu.gameserver.world.zone.handler.ZoneHandler;
 
+/**
+ * Shields have material ID 11 in geo.
+ * 
+ * @author Rolandas
+ */
 public class SiegeShield implements ZoneHandler {
+
 	private final Map<Integer, ActionObserver> observed = new ConcurrentHashMap<>();
 	private final Spatial geometry;
 	private int siegeLocationId;
@@ -37,57 +37,41 @@ public class SiegeShield implements ZoneHandler {
 		return geometry;
 	}
 
-	    @Override
-    public void onEnterZone(Creature creature, ZoneInstance zone) {
-        if (!(creature instanceof Player player)) {
-            return;
-        }
-        if (!isEnabled) {
-            return;
-        }
-        var loc = SiegeService.getInstance().getFortress(siegeLocationId);
-        if (loc == null || loc.getRace() != SiegeRace.getByRace(player.getRace())) {
-            var actionObserver = ShieldService.getInstance().createShieldObserver(this, creature);
-            if (actionObserver != null) {
-                creature.getObserveController().addObserver(actionObserver);
-                observed.put(creature.getObjectId(), actionObserver);
-            }
-        }
-    }
+	@Override
+	public void onEnterZone(Creature creature, ZoneInstance zone) {
+		if (creature instanceof Player player && (isEnabled || siegeLocationId == 0)) {
+			FortressLocation loc = SiegeService.getInstance().getFortress(siegeLocationId);
+			if (loc == null || loc.getRace() != SiegeRace.getByRace(player.getRace())) {
+				ActionObserver actionObserver = ShieldService.getInstance().createShieldObserver(this, creature);
+				if (actionObserver != null) {
+					creature.getObserveController().addObserver(actionObserver);
+					observed.put(creature.getObjectId(), actionObserver);
+				}
+			}
+		}
+	}
 
 	@Override
 	public void onLeaveZone(Creature creature, ZoneInstance zone) {
-		var actionObserver = observed.remove(creature.getObjectId());
+		ActionObserver actionObserver = observed.remove(creature.getObjectId());
 		if (actionObserver != null)
 			creature.getObserveController().removeObserver(actionObserver);
 	}
 
-   public void setEnabled(boolean enable) {
-        if (isEnabled == enable) {
-            return;
-        }
-        isEnabled = enable;
-        if (!enable) {
-            clearObservers();
-        }
-        if (geometry != null && geometry.getParent() instanceof DespawnableNode despawnableNode) {
-            despawnableNode.setActive(1, enable);
-        }
-    }
+	public void setEnabled(boolean enable) {
+		isEnabled = enable;
+		if (geometry != null && geometry.getParent() instanceof DespawnableNode despawnableNode) {
+			despawnableNode.setActive(1, enable);
+		}
+	}
 
-     //Insurance just in case.
-	   public void clearObservers() {
-        if (observed.isEmpty()) {
-            return;
-        }
-        observed.forEach((objectId, obs) -> {
-            var obj = World.getInstance().findVisibleObject(objectId);
-            if (obj instanceof Creature creature) {
-                creature.getObserveController().removeObserver(obs);
-            }
-        });
-        observed.clear();
-    }
+	public boolean isEnabled() {
+		return isEnabled;
+	}
+
+	public int getSiegeLocationId() {
+		return siegeLocationId;
+	}
 
 	public void setSiegeLocationId(int siegeLocationId) {
 		this.siegeLocationId = siegeLocationId;
@@ -100,4 +84,5 @@ public class SiegeShield implements ZoneHandler {
 	public String toString() {
 		return "LocId=" + siegeLocationId + "; Name=" + geometry.getName() + "; Bounds=" + geometry.getWorldBound();
 	}
+
 }

--- a/game-server/src/com/aionemu/gameserver/services/ShieldService.java
+++ b/game-server/src/com/aionemu/gameserver/services/ShieldService.java
@@ -1,72 +1,54 @@
 package com.aionemu.gameserver.services;
 
-import com.aionemu.gameserver.configs.main.GeoDataConfig;
-import com.aionemu.gameserver.controllers.observer.ActionObserver;
-import com.aionemu.gameserver.controllers.observer.CollisionDieActor;
-import com.aionemu.gameserver.controllers.observer.ShieldObserver;
-import com.aionemu.gameserver.dataholders.DataManager;
-import com.aionemu.gameserver.model.gameobjects.Creature;
-import com.aionemu.gameserver.model.siege.FortressLocation;
-import com.aionemu.gameserver.model.siege.SiegeLocation;
-import com.aionemu.gameserver.model.siege.SiegeShield;
-import com.aionemu.gameserver.model.siege.SiegeType;
-import com.aionemu.gameserver.model.templates.shield.ShieldTemplate;
-import com.aionemu.gameserver.geoEngine.bounding.BoundingBox;
-import com.aionemu.gameserver.geoEngine.bounding.BoundingVolume;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * @author SVDNESS
- * @version 4.8 [JDK 25]
- */
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.aionemu.gameserver.configs.main.GeoDataConfig;
+import com.aionemu.gameserver.controllers.observer.ActionObserver;
+import com.aionemu.gameserver.controllers.observer.CollisionDieActor;
+import com.aionemu.gameserver.controllers.observer.ShieldObserver;
+import com.aionemu.gameserver.dataholders.DataManager;
+import com.aionemu.gameserver.geoEngine.bounding.BoundingBox;
+import com.aionemu.gameserver.model.gameobjects.Creature;
+import com.aionemu.gameserver.model.siege.FortressLocation;
+import com.aionemu.gameserver.model.siege.SiegeLocation;
+import com.aionemu.gameserver.model.siege.SiegeShield;
+import com.aionemu.gameserver.model.templates.shield.ShieldTemplate;
+
+/**
+ * @author xavier, Rolandas, SVDNESS
+ */
 public class ShieldService {
-	Logger log = LoggerFactory.getLogger(ShieldService.class);
+
+	private static final Logger log = LoggerFactory.getLogger(ShieldService.class);
+	private static final Map<Integer, Set<String>> IGNORED_SHIELDS_BY_MAP_ID = Map.of(
+		310100000, Set.of("BU_AB_CASTLESHIELD_SAMJUNG_03C_TYPE2_487543"), // Azoturan Fortress
+		400010000, Set.of("BU_AB_SAMJUNG_BASE_01_SHIELD_313626", "BU_AB_SAMJUNG_BASE_01_SHIELD_299314", "BU_AB_SAMJUNG_BASE_01_SHIELD_137227") // artifact
+	);
 	private final Map<Integer, ShieldTemplate> sphereShields = new ConcurrentHashMap<>();
 	private final Map<Integer, List<SiegeShield>> registeredShields = new ConcurrentHashMap<>();
-	private static final Set<Integer> IGNORE_DETACHED_SHIELDS_MAPS = Set.of(400010000, 310100000);
-	private static final String[] IGNORE_DETACHED_SHIELDS_PREFIXES = {
-            "PR_A_AIRBUNKER_EFFECT_",
-            "BU_AB_SAMJUNG_BASE_01_SHIELD_",
-            "BU_DG_DRAGONSHIELD_"
-    };
 
 	private ShieldService() {
-		for (var template : DataManager.SHIELD_DATA.getShieldTemplates()) {
+		for (ShieldTemplate template : DataManager.SHIELD_DATA.getShieldTemplates()) {
 			sphereShields.put(template.getId(), template);
 		}
 	}
 
-	   public void logDetachedShields() {
-        registeredShields.forEach((mapId, shields) -> {
-            if (shields == null || shields.isEmpty()) {
-                return;
-            }
-            List<SiegeShield> important = null;
-            for (var s : shields) {
-                if (!shouldIgnoreDetachedShield(mapId, s)) {
-                    if (important == null) {
-                        important = new ArrayList<>();
-                    }
-                    important.add(s);
-                }
-            }
-            if (important == null || important.isEmpty()) {
-                return;
-            }
-            log.warn("{} geo shield(s) are not attached to a SiegeLocation on map {}: {}.", important.size(), mapId, important);
-        });
-    }
+	public void logDetachedShields() {
+		registeredShields.forEach((mapId, shields) -> {
+			if (!shields.isEmpty())
+				log.warn("{} geo shield(s) are not attached to a SiegeLocation on map {}: {}", shields.size(), mapId, shields);
+		});
+	}
 
 	public ShieldObserver createShieldObserver(FortressLocation location, Creature observed) {
-		var template = sphereShields.get(location.getLocationId());
+		ShieldTemplate template = sphereShields.get(location.getLocationId());
 		return template == null ? null : new ShieldObserver(location, template, observed);
 	}
 
@@ -74,98 +56,77 @@ public class ShieldService {
 		return GeoDataConfig.GEO_SHIELDS_ENABLE ? new CollisionDieActor(observed, geoShield.getGeometry()) : null;
 	}
 
+	/**
+	 * Registers geo shield for zone lookup
+	 */
 	public void registerShield(int worldId, SiegeShield shield) {
-		registeredShields.computeIfAbsent(worldId, k -> new ArrayList<>()).add(shield);
+		if (!isIgnored(worldId, shield))
+			registeredShields.computeIfAbsent(worldId, _ -> new ArrayList<>()).add(shield);
 	}
 
+	/**
+	 * Attaches geo shield and removes obsolete sphere shield if such exists. Should be called when geo shields and SiegeZoneInstance were created.
+	 */
 	public void attachShield(SiegeLocation location) {
-        var mapId = location.getTemplate().getWorldId();
-        var mapShields = registeredShields.get(mapId);
-        if (mapShields == null || mapShields.isEmpty()) {
-            return;
-        }
-        var zones = location.getZone();
-        if (zones == null || zones.isEmpty()) {
-            return;
-        }
-        List<SiegeShield> attached = new ArrayList<>();
-        for (int i = mapShields.size() - 1; i >= 0; i--) {
-            var shield = mapShields.get(i);
-            var geo = shield.getGeometry();
-            if (geo == null) {
-                continue;
-            }
-            var wb = geo.getWorldBound();
-            if (wb == null) {
-                continue;
-            }
-            var center = wb.getCenter();
-            boolean inside = false;
-            for (var z : zones) {
-                var area = z.getAreaTemplate();
-                if (area == null) {
-                    continue;
-                }
-                //1. Center.
-                if (area.isInside3D(center.x, center.y, center.z)) {
-                    inside = true;
-                    break;
-                }
-                //2. Corners AABB.
-                if (wb.getType() == BoundingVolume.Type.AABB) {
-                    var bb = (BoundingBox) wb;
-                    var min = bb.getMin(null);
-                    var max = bb.getMax(null);
-                    if (area.isInside3D(min.x, min.y, min.z) ||
-                            area.isInside3D(min.x, min.y, max.z) ||
-                            area.isInside3D(min.x, max.y, min.z) ||
-                            area.isInside3D(min.x, max.y, max.z) ||
-                            area.isInside3D(max.x, min.y, min.z) ||
-                            area.isInside3D(max.x, min.y, max.z) ||
-                            area.isInside3D(max.x, max.y, min.z) ||
-                            area.isInside3D(max.x, max.y, max.z)) {
-                        inside = true;
-                        break;
-                    }
-                }
-            }
-            if (inside) {
-                attached.add(shield);
-                mapShields.remove(i);
-                sphereShields.remove(location.getLocationId());
-                shield.setSiegeLocationId(location.getLocationId());
-            }
-        }
-        if (attached.isEmpty()) {
-            if (location.getType() != SiegeType.OUTPOST && location.getLocationId() != 1241) {
-                log.warn("Could not find a shield for locId: {}.", location.getLocationId());
-            }
-        } else {
-            location.setShields(attached);
-        }
-    }
+		var mapId = location.getTemplate().getWorldId();
+		var mapShields = registeredShields.get(mapId);
+		if (mapShields == null || mapShields.isEmpty()) {
+			return;
+		}
+		List<SiegeShield> attached = new ArrayList<>();
+		for (int i = mapShields.size() - 1; i >= 0; i--) {
+			var shield = mapShields.get(i);
+			if (isShieldInsideLocation(shield, location)) {
+				attached.add(shield);
+				mapShields.remove(i);
+				sphereShields.remove(location.getLocationId());
+				shield.setSiegeLocationId(location.getLocationId());
+			}
+		}
+		if (attached.isEmpty()) {
+			if (location.getLocationId() != 1241) { // miren doesn't have any shields
+				log.warn("Could not find a shield for location ID {}.", location.getLocationId());
+			}
+		} else {
+			location.setShields(attached);
+		}
+	}
 
-	private static boolean shouldIgnoreDetachedShield(int mapId, SiegeShield shield) {
-        if (IGNORE_DETACHED_SHIELDS_MAPS.contains(mapId)) {
-            return true;
-        }
-        var geo = shield.getGeometry();
-        if (geo == null) {
-            return false;
-        }
-        var name = geo.getName();
-        if (name == null) {
-            return false;
-        }
-        for (var p : IGNORE_DETACHED_SHIELDS_PREFIXES) {
-            if (name.startsWith(p)) {
-                return true;
-            }
-        }
-        return false;
-    }
+	private static boolean isShieldInsideLocation(SiegeShield shield, SiegeLocation location) {
+		var wb = shield.getGeometry().getWorldBound();
+		var center = wb.getCenter();
+		for (var z : location.getZone()) {
+			var area = z.getAreaTemplate();
+			//1. Center.
+			if (area.isInside3D(center.x, center.y, center.z)) {
+				return true;
+			}
+			//2. Corners AABB.
+			if (wb instanceof BoundingBox bb) {
+				var min = bb.getMin(null);
+				var max = bb.getMax(null);
+				if (area.isInside3D(min.x, min.y, min.z) ||
+					area.isInside3D(min.x, min.y, max.z) ||
+					area.isInside3D(min.x, max.y, min.z) ||
+					area.isInside3D(min.x, max.y, max.z) ||
+					area.isInside3D(max.x, min.y, min.z) ||
+					area.isInside3D(max.x, min.y, max.z) ||
+					area.isInside3D(max.x, max.y,min.z) ||
+					area.isInside3D(max.x, max.y, max.z)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
 
-		private static class SingletonHolder {
+	private static boolean isIgnored(int mapId, SiegeShield shield) {
+		var ignoredShields = IGNORED_SHIELDS_BY_MAP_ID.get(mapId);
+		return ignoredShields != null && ignoredShields.contains(shield.getGeometry().getName());
+	}
+
+	private static class SingletonHolder {
+
 		protected static final ShieldService instance = new ShieldService();
 	}
 

--- a/game-server/src/com/aionemu/gameserver/services/ShieldService.java
+++ b/game-server/src/com/aionemu/gameserver/services/ShieldService.java
@@ -1,61 +1,72 @@
 package com.aionemu.gameserver.services;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.aionemu.gameserver.configs.main.GeoDataConfig;
 import com.aionemu.gameserver.controllers.observer.ActionObserver;
 import com.aionemu.gameserver.controllers.observer.CollisionDieActor;
 import com.aionemu.gameserver.controllers.observer.ShieldObserver;
 import com.aionemu.gameserver.dataholders.DataManager;
-import com.aionemu.gameserver.geoEngine.math.Vector3f;
 import com.aionemu.gameserver.model.gameobjects.Creature;
 import com.aionemu.gameserver.model.siege.FortressLocation;
 import com.aionemu.gameserver.model.siege.SiegeLocation;
 import com.aionemu.gameserver.model.siege.SiegeShield;
 import com.aionemu.gameserver.model.siege.SiegeType;
 import com.aionemu.gameserver.model.templates.shield.ShieldTemplate;
-import com.aionemu.gameserver.world.zone.ZoneInstance;
+import com.aionemu.gameserver.geoEngine.bounding.BoundingBox;
+import com.aionemu.gameserver.geoEngine.bounding.BoundingVolume;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * @author xavier, Rolandas
+ * @author SVDNESS
+ * @version 4.8 [JDK 25]
  */
+
 public class ShieldService {
-
 	Logger log = LoggerFactory.getLogger(ShieldService.class);
-
-	private static class SingletonHolder {
-
-		protected static final ShieldService instance = new ShieldService();
-	}
-
 	private final Map<Integer, ShieldTemplate> sphereShields = new ConcurrentHashMap<>();
 	private final Map<Integer, List<SiegeShield>> registeredShields = new ConcurrentHashMap<>();
-
-	public static ShieldService getInstance() {
-		return SingletonHolder.instance;
-	}
+	private static final Set<Integer> IGNORE_DETACHED_SHIELDS_MAPS = Set.of(400010000, 310100000);
+	private static final String[] IGNORE_DETACHED_SHIELDS_PREFIXES = {
+            "PR_A_AIRBUNKER_EFFECT_",
+            "BU_AB_SAMJUNG_BASE_01_SHIELD_",
+            "BU_DG_DRAGONSHIELD_"
+    };
 
 	private ShieldService() {
-		for (ShieldTemplate template : DataManager.SHIELD_DATA.getShieldTemplates()) {
+		for (var template : DataManager.SHIELD_DATA.getShieldTemplates()) {
 			sphereShields.put(template.getId(), template);
 		}
 	}
 
-	public void logDetachedShields() {
-		registeredShields.forEach((mapId, shields) -> {
-			if (!shields.isEmpty())
-				log.warn(shields.size() + " geo shield(s) are not attached to a SiegeLocation on map " + mapId + ": " + shields);
-		});
-	}
+	   public void logDetachedShields() {
+        registeredShields.forEach((mapId, shields) -> {
+            if (shields == null || shields.isEmpty()) {
+                return;
+            }
+            List<SiegeShield> important = null;
+            for (var s : shields) {
+                if (!shouldIgnoreDetachedShield(mapId, s)) {
+                    if (important == null) {
+                        important = new ArrayList<>();
+                    }
+                    important.add(s);
+                }
+            }
+            if (important == null || important.isEmpty()) {
+                return;
+            }
+            log.warn("{} geo shield(s) are not attached to a SiegeLocation on map {}: {}.", important.size(), mapId, important);
+        });
+    }
 
 	public ShieldObserver createShieldObserver(FortressLocation location, Creature observed) {
-		ShieldTemplate template = sphereShields.get(location.getLocationId());
+		var template = sphereShields.get(location.getLocationId());
 		return template == null ? null : new ShieldObserver(location, template, observed);
 	}
 
@@ -63,46 +74,102 @@ public class ShieldService {
 		return GeoDataConfig.GEO_SHIELDS_ENABLE ? new CollisionDieActor(observed, geoShield.getGeometry()) : null;
 	}
 
-	/**
-	 * Registers geo shield for zone lookup
-	 * 
-	 * @param shield
-	 *          - shield to be registered
-	 */
 	public void registerShield(int worldId, SiegeShield shield) {
 		registeredShields.computeIfAbsent(worldId, k -> new ArrayList<>()).add(shield);
 	}
 
-	/**
-	 * Attaches geo shield and removes obsolete sphere shield if such exists. Should be called when geo shields and SiegeZoneInstance were created.
-	 * 
-	 * @param location
-	 *          - siege location id
-	 */
 	public void attachShield(SiegeLocation location) {
-		List<SiegeShield> mapShields = registeredShields.get(location.getTemplate().getWorldId());
-		if (mapShields == null)
-			return;
+        var mapId = location.getTemplate().getWorldId();
+        var mapShields = registeredShields.get(mapId);
+        if (mapShields == null || mapShields.isEmpty()) {
+            return;
+        }
+        var zones = location.getZone();
+        if (zones == null || zones.isEmpty()) {
+            return;
+        }
+        List<SiegeShield> attached = new ArrayList<>();
+        for (int i = mapShields.size() - 1; i >= 0; i--) {
+            var shield = mapShields.get(i);
+            var geo = shield.getGeometry();
+            if (geo == null) {
+                continue;
+            }
+            var wb = geo.getWorldBound();
+            if (wb == null) {
+                continue;
+            }
+            var center = wb.getCenter();
+            boolean inside = false;
+            for (var z : zones) {
+                var area = z.getAreaTemplate();
+                if (area == null) {
+                    continue;
+                }
+                //1. Center.
+                if (area.isInside3D(center.x, center.y, center.z)) {
+                    inside = true;
+                    break;
+                }
+                //2. Corners AABB.
+                if (wb.getType() == BoundingVolume.Type.AABB) {
+                    var bb = (BoundingBox) wb;
+                    var min = bb.getMin(null);
+                    var max = bb.getMax(null);
+                    if (area.isInside3D(min.x, min.y, min.z) ||
+                            area.isInside3D(min.x, min.y, max.z) ||
+                            area.isInside3D(min.x, max.y, min.z) ||
+                            area.isInside3D(min.x, max.y, max.z) ||
+                            area.isInside3D(max.x, min.y, min.z) ||
+                            area.isInside3D(max.x, min.y, max.z) ||
+                            area.isInside3D(max.x, max.y, min.z) ||
+                            area.isInside3D(max.x, max.y, max.z)) {
+                        inside = true;
+                        break;
+                    }
+                }
+            }
+            if (inside) {
+                attached.add(shield);
+                mapShields.remove(i);
+                sphereShields.remove(location.getLocationId());
+                shield.setSiegeLocationId(location.getLocationId());
+            }
+        }
+        if (attached.isEmpty()) {
+            if (location.getType() != SiegeType.OUTPOST && location.getLocationId() != 1241) {
+                log.warn("Could not find a shield for locId: {}.", location.getLocationId());
+            }
+        } else {
+            location.setShields(attached);
+        }
+    }
 
-		ZoneInstance zone = location.getZone().get(0);
-		List<SiegeShield> shields = new ArrayList<>();
+	private static boolean shouldIgnoreDetachedShield(int mapId, SiegeShield shield) {
+        if (IGNORE_DETACHED_SHIELDS_MAPS.contains(mapId)) {
+            return true;
+        }
+        var geo = shield.getGeometry();
+        if (geo == null) {
+            return false;
+        }
+        var name = geo.getName();
+        if (name == null) {
+            return false;
+        }
+        for (var p : IGNORE_DETACHED_SHIELDS_PREFIXES) {
+            if (name.startsWith(p)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-		for (int index = mapShields.size() - 1; index >= 0; index--) {
-			SiegeShield shield = mapShields.get(index);
-			Vector3f center = shield.getGeometry().getWorldBound().getCenter();
-			if (zone.getAreaTemplate().isInside3D(center.x, center.y, center.z)) {
-				shields.add(shield);
-				mapShields.remove(index);
-				sphereShields.remove(location.getLocationId());
-				shield.setSiegeLocationId(location.getLocationId());
-			}
-		}
-		if (shields.isEmpty()) {
-			if (location.getType() != SiegeType.OUTPOST && location.getLocationId() != 1241) // outposts and miren don't have any shields
-				log.warn("Could not find a shield for locId: " + location.getLocationId());
-		} else {
-			location.setShields(shields);
-		}
+		private static class SingletonHolder {
+		protected static final ShieldService instance = new ShieldService();
 	}
 
+	public static ShieldService getInstance() {
+		return SingletonHolder.instance;
+	}
 }

--- a/game-server/src/com/aionemu/gameserver/services/ShieldService.java
+++ b/game-server/src/com/aionemu/gameserver/services/ShieldService.java
@@ -19,6 +19,7 @@ import com.aionemu.gameserver.model.gameobjects.Creature;
 import com.aionemu.gameserver.model.siege.FortressLocation;
 import com.aionemu.gameserver.model.siege.SiegeLocation;
 import com.aionemu.gameserver.model.siege.SiegeShield;
+import com.aionemu.gameserver.model.siege.SiegeType;
 import com.aionemu.gameserver.model.templates.shield.ShieldTemplate;
 
 /**
@@ -70,7 +71,7 @@ public class ShieldService {
 	public void attachShield(SiegeLocation location) {
 		var mapId = location.getTemplate().getWorldId();
 		var mapShields = registeredShields.get(mapId);
-		if (mapShields == null || mapShields.isEmpty()) {
+		if (mapShields == null) {
 			return;
 		}
 		List<SiegeShield> attached = new ArrayList<>();
@@ -84,7 +85,7 @@ public class ShieldService {
 			}
 		}
 		if (attached.isEmpty()) {
-			if (location.getLocationId() != 1241) { // miren doesn't have any shields
+			if (location.getType() != SiegeType.OUTPOST && location.getLocationId() != 1241) { // outposts and miren don't have any shields
 				log.warn("Could not find a shield for location ID {}.", location.getLocationId());
 			}
 		} else {
@@ -111,7 +112,7 @@ public class ShieldService {
 					area.isInside3D(min.x, max.y, max.z) ||
 					area.isInside3D(max.x, min.y, min.z) ||
 					area.isInside3D(max.x, min.y, max.z) ||
-					area.isInside3D(max.x, max.y,min.z) ||
+					area.isInside3D(max.x, max.y, min.z) ||
 					area.isInside3D(max.x, max.y, max.z)) {
 					return true;
 				}


### PR DESCRIPTION
Attempt to solve #11

Part 1.
You need to make the logic in the "attachShield" method less fragile:

1. Check all zones, not just getFirst().
2. Check corners, not just the center.
Because:
your original binding of "shield -> siege location" in the core is made according to a very strict and sometimes incorrect condition: "the center of the shield must fall inside the first zone."
3. getFirst() is not a guarantee of the "main" zone.
4. Checking only the center — it often misses.
Why do "AABB angles" decide?
If at least one corner of AABB is inside the zone, then the object intersects the zone (or at least its bounding box intersects).
And for the purposes of "attaching a shield to a location," this is much closer to the truth than "the center must be inside."
This is important because siegeLocationId is the key identifier, which determines whether the shield is turned on|off and the logic of collisions (via observer).
When the shield remains LocId=0, then the "ghost" problems begin.

Part 2.
You also need to exclude maps that report a "WARN" error in the console.
But this is not a mistake!
These geo-shields should NOT be tied to SiegeLocation.
In any case, it was not worth trying to fix them through attachShield!
Because it would be logically wrong:

1. They don't have a SiegeLocation.
2. Assign them siegeLocationId -> break the logic.

Therefore, they just had to be eliminated.
It was also worth adding some kind of insurance, in the form of "public void clearObservers() {...}", this does not break the logic, but makes it more secure.
