### PR TITLE
Fix delevel exploit while using exp extracting items

### DIFF
--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpExtractAction.java
@@ -15,8 +15,7 @@ import com.aionemu.gameserver.utils.PacketSendUtility;
 import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
- * @author Rolandas
- * Fix by daddycaddy
+ * @author Rolandas, daddycaddy
  */
 public class ExpExtractAction extends AbstractItemAction {
 

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpExtractAction.java
@@ -20,34 +20,29 @@ import com.aionemu.gameserver.utils.ThreadPoolManager;
 public class ExpExtractAction extends AbstractItemAction {
 
 	@XmlAttribute
-	protected int cost;
+	private long cost;
 	@XmlAttribute(name = "percent")
-	protected boolean isPercent;
+	private boolean isPercent;
 	@XmlAttribute(name = "item_id")
-	protected int itemId;
+	private int itemId;
 
 	@Override
 	public boolean canAct(Player player, Item parentItem, Item targetItem, Object... params) {
-		if (player.getInventory().isFull()) {
-			return false;
-		}
-
 		PlayerCommonData cd = player.getCommonData();
+		long newExp = cd.getExp() - getRequiredExp(cd);
+		return canExtractExp(player, newExp);
+	}
 
-		long expShown = cd.getExpShown();
-
-		int required;
-		if (isPercent) {
-			required = (int) ((long) cd.getExpNeed() * cost / 100L);
-		} else {
-			required = cost;
-		}
-
-		if (required <= 0) {
+	private boolean canExtractExp(Player player, long newExp) {
+		if (player.getInventory().isFull()) {
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_DECOMPRESS_INVENTORY_IS_FULL());
 			return false;
 		}
-
-		return expShown >= required;
+		if (newExp < DataManager.PLAYER_EXPERIENCE_TABLE.getStartExpForLevel(player.getLevel())) {
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_EXP_EXTRACTION_USE_NOT_ENOUGH_EXP());
+			return false;
+		}
+		return true;
 	}
 
 	@Override
@@ -76,25 +71,11 @@ public class ExpExtractAction extends AbstractItemAction {
 			public void run() {
 				player.getObserveController().removeObserver(observer);
 
-				int toDecrease;
-				if (isPercent) {
-					toDecrease = (int) ((long) player.getCommonData().getExpNeed() * cost / 100L);
-				} else {
-					toDecrease = cost;
-				}
-
 				PlayerCommonData cd = player.getCommonData();
-				long currentExp = cd.getExp();
-				long levelStartExp = DataManager.PLAYER_EXPERIENCE_TABLE.getStartExpForLevel(cd.getLevel());
-
-				long newExp = currentExp - toDecrease;
-				if (newExp < levelStartExp) {
-					newExp = levelStartExp;
-				}
-
-				if (newExp == currentExp) {
+				long requiredExp = getRequiredExp(cd);
+				long newExp = cd.getExp() - requiredExp;
+				if (!canExtractExp(player, newExp) || !player.getInventory().decreaseByItemId(parentItem.getItemId(), 1)) {
 					player.getController().cancelTask(TaskId.ITEM_USE);
-					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_INVALID_STANCE(parentItem.getL10n()));
 					PacketSendUtility.sendPacket(player,
 						new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(),
 							parentItem.getItemTemplate().getTemplateId(), 0, 2, 0));
@@ -102,14 +83,19 @@ public class ExpExtractAction extends AbstractItemAction {
 				}
 
 				cd.setExp(newExp);
-
 				ItemService.addItem(player, itemId, 1);
-				player.getInventory().decreaseByItemId(parentItem.getItemId(), 1);
-
+				String rewardItem = DataManager.ITEM_DATA.getItemTemplate(itemId).getL10n();
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_EXP_EXTRACTION_USE(parentItem.getL10n(), requiredExp, rewardItem));
 				PacketSendUtility.sendPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 1, 0));
 			}
 		}, 5000));
+	}
 
