### PR TITLE
Prevent misconfiguration of NIO threads > 1

### DIFF
--- a/game-server/config/network/network.properties
+++ b/game-server/config/network/network.properties
@@ -38,6 +38,9 @@ gameserver.network.chat.password =
 # Value > 0 means there will be x dedicated read/write threads + 1 acceptor.
 gameserver.network.nio.threads = 1
 
+# Allows values > 1 for nio.threads. Only for development/debugging - the game server is not thread-safe!
+gameserver.network.nio.threads.unsafe.allow = false
+
 # Number of threads (min) that will be used to execute client packets
 gameserver.network.packet.processor.threads.min = 4
 

--- a/game-server/src/com/aionemu/gameserver/GameServer.java
+++ b/game-server/src/com/aionemu/gameserver/GameServer.java
@@ -194,6 +194,8 @@ public class GameServer {
 	 * Starts servers for connection with aion client and login\chat server.
 	 */
 	private static NioServer initNioServer() {
+		if (NetworkConfig.NIO_READ_WRITE_THREADS > 1 && !NetworkConfig.NIO_READ_WRITE_THREADS_UNSAFE_ALLOW)
+			throw new Error("gameserver.network.nio.threads must not exceed 1 (the game server is not thread-safe)");
 		NioServer nioServer = new NioServer(NetworkConfig.NIO_READ_WRITE_THREADS,
 			new ServerCfg(NetworkConfig.CLIENT_SOCKET_ADDRESS, "Aion game clients", new GameConnectionFactoryImpl()));
 		nioServer.connect(ThreadPoolManager.getInstance());

--- a/game-server/src/com/aionemu/gameserver/configs/network/NetworkConfig.java
+++ b/game-server/src/com/aionemu/gameserver/configs/network/NetworkConfig.java
@@ -68,6 +68,12 @@ public class NetworkConfig {
 	public static int NIO_READ_WRITE_THREADS;
 
 	/**
+	 * Allows values > 1 for nio.threads. Only for development/debugging - the game server is not thread-safe!
+	 */
+	@Property(key = "gameserver.network.nio.threads.unsafe.allow", defaultValue = "false")
+	public static boolean NIO_READ_WRITE_THREADS_UNSAFE_ALLOW;
+
+	/**
 	 * Number of minimum threads that will be used to execute aion client packets.
 	 */
 	@Property(key = "gameserver.network.packet.processor.threads.min", defaultValue = "4")


### PR DESCRIPTION
## Summary
- Fail startup if `gameserver.network.nio.threads` > 1 (game server is not thread-safe)
- Added bypass config `gameserver.network.nio.threads.unsafe.allow` for dev/debugging

Let's stop the delusion.