### PR TITLE
Fix magical cast time calculation: proper stat cap (75%) and summon-type behavior

### DIFF
--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
@@ -349,7 +349,7 @@ public class Skill {
 			castDuration = (int) effector.getGameStats().getPositiveStat(StatEnum.ATTACK_SPEED, baseCastDuration);
 		else
 			castDuration = calculateMagicalCastDuration();
-		return Math.max(castDuration, (int) (baseCastDuration * 0.3f)); // TODO check limit with retail
+		return Math.max(castDuration, (int) (baseCastDuration * 0.25f));
 	}
 
 	private int calculateCastDuration() {
@@ -362,19 +362,16 @@ public class Skill {
 	}
 
 	private int calculateMagicalCastDuration() {
-		boolean noBaseDurationCap = false;
-		int castDuration = effector.getGameStats().getPositiveReverseStat(StatEnum.BOOST_CASTING_TIME, baseCastDuration);
+		int baseDurationCap = Math.round(baseCastDuration * 0.25f);
+		//casting time stats cap 75%
+		int castDuration = Math.max(effector.getGameStats().getPositiveReverseStat(StatEnum.BOOST_CASTING_TIME, baseCastDuration), baseDurationCap);
 		int boostValue = effector.getGameStats().getPositiveReverseStat(StatEnum.BOOST_CASTING_TIME_SKILL, baseCastDuration);
 		switch (skillTemplate.getSubType()) {
 			case SUMMON:
 				boostValue = effector.getGameStats().getPositiveReverseStat(StatEnum.BOOST_CASTING_TIME_SUMMON, boostValue);
-				if (effector.getEffectController().hasAbnormalEffect(3779))
-					noBaseDurationCap = true;
 				break;
 			case SUMMONHOMING:
 				boostValue = effector.getGameStats().getPositiveReverseStat(StatEnum.BOOST_CASTING_TIME_SUMMONHOMING, boostValue);
-				if (effector.getEffectController().hasAbnormalEffect(3779))
-					noBaseDurationCap = true;
 				break;
 			case SUMMONTRAP:
 				int tempBoostVal = boostValue;
@@ -382,8 +379,6 @@ public class Skill {
 				if (boostValue == 0 && castDuration < tempBoostVal) {
 					boostValue = tempBoostVal - castDuration;
 				}
-				if (effector.getEffectController().hasAbnormalEffect(913))
-					noBaseDurationCap = true;
 				break;
 			case HEAL:
 				boostValue = effector.getGameStats().getPositiveReverseStat(StatEnum.BOOST_CASTING_TIME_HEAL, boostValue);
@@ -393,16 +388,17 @@ public class Skill {
 				break;
 		}
 		castDuration -= baseCastDuration - boostValue;
-
-		// 75% of base skill castDuration cap
-		// No cast speed cap for skill Summoning Alacrity I(skillId: 1778) and Nimble Fingers I(skillId: 2386)
-		if (!noBaseDurationCap) {
-			int baseDurationCap = Math.round(baseCastDuration * 0.25f);
+		
+		if (!isSummonType(skillTemplate.getSubType())) {
 			if (castDuration < baseDurationCap) {
 				castDuration = baseDurationCap;
 			}
 		}
 		return Math.max(castDuration, 0);
+	}
+
+	private boolean isSummonType(SkillSubType type) {
+		return type == SkillSubType.SUMMON || type == SkillSubType.SUMMONHOMING || type == SkillSubType.SUMMONTRAP;
 	}
 
 	protected void updateHitTime(boolean checkAnimation) {

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
@@ -394,10 +394,10 @@ public class Skill {
 		}
 		castDuration -= baseCastDuration - boostValue;
 
-		// 70% of base skill castDuration cap
+		// 75% of base skill castDuration cap
 		// No cast speed cap for skill Summoning Alacrity I(skillId: 1778) and Nimble Fingers I(skillId: 2386)
 		if (!noBaseDurationCap) {
-			int baseDurationCap = Math.round(baseCastDuration * 0.3f);
+			int baseDurationCap = Math.round(baseCastDuration * 0.25f);
 			if (castDuration < baseDurationCap) {
 				castDuration = baseDurationCap;
 			}

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
@@ -366,27 +366,10 @@ public class Skill {
 		//casting time stats cap 75%
 		int castDuration = Math.max(effector.getGameStats().getPositiveReverseStat(StatEnum.BOOST_CASTING_TIME, baseCastDuration), baseDurationCap);
 		int boostValue = effector.getGameStats().getPositiveReverseStat(StatEnum.BOOST_CASTING_TIME_SKILL, baseCastDuration);
-		switch (skillTemplate.getSubType()) {
-			case SUMMON:
-				boostValue = effector.getGameStats().getPositiveReverseStat(StatEnum.BOOST_CASTING_TIME_SUMMON, boostValue);
-				break;
-			case SUMMONHOMING:
-				boostValue = effector.getGameStats().getPositiveReverseStat(StatEnum.BOOST_CASTING_TIME_SUMMONHOMING, boostValue);
-				break;
-			case SUMMONTRAP:
-				int tempBoostVal = boostValue;
-				boostValue = effector.getGameStats().getPositiveReverseStat(StatEnum.BOOST_CASTING_TIME_TRAP, boostValue);
-				if (boostValue == 0 && castDuration < tempBoostVal) {
-					boostValue = tempBoostVal - castDuration;
-				}
-				break;
-			case HEAL:
-				boostValue = effector.getGameStats().getPositiveReverseStat(StatEnum.BOOST_CASTING_TIME_HEAL, boostValue);
-				break;
-			case ATTACK:
-				boostValue = effector.getGameStats().getPositiveReverseStat(StatEnum.BOOST_CASTING_TIME_ATTACK, boostValue);
-				break;
-		}
+		StatEnum skillCastBoostStat = getSkillCastBoostStat();
+		if (skillCastBoostStat != null)
+			boostValue = effector.getGameStats().getPositiveReverseStat(skillCastBoostStat, boostValue);
+
 		int buffDelta = baseCastDuration - boostValue;
 		castDuration -= buffDelta;
 		
@@ -394,6 +377,17 @@ public class Skill {
 			castDuration = Math.max(castDuration, baseDurationCap);
 		}
 		return Math.max(castDuration, 0);
+	}
+
+	private StatEnum getSkillCastBoostStat() {
+		return switch (skillTemplate.getSubType()) {
+			case SUMMON -> StatEnum.BOOST_CASTING_TIME_SUMMON;
+			case SUMMONHOMING -> StatEnum.BOOST_CASTING_TIME_SUMMONHOMING;
+			case SUMMONTRAP -> StatEnum.BOOST_CASTING_TIME_TRAP;
+			case HEAL -> StatEnum.BOOST_CASTING_TIME_HEAL;
+			case ATTACK -> StatEnum.BOOST_CASTING_TIME_ATTACK;
+			default -> null;
+		};
 	}
 
 	private boolean isSummonType(SkillSubType type) {

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
@@ -387,12 +387,11 @@ public class Skill {
 				boostValue = effector.getGameStats().getPositiveReverseStat(StatEnum.BOOST_CASTING_TIME_ATTACK, boostValue);
 				break;
 		}
-		castDuration -= baseCastDuration - boostValue;
+		int buffDelta = baseCastDuration - boostValue;
+		castDuration -= buffDelta;
 		
 		if (!isSummonType(skillTemplate.getSubType())) {
-			if (castDuration < baseDurationCap) {
-				castDuration = baseDurationCap;
-			}
+			castDuration = Math.max(castDuration, baseDurationCap);
 		}
 		return Math.max(castDuration, 0);
 	}


### PR DESCRIPTION
## Description

This PR reworks the magical cast time calculation to better match retail Aion behavior.

### Key changes

- **Casting speed stats are hard-capped at 75% reduction**
  Stat-based cast speed (e.g. gear) is capped before any other modifiers are applied, matching retail behavior.

- **Skill-based cast speed buffs are applied additively**
  Buffs (`BOOST_CASTING_TIME_SKILL` and subtype-specific bonuses) do not modify stat values and are applied on top of the capped stat reduction.

- **Different final caps based on skill subtype**
  - **Normal skills**: final cast speed reduction capped at **75%** (minimum 25% of base cast time)
  - **SUMMON / SUMMONHOMING / SUMMONTRAP**: can exceed 75% and reach **100% reduction (instant cast)**

- **Removed hardcoded abnormal-effect checks**
  Previous logic relied on specific effect IDs to bypass the cast time cap. Retail behavior shows that summon-type skills can reach 100% reduction without such effects.

- **Corrected base cast duration floor**
  The lower bound was corrected from `30%` to the correct `25%` of base cast duration.

- **Simplified and clarified calculation flow**
  The logic now follows a clear order:
  1. Apply stat-based cap
  2. Apply skill-based buffs
  3. Apply final cap based on skill subtype

  Legacy workaround code related to trap skills was removed.

### Examples (retail behavior)

- **Gear −30% + buff −50%**
  - Normal skill: **75% cap**
  - Summon skill: **80% reduction**

- **Gear −80% + buff −50%**
  - Normal skill: **75% cap**
  - Summon skill: **100% reduction**

- **No gear + buff −100%**
  - Normal skill: **75% cap**
  - Summon skill: **100% reduction**
  
- **Gear −80% + buff −5%**
  - Stat reduction is capped to **75%** first
  - Total reduction becomes **80%**
  - Normal skill: **75% cap**
  - Summon skill: **80% reduction**

### Note
The existing workaround for `SUMMONTRAP` cast speed calculation was intentionally left unchanged.
It may be redundant with the updated logic, but was preserved due to unclear historical context.

[Video from 4.6 PTS](https://www.youtube.com/watch?v=Wnl25YkPOuQ)


