### PR TITLE
Magical defend while moving forward: -20% stat

### DIFF
--- a/game-server/src/com/aionemu/gameserver/model/SkillElement.java
+++ b/game-server/src/com/aionemu/gameserver/model/SkillElement.java
@@ -1,14 +1,25 @@
 package com.aionemu.gameserver.model;
 
+import com.aionemu.gameserver.model.stats.container.StatEnum;
+
 /**
  * @author xavier
  */
 public enum SkillElement {
-	NONE,
-	FIRE,
-	WATER,
-	WIND,
-	EARTH,
-	LIGHT,
-	DARK
+	NONE(null),
+	FIRE(StatEnum.FIRE_RESISTANCE),
+	WATER(StatEnum.WATER_RESISTANCE),
+	WIND(StatEnum.WIND_RESISTANCE),
+	EARTH(StatEnum.EARTH_RESISTANCE),
+	LIGHT(StatEnum.LIGHT_RESISTANCE),
+	DARK(StatEnum.DARK_RESISTANCE),;
+	private final StatEnum statEnum;
+
+	SkillElement(StatEnum statEnum) {
+		this.statEnum = statEnum;
+	}
+
+	public StatEnum getStatForElement() {
+		return statEnum;
+	}
 }

--- a/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
+++ b/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
@@ -353,7 +353,7 @@ public class StatFunctions {
 	 */
 	private static float reduceDamageByElementalResistance(Creature attacked, SkillElement element, float damage) {
 		float elementalDenominator = attacked instanceof Player ? 1450 : 1300;
-		return damage * (1 - adjustStatByMovementModifier(attacked, StatEnum.MAGICAL_DEFEND, attacked.getGameStats().getMagicalDefenseFor(element)) / elementalDenominator);
+		return damage * (1 - adjustStatByMovementModifier(attacked, element.getStatForElement(), attacked.getGameStats().getMagicalDefenseFor(element)) / elementalDenominator);
 	}
 
 	public static float calculateMagicalSkillDamage(Creature effector, Creature target, float baseDamage, int bonus, EffectTemplate template,
@@ -375,7 +375,7 @@ public class StatFunctions {
 		if (template.getElement() != SkillElement.NONE && !(template instanceof NoReduceSpellATKInstantEffect)) {
 			damage = reduceDamageByElementalResistance(target, template.getElement(), damage);
 			// damage is reduced by 100 per 1000 mdef
-			damage -= target.getGameStats().getMDef().getCurrent()/10f;
+			damage -= adjustStatByMovementModifier(target, StatEnum.MAGICAL_DEFEND, target.getGameStats().getMDef().getCurrent()) / 10f;
 		}
 
 		if (damage < 0) {
@@ -613,10 +613,10 @@ public class StatFunctions {
 					case PHYSICAL_ATTACK:
 					case MAGICAL_ATTACK:
 						return value * 1.1f; // verified on 4.6 PTS
-					case MAGICAL_DEFEND:
+					case FIRE_RESISTANCE, EARTH_RESISTANCE, WATER_RESISTANCE, WIND_RESISTANCE, LIGHT_RESISTANCE, DARK_RESISTANCE:
 						return value - 50; // verified on 4.6 PTS
-					case PHYSICAL_DEFENSE:
-						return value * 0.8f;
+					case MAGICAL_DEFEND, PHYSICAL_DEFENSE:
+						return value * 0.8f; // verified on 4.6 PTS
 				}
 				break;
 			case SIDEWAYS:


### PR DESCRIPTION
When the target moves forward, not only is its elemental resistance reduced by 50 units, but also its magical defense is reduced by 20%.
[4.6 PTS proof](https://www.youtube.com/watch?v=JrXST_MfqJk)