### PR TITLE
NPC diff lvl modifiers have been adjusted

### DIFF
--- a/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
+++ b/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
@@ -647,18 +647,9 @@ public class StatFunctions {
 
 	private static float getNpcLevelDiffMod(Creature target, Creature attacker) {
 		int levelDiff = target.getLevel() - attacker.getLevel();
-		return switch (levelDiff) {
-			case 3 -> 0.1f;
-			case 4 -> 0.2f;
-			case 5 -> 0.3f;
-			case 6 -> 0.4f;
-			case 7 -> 0.5f;
-			case 8 -> 0.6f;
-			case 9 -> 0.7f;
-			case 10 -> 0.8f;
-			case 11 -> 0.9f;
-			default -> levelDiff > 11 ? 1f : 0;
-		};
+		if (levelDiff <= 2) return 0f;
+		if (levelDiff >= 12) return 1f;
+		return (levelDiff - 2) * 0.1f;
 	}
 
 	/**

--- a/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
+++ b/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
@@ -647,8 +647,10 @@ public class StatFunctions {
 
 	private static float getNpcLevelDiffMod(Creature target, Creature attacker) {
 		int levelDiff = target.getLevel() - attacker.getLevel();
-		if (levelDiff <= 2) return 0f;
-		if (levelDiff >= 12) return 1f;
+		if (levelDiff <= 2)
+			return 0f;
+		if (levelDiff >= 12)
+			return 1f;
 		return (levelDiff - 2) * 0.1f;
 	}
 

--- a/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
+++ b/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
@@ -655,7 +655,9 @@ public class StatFunctions {
 			case 7 -> 0.5f;
 			case 8 -> 0.6f;
 			case 9 -> 0.7f;
-			default -> levelDiff > 9 ? 0.8f : 0;
+			case 10 -> 0.8f;
+			case 11 -> 0.9f;
+			default -> levelDiff > 11 ? 1f : 0;
 		};
 	}
 


### PR DESCRIPTION
When difflvl with npc > 11 damage reduced to 1 (if no shields)
Proof: Player 56 lvl, training dummy 68. (For SpellATK, Bleed, MagicCounterATK, Poison shouldn't work)
<img width="875" height="359" alt="image" src="https://github.com/user-attachments/assets/6f77d696-37a7-4c09-8831-4368d2f6bbfe" />
