### PR TITLE
Fix HP percentage showing 0% for living creatures

### DIFF
--- a/game-server/src/com/aionemu/gameserver/model/stats/container/CreatureLifeStats.java
+++ b/game-server/src/com/aionemu/gameserver/model/stats/container/CreatureLifeStats.java
@@ -293,10 +293,12 @@ public abstract class CreatureLifeStats<T extends Creature> {
 	}
 
 	/**
-	 * @return HP percentage 0 - 100
+	 * @return HP percentage 0 - 100 (minimum 1% while alive)
 	 */
 	public int getHpPercentage() {
-		return (int) (100f * currentHp / getMaxHp());
+		if (currentHp == 0)
+			return 0;
+		return Math.max(1, (int) (100f * currentHp / getMaxHp()));
 	}
 
 	/**

--- a/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_ATTACK.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_ATTACK.java
@@ -50,13 +50,8 @@ public class SM_ATTACK extends AionServerPacket {
 
 		writeD(target.getObjectId());
 
-		int attackerMaxHp = attacker.getLifeStats().getMaxHp();
-		int attackerCurrHp = attacker.getLifeStats().getCurrentHp();
-		int targetMaxHp = target.getLifeStats().getMaxHp();
-		int targetCurrHp = target.getLifeStats().getCurrentHp();
-
-		writeC((byte) (100f * targetCurrHp / targetMaxHp)); // target %hp
-		writeC((byte) (100f * attackerCurrHp / attackerMaxHp)); // attacker %hp
+		writeC(target.getLifeStats().getHpPercentage());
+		writeC(attacker.getLifeStats().getHpPercentage());
 
 		// TODO refactor attack controller
 		switch (attackList.get(0).getAttackStatus().getId()) // Counter skills

--- a/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_NPC_INFO.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_NPC_INFO.java
@@ -80,7 +80,7 @@ public class SM_NPC_INFO extends AionServerPacket {
 		writeD(creatorId);// creatorId - playerObjectId or House address
 		writeS(masterName);// masterName
 
-		writeC((byte) (100f * npc.getLifeStats().getCurrentHp() / npc.getLifeStats().getMaxHp()));// %hp
+		writeC(npc.getLifeStats().getHpPercentage());
 		writeD(npc.getGameStats().getMaxHp().getCurrent());
 		writeC(npc.getLevel());
 

--- a/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_PLAYER_INFO.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_PLAYER_INFO.java
@@ -88,9 +88,7 @@ public class SM_PLAYER_INFO extends AbstractPlayerInfoPacket {
 		} else {
 			writeB(new byte[12]);
 		}
-		int maxHp = player.getLifeStats().getMaxHp();
-		int currHp = player.getLifeStats().getCurrentHp();
-		writeC(100 * currHp / maxHp);// %hp
+		writeC(player.getLifeStats().getHpPercentage());
 		writeH(pcd.getDp());// current dp
 		writeC(0x00);// unk (0x00)
 

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
@@ -318,8 +318,10 @@ public class Effect implements StatOwner {
 				// effected is about to die
 				if (!effected.isDead())
 					effected.getLifeStats().setKillingBlow(er.getValue());
+				effectedHp = 0;
+			} else {
+				effectedHp = Math.max(1, (int) (100f * value / effected.getLifeStats().getMaxHp()));
 			}
-			effectedHp = (int) (100f * value / effected.getLifeStats().getMaxHp());
 		}
 		synchronized (reservedEffects) {
 			reservedEffects.add(er);

--- a/game-server/test/com/aionemu/gameserver/model/stats/container/CreatureLifeStatsTest.java
+++ b/game-server/test/com/aionemu/gameserver/model/stats/container/CreatureLifeStatsTest.java
@@ -1,0 +1,79 @@
+package com.aionemu.gameserver.model.stats.container;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.aionemu.gameserver.model.gameobjects.Creature;
+
+/**
+ * Tests for HP percentage calculation in CreatureLifeStats.
+ * Validates fix for issue #28: HP showing 0% for living creatures.
+ */
+class CreatureLifeStatsTest {
+
+	/**
+	 * Minimal test implementation of CreatureLifeStats that allows setting maxHp directly.
+	 */
+	private static class TestLifeStats extends CreatureLifeStats<Creature> {
+
+		private final int maxHp;
+
+		TestLifeStats(int currentHp, int maxHp) {
+			super(null, currentHp, 0);
+			this.maxHp = maxHp;
+		}
+
+		@Override
+		public int getMaxHp() {
+			return maxHp;
+		}
+
+		@Override
+		public int getMaxMp() {
+			return 100;
+		}
+	}
+
+	@Test
+	void testHpPercentageReturnsZeroWhenDead() {
+		TestLifeStats stats = new TestLifeStats(0, 1000);
+		assertEquals(0, stats.getHpPercentage(), "Dead creature (HP=0) should return 0%");
+	}
+
+	@Test
+	void testHpPercentageReturnsMinOneWhenAliveWithVeryLowHp() {
+		TestLifeStats stats = new TestLifeStats(1, 10000);
+		assertEquals(1, stats.getHpPercentage(), "Living creature with <1% HP should return 1%, not 0%");
+	}
+
+	@Test
+	void testHpPercentageReturnsMinOneAtExactlyHalfPercent() {
+		TestLifeStats stats = new TestLifeStats(5, 1000);
+		assertEquals(1, stats.getHpPercentage(), "0.5% HP should round up to 1%");
+	}
+
+	@Test
+	void testHpPercentageReturnsHundredWhenFull() {
+		TestLifeStats stats = new TestLifeStats(1000, 1000);
+		assertEquals(100, stats.getHpPercentage(), "Full HP should return 100%");
+	}
+
+	@Test
+	void testHpPercentageCalculatesCorrectlyAtFiftyPercent() {
+		TestLifeStats stats = new TestLifeStats(500, 1000);
+		assertEquals(50, stats.getHpPercentage(), "50% HP should return 50");
+	}
+
+	@Test
+	void testHpPercentageCalculatesCorrectlyAtOnePercent() {
+		TestLifeStats stats = new TestLifeStats(10, 1000);
+		assertEquals(1, stats.getHpPercentage(), "1% HP should return 1");
+	}
+
+	@Test
+	void testHpPercentageCalculatesCorrectlyAtNinetyNinePercent() {
+		TestLifeStats stats = new TestLifeStats(990, 1000);
+		assertEquals(99, stats.getHpPercentage(), "99% HP should return 99");
+	}
+}


### PR DESCRIPTION
## Summary
- `getHpPercentage()` now returns minimum 1% while alive (0% only when dead)
- Refactored inline HP calculations in SM_ATTACK, SM_NPC_INFO, SM_PLAYER_INFO to use the fixed method
- Fixed Effect.java to use min 1% for predicted HP after damage
- Added 7 unit tests for HP percentage calculation

Fixes #28