+	private long getRequiredExp(PlayerCommonData cd) {
+		if (isPercent) {
+			return Math.max(1, cd.getExpNeed() * cost / 100L);
+		}
+		return cost;
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpExtractAction.java
@@ -3,11 +3,12 @@ package com.aionemu.gameserver.model.templates.item.actions;
 import javax.xml.bind.annotation.XmlAttribute;
 
 import com.aionemu.gameserver.controllers.observer.ItemUseObserver;
+import com.aionemu.gameserver.dataholders.DataManager;
 import com.aionemu.gameserver.model.TaskId;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
+import com.aionemu.gameserver.model.gameobjects.player.PlayerCommonData;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_STATUPDATE_EXP;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.services.item.ItemService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
@@ -15,6 +16,7 @@ import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author Rolandas
+ * Fix by daddycaddy
  */
 public class ExpExtractAction extends AbstractItemAction {
 
@@ -27,22 +29,36 @@ public class ExpExtractAction extends AbstractItemAction {
 
 	@Override
 	public boolean canAct(Player player, Item parentItem, Item targetItem, Object... params) {
-		if (player.getCommonData().getExp() == 0) {
-			return false;
-		}
 		if (player.getInventory().isFull()) {
 			return false;
 		}
-		return true;
+
+		PlayerCommonData cd = player.getCommonData();
+
+		long expShown = cd.getExpShown();
+
+		int required;
+		if (isPercent) {
+			required = (int) ((long) cd.getExpNeed() * cost / 100L);
+		} else {
+			required = cost;
+		}
+
+		if (required <= 0) {
+			return false;
+		}
+
+		return expShown >= required;
 	}
 
 	@Override
 	public void act(final Player player, final Item parentItem, Item targetItem, Object... params) {
 		PacketSendUtility.sendPacket(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 5000, 0, 0));
-		player.getController().cancelTask(TaskId.ITEM_USE);
-		final ItemUseObserver observer = new ItemUseObserver() {
 
+		player.getController().cancelTask(TaskId.ITEM_USE);
+
+		final ItemUseObserver observer = new ItemUseObserver() {
 			@Override
 			public void abort() {
 				player.getController().cancelTask(TaskId.ITEM_USE);
@@ -52,28 +68,49 @@ public class ExpExtractAction extends AbstractItemAction {
 				player.getObserveController().removeObserver(this);
 			}
 		};
+
 		player.getObserveController().attach(observer);
+
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(new Runnable() {
 
 			@Override
 			public void run() {
 				player.getObserveController().removeObserver(observer);
-				int toDecrease = 0;
+
+				int toDecrease;
 				if (isPercent) {
-					toDecrease = (int) (player.getCommonData().getExpNeed() / 100) * cost;
+					toDecrease = (int) ((long) player.getCommonData().getExpNeed() * cost / 100L);
 				} else {
 					toDecrease = cost;
 				}
-				player.getCommonData().setExp(player.getCommonData().getExp() - toDecrease);
+
+				PlayerCommonData cd = player.getCommonData();
+				long currentExp = cd.getExp();
+				long levelStartExp = DataManager.PLAYER_EXPERIENCE_TABLE.getStartExpForLevel(cd.getLevel());
+
+				long newExp = currentExp - toDecrease;
+				if (newExp < levelStartExp) {
+					newExp = levelStartExp;
+				}
+
+				if (newExp == currentExp) {
+					player.getController().cancelTask(TaskId.ITEM_USE);
+					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_INVALID_STANCE(parentItem.getL10n()));
+					PacketSendUtility.sendPacket(player,
+						new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(),
+							parentItem.getItemTemplate().getTemplateId(), 0, 2, 0));
+					return;
+				}
+
+				cd.setExp(newExp);
+
 				ItemService.addItem(player, itemId, 1);
 				player.getInventory().decreaseByItemId(parentItem.getItemId(), 1);
+
 				PacketSendUtility.sendPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 1, 0));
 			}
 		}, 5000));
-		PacketSendUtility.sendPacket(player, new SM_STATUPDATE_EXP(player.getCommonData().getExpShown(), player.getCommonData().getExpRecoverable(),
-			player.getCommonData().getExpNeed(), player.getCommonData().getCurrentReposeEnergy(), player.getCommonData().getMaxReposeEnergy()));
 
 	}
-
 }

--- a/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_SYSTEM_MESSAGE.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_SYSTEM_MESSAGE.java
@@ -26227,6 +26227,20 @@ public final class SM_SYSTEM_MESSAGE extends AionServerPacket {
 	}
 
 	/**
+	 * By using %0, you have lost %num1 XP, but received %2.
+	 */
+	public static SM_SYSTEM_MESSAGE STR_MSG_EXP_EXTRACTION_USE(String extractionItem, long exp, String rewardItem) {
+		return new SM_SYSTEM_MESSAGE(1401705, extractionItem, exp, rewardItem);
+	}
+
+	/**
+	 * You need more XP to use this item.
+	 */
+	public static SM_SYSTEM_MESSAGE STR_MSG_EXP_EXTRACTION_USE_NOT_ENOUGH_EXP() {
+		return new SM_SYSTEM_MESSAGE(1401706);
+	}
+
+	/**
 	 * %0 has been defeated and the number of points has been reduced from %1 by %num2.
 	 */
 	public static SM_SYSTEM_MESSAGE STR_MSG_LOSE_SCORE_ENEMY(String defeated, String faction, int points) {


### PR DESCRIPTION
prevents delevel exploit (only extract exp progress inside current level) and only if the player has the correct amount of exp