### PR TITLE
Unify elemental resistance caps and damage normalization logic

### DIFF
--- a/game-server/data/handlers/admincommands/Info.java
+++ b/game-server/data/handlers/admincommands/Info.java
@@ -100,12 +100,12 @@ public class Info extends AdminCommand {
 							+ "\n\t\tEvasion: " + pgs.getEvasion().getCurrent()
 							+ "\n\t\tCrit. Strike Resist: " + pgs.getPCR().getCurrent()
 							+ "\n\t\tCrit. Strike Fortitude: " + pgs.getStat(StatEnum.PHYSICAL_CRITICAL_DAMAGE_REDUCE, 0).getCurrent()
-							+ "\n\t\tWind Resist: " + pgs.getElementalDefendFor(SkillElement.WIND)
-							+ "\n\t\tWater Resist: " + pgs.getElementalDefendFor(SkillElement.WATER)
-							+ "\n\t\tEarth Resist: " + pgs.getElementalDefendFor(SkillElement.EARTH)
-							+ "\n\t\tFire Resist: " + pgs.getElementalDefendFor(SkillElement.FIRE)
-							+ "\n\t\tDark Resist: " + pgs.getElementalDefendFor(SkillElement.DARK)
-							+ "\n\t\tLight Resist: " + pgs.getElementalDefendFor(SkillElement.LIGHT)
+							+ "\n\t\tWind Resist: " + pgs.getElementalDefenseFor(SkillElement.WIND)
+							+ "\n\t\tWater Resist: " + pgs.getElementalDefenseFor(SkillElement.WATER)
+							+ "\n\t\tEarth Resist: " + pgs.getElementalDefenseFor(SkillElement.EARTH)
+							+ "\n\t\tFire Resist: " + pgs.getElementalDefenseFor(SkillElement.FIRE)
+							+ "\n\t\tDark Resist: " + pgs.getElementalDefenseFor(SkillElement.DARK)
+							+ "\n\t\tLight Resist: " + pgs.getElementalDefenseFor(SkillElement.LIGHT)
 							+ "\n\t-------------PvP Stats-------------"
 							+ "\n\tPvP attack: " + pgs.getStat(StatEnum.PVP_ATTACK_RATIO, 0).getCurrent() * 0.1f + "%"
 							+ "\n\tPvP p. attack: " + pgs.getStat(StatEnum.PVP_ATTACK_RATIO_PHYSICAL, 0).getCurrent() * 0.1f + "%"

--- a/game-server/data/handlers/admincommands/Info.java
+++ b/game-server/data/handlers/admincommands/Info.java
@@ -100,12 +100,12 @@ public class Info extends AdminCommand {
 							+ "\n\t\tEvasion: " + pgs.getEvasion().getCurrent()
 							+ "\n\t\tCrit. Strike Resist: " + pgs.getPCR().getCurrent()
 							+ "\n\t\tCrit. Strike Fortitude: " + pgs.getStat(StatEnum.PHYSICAL_CRITICAL_DAMAGE_REDUCE, 0).getCurrent()
-							+ "\n\t\tWind Resist: " + pgs.getMagicalDefenseFor(SkillElement.WIND)
-							+ "\n\t\tWater Resist: " + pgs.getMagicalDefenseFor(SkillElement.WATER)
-							+ "\n\t\tEarth Resist: " + pgs.getMagicalDefenseFor(SkillElement.EARTH)
-							+ "\n\t\tFire Resist: " + pgs.getMagicalDefenseFor(SkillElement.FIRE)
-							+ "\n\t\tDark Resist: " + pgs.getMagicalDefenseFor(SkillElement.DARK)
-							+ "\n\t\tLight Resist: " + pgs.getMagicalDefenseFor(SkillElement.LIGHT)
+							+ "\n\t\tWind Resist: " + pgs.getElementalDefendFor(SkillElement.WIND)
+							+ "\n\t\tWater Resist: " + pgs.getElementalDefendFor(SkillElement.WATER)
+							+ "\n\t\tEarth Resist: " + pgs.getElementalDefendFor(SkillElement.EARTH)
+							+ "\n\t\tFire Resist: " + pgs.getElementalDefendFor(SkillElement.FIRE)
+							+ "\n\t\tDark Resist: " + pgs.getElementalDefendFor(SkillElement.DARK)
+							+ "\n\t\tLight Resist: " + pgs.getElementalDefendFor(SkillElement.LIGHT)
 							+ "\n\t-------------PvP Stats-------------"
 							+ "\n\tPvP attack: " + pgs.getStat(StatEnum.PVP_ATTACK_RATIO, 0).getCurrent() * 0.1f + "%"
 							+ "\n\tPvP p. attack: " + pgs.getStat(StatEnum.PVP_ATTACK_RATIO_PHYSICAL, 0).getCurrent() * 0.1f + "%"

--- a/game-server/data/handlers/admincommands/Info.java
+++ b/game-server/data/handlers/admincommands/Info.java
@@ -100,12 +100,12 @@ public class Info extends AdminCommand {
 							+ "\n\t\tEvasion: " + pgs.getEvasion().getCurrent()
 							+ "\n\t\tCrit. Strike Resist: " + pgs.getPCR().getCurrent()
 							+ "\n\t\tCrit. Strike Fortitude: " + pgs.getStat(StatEnum.PHYSICAL_CRITICAL_DAMAGE_REDUCE, 0).getCurrent()
-							+ "\n\t\tWind Resist: " + pgs.getElementalDefenseFor(SkillElement.WIND)
-							+ "\n\t\tWater Resist: " + pgs.getElementalDefenseFor(SkillElement.WATER)
-							+ "\n\t\tEarth Resist: " + pgs.getElementalDefenseFor(SkillElement.EARTH)
-							+ "\n\t\tFire Resist: " + pgs.getElementalDefenseFor(SkillElement.FIRE)
-							+ "\n\t\tDark Resist: " + pgs.getElementalDefenseFor(SkillElement.DARK)
-							+ "\n\t\tLight Resist: " + pgs.getElementalDefenseFor(SkillElement.LIGHT)
+							+ "\n\t\tWind Defense: " + pgs.getElementalDefenseFor(SkillElement.WIND)
+							+ "\n\t\tWater Defense: " + pgs.getElementalDefenseFor(SkillElement.WATER)
+							+ "\n\t\tEarth Defense: " + pgs.getElementalDefenseFor(SkillElement.EARTH)
+							+ "\n\t\tFire Defense: " + pgs.getElementalDefenseFor(SkillElement.FIRE)
+							+ "\n\t\tDark Defense: " + pgs.getElementalDefenseFor(SkillElement.DARK)
+							+ "\n\t\tLight Defense: " + pgs.getElementalDefenseFor(SkillElement.LIGHT)
 							+ "\n\t-------------PvP Stats-------------"
 							+ "\n\tPvP attack: " + pgs.getStat(StatEnum.PVP_ATTACK_RATIO, 0).getCurrent() * 0.1f + "%"
 							+ "\n\tPvP p. attack: " + pgs.getStat(StatEnum.PVP_ATTACK_RATIO_PHYSICAL, 0).getCurrent() * 0.1f + "%"

--- a/game-server/data/handlers/ai/instance/custom/eternalChallenge/CustomInstanceBossAI.java
+++ b/game-server/data/handlers/ai/instance/custom/eternalChallenge/CustomInstanceBossAI.java
@@ -252,10 +252,10 @@ public class CustomInstanceBossAI extends GeneralNpcAI {
 	private void adaptStats(Player player) {
 		PlayerGameStats pgs = player.getGameStats();
 		List<StatSetFunction> functions = new ArrayList<>();
-		functions.add(new StatSetFunction(StatEnum.EARTH_RESISTANCE, pgs.getMagicalDefenseFor(SkillElement.EARTH)));
-		functions.add(new StatSetFunction(StatEnum.FIRE_RESISTANCE, pgs.getMagicalDefenseFor(SkillElement.FIRE)));
-		functions.add(new StatSetFunction(StatEnum.WATER_RESISTANCE, pgs.getMagicalDefenseFor(SkillElement.WATER)));
-		functions.add(new StatSetFunction(StatEnum.WIND_RESISTANCE, pgs.getMagicalDefenseFor(SkillElement.WIND)));
+		functions.add(new StatSetFunction(StatEnum.EARTH_RESISTANCE, pgs.getElementalDefendFor(SkillElement.EARTH)));
+		functions.add(new StatSetFunction(StatEnum.FIRE_RESISTANCE, pgs.getElementalDefendFor(SkillElement.FIRE)));
+		functions.add(new StatSetFunction(StatEnum.WATER_RESISTANCE, pgs.getElementalDefendFor(SkillElement.WATER)));
+		functions.add(new StatSetFunction(StatEnum.WIND_RESISTANCE, pgs.getElementalDefendFor(SkillElement.WIND)));
 		functions.add(new StatSetFunction(StatEnum.ABNORMAL_RESISTANCE_ALL, pgs.getAbnormalResistance().getCurrent()));
 		functions.add(new StatSetFunction(StatEnum.ACCURACY, pgs.getAccuracy().getCurrent()));
 		functions.add(new StatSetFunction(StatEnum.AGILITY, pgs.getAgility().getCurrent()));

--- a/game-server/data/handlers/ai/instance/custom/eternalChallenge/CustomInstanceBossAI.java
+++ b/game-server/data/handlers/ai/instance/custom/eternalChallenge/CustomInstanceBossAI.java
@@ -252,10 +252,10 @@ public class CustomInstanceBossAI extends GeneralNpcAI {
 	private void adaptStats(Player player) {
 		PlayerGameStats pgs = player.getGameStats();
 		List<StatSetFunction> functions = new ArrayList<>();
-		functions.add(new StatSetFunction(StatEnum.EARTH_RESISTANCE, pgs.getElementalDefendFor(SkillElement.EARTH)));
-		functions.add(new StatSetFunction(StatEnum.FIRE_RESISTANCE, pgs.getElementalDefendFor(SkillElement.FIRE)));
-		functions.add(new StatSetFunction(StatEnum.WATER_RESISTANCE, pgs.getElementalDefendFor(SkillElement.WATER)));
-		functions.add(new StatSetFunction(StatEnum.WIND_RESISTANCE, pgs.getElementalDefendFor(SkillElement.WIND)));
+		functions.add(new StatSetFunction(StatEnum.EARTH_RESISTANCE, pgs.getElementalDefenseFor(SkillElement.EARTH)));
+		functions.add(new StatSetFunction(StatEnum.FIRE_RESISTANCE, pgs.getElementalDefenseFor(SkillElement.FIRE)));
+		functions.add(new StatSetFunction(StatEnum.WATER_RESISTANCE, pgs.getElementalDefenseFor(SkillElement.WATER)));
+		functions.add(new StatSetFunction(StatEnum.WIND_RESISTANCE, pgs.getElementalDefenseFor(SkillElement.WIND)));
 		functions.add(new StatSetFunction(StatEnum.ABNORMAL_RESISTANCE_ALL, pgs.getAbnormalResistance().getCurrent()));
 		functions.add(new StatSetFunction(StatEnum.ACCURACY, pgs.getAccuracy().getCurrent()));
 		functions.add(new StatSetFunction(StatEnum.AGILITY, pgs.getAgility().getCurrent()));

--- a/game-server/src/com/aionemu/gameserver/model/stats/calc/StatCapUtil.java
+++ b/game-server/src/com/aionemu/gameserver/model/stats/calc/StatCapUtil.java
@@ -19,7 +19,7 @@ public class StatCapUtil {
 		}
 	}
 
-	public static int getElementalDefendBaseValue() {
+	public static int getElementalDefenseBaseValue() {
 		return 1300;
 	}
 
@@ -39,8 +39,8 @@ public class StatCapUtil {
 	}
 
 	public static int getLowerCap(StatEnum stat, Creature creature) {
-		if (isElementalDefendStat(stat)) {
-			return -getElementalCapForCreature(creature);
+		if (isElementalDefenseStat(stat)) {
+			return -getElementalDefenseCapForCreature(creature);
 		}
 		return limits.get(stat).lowerCap;
 	}
@@ -49,20 +49,20 @@ public class StatCapUtil {
 		boolean isSpeedUnrestricted = !(creature instanceof Player) || ((Player) creature).isStaff();
 		if ((stat == StatEnum.SPEED || stat == StatEnum.FLY_SPEED) && isSpeedUnrestricted)
 			return Integer.MAX_VALUE;
-		if (isElementalDefendStat(stat)) {
-			return getElementalCapForCreature(creature);
+		if (isElementalDefenseStat(stat)) {
+			return getElementalDefenseCapForCreature(creature);
 		}
 		return limits.get(stat).upperCap;
 	}
 
-	public static int getElementalCapForCreature(Creature creature) {
+	public static int getElementalDefenseCapForCreature(Creature creature) {
 		if (creature instanceof Player) {
 			return 1000 + Math.max(0, creature.getLevel() - 50) * 10;
 		}
-		return getElementalDefendBaseValue();
+		return getElementalDefenseBaseValue();
 	}
 
-	private static boolean isElementalDefendStat(StatEnum stat) {
+	private static boolean isElementalDefenseStat(StatEnum stat) {
 		return switch (stat) {
 			case WATER_RESISTANCE, FIRE_RESISTANCE, EARTH_RESISTANCE, WIND_RESISTANCE, DARK_RESISTANCE, LIGHT_RESISTANCE -> true;
 			default -> false;

--- a/game-server/src/com/aionemu/gameserver/model/stats/calc/StatCapUtil.java
+++ b/game-server/src/com/aionemu/gameserver/model/stats/calc/StatCapUtil.java
@@ -57,7 +57,7 @@ public class StatCapUtil {
 
 	public static int getElementalCapForCreature(Creature creature) {
 		if (creature instanceof Player) {
-			return getElementalResistanceBaseValue() + Math.max(0, creature.getLevel() - 50) * 10;
+			return getElementalResistanceBaseValue() - 300 + Math.max(0, creature.getLevel() - 50) * 10;
 		}
 		return getElementalResistanceBaseValue();
 	}

--- a/game-server/src/com/aionemu/gameserver/model/stats/calc/StatCapUtil.java
+++ b/game-server/src/com/aionemu/gameserver/model/stats/calc/StatCapUtil.java
@@ -121,12 +121,6 @@ public class StatCapUtil {
 					value = 0;
 					break;
 				case HEAL_BOOST:
-				case WATER_RESISTANCE:
-				case FIRE_RESISTANCE:
-				case EARTH_RESISTANCE:
-				case WIND_RESISTANCE:
-				case DARK_RESISTANCE:
-				case LIGHT_RESISTANCE:
 					value = -1000;
 					break;
 			}
@@ -145,7 +139,7 @@ public class StatCapUtil {
 				case PVP_DEFEND_RATIO:
 					value = 900;
 					break;
-				case HEAL_BOOST, WATER_RESISTANCE, FIRE_RESISTANCE, EARTH_RESISTANCE, WIND_RESISTANCE, DARK_RESISTANCE, LIGHT_RESISTANCE:
+				case HEAL_BOOST:
 					value = 1000;
 					break;
 			}

--- a/game-server/src/com/aionemu/gameserver/model/stats/calc/StatCapUtil.java
+++ b/game-server/src/com/aionemu/gameserver/model/stats/calc/StatCapUtil.java
@@ -19,7 +19,7 @@ public class StatCapUtil {
 		}
 	}
 
-	public static int getElementalResistanceBaseValue() {
+	public static int getElementalDefendBaseValue() {
 		return 1300;
 	}
 
@@ -59,7 +59,7 @@ public class StatCapUtil {
 		if (creature instanceof Player) {
 			return 1000 + Math.max(0, creature.getLevel() - 50) * 10;
 		}
-		return getElementalResistanceBaseValue();
+		return getElementalDefendBaseValue();
 	}
 
 	private static boolean isElementalDefendStat(StatEnum stat) {

--- a/game-server/src/com/aionemu/gameserver/model/stats/calc/StatCapUtil.java
+++ b/game-server/src/com/aionemu/gameserver/model/stats/calc/StatCapUtil.java
@@ -120,9 +120,6 @@ public class StatCapUtil {
 				case MAXMP:
 					value = 0;
 					break;
-				case HEAL_BOOST:
-					value = -1000;
-					break;
 			}
 			return value;
 		}

--- a/game-server/src/com/aionemu/gameserver/model/stats/calc/StatCapUtil.java
+++ b/game-server/src/com/aionemu/gameserver/model/stats/calc/StatCapUtil.java
@@ -57,7 +57,7 @@ public class StatCapUtil {
 
 	public static int getElementalCapForCreature(Creature creature) {
 		if (creature instanceof Player) {
-			return getElementalResistanceBaseValue() - 300 + Math.max(0, creature.getLevel() - 50) * 10;
+			return 1000 + Math.max(0, creature.getLevel() - 50) * 10;
 		}
 		return getElementalResistanceBaseValue();
 	}

--- a/game-server/src/com/aionemu/gameserver/model/stats/calc/StatCapUtil.java
+++ b/game-server/src/com/aionemu/gameserver/model/stats/calc/StatCapUtil.java
@@ -19,8 +19,12 @@ public class StatCapUtil {
 		}
 	}
 
+	public static int getElementalResistanceBaseValue() {
+		return 1300;
+	}
+
 	public static void calculateBaseValue(Stat2 stat, Creature creature) {
-		int lowerCap = getLowerCap(stat.getStat());
+		int lowerCap = getLowerCap(stat.getStat(), creature);
 		int upperCap = getUpperCap(stat.getStat(), creature);
 
 		if (stat.getStat() == StatEnum.ATTACK_SPEED) {
@@ -34,7 +38,10 @@ public class StatCapUtil {
 		calculate(stat, lowerCap, upperCap);
 	}
 
-	public static int getLowerCap(StatEnum stat) {
+	public static int getLowerCap(StatEnum stat, Creature creature) {
+		if (isElementalDefendStat(stat)) {
+			return -getElementalCapForCreature(creature);
+		}
 		return limits.get(stat).lowerCap;
 	}
 
@@ -42,7 +49,24 @@ public class StatCapUtil {
 		boolean isSpeedUnrestricted = !(creature instanceof Player) || ((Player) creature).isStaff();
 		if ((stat == StatEnum.SPEED || stat == StatEnum.FLY_SPEED) && isSpeedUnrestricted)
 			return Integer.MAX_VALUE;
+		if (isElementalDefendStat(stat)) {
+			return getElementalCapForCreature(creature);
+		}
 		return limits.get(stat).upperCap;
+	}
+
+	public static int getElementalCapForCreature(Creature creature) {
+		if (creature instanceof Player) {
+			return getElementalResistanceBaseValue() + Math.max(0, creature.getLevel() - 50) * 10;
+		}
+		return getElementalResistanceBaseValue();
+	}
+
+	private static boolean isElementalDefendStat(StatEnum stat) {
+		return switch (stat) {
+			case WATER_RESISTANCE, FIRE_RESISTANCE, EARTH_RESISTANCE, WIND_RESISTANCE, DARK_RESISTANCE, LIGHT_RESISTANCE -> true;
+			default -> false;
+		};
 	}
 
 	public static int getDifferenceLimit(StatEnum stat) {
@@ -55,6 +79,12 @@ public class StatCapUtil {
 		} else if (stat2.getCurrent() < lowerCap) {
 			stat2.setBonus(lowerCap - stat2.getBase());
 		}
+	}
+
+	public static int clampStatValue(StatEnum stat, Creature creature, int value) {
+		int lower = getLowerCap(stat, creature);
+		int upper = getUpperCap(stat, creature);
+		return Math.min(upper, Math.max(lower, value));
 	}
 
 	private static class StatLimits {
@@ -90,13 +120,14 @@ public class StatCapUtil {
 				case MAXMP:
 					value = 0;
 					break;
+				case HEAL_BOOST:
 				case WATER_RESISTANCE:
 				case FIRE_RESISTANCE:
 				case EARTH_RESISTANCE:
 				case WIND_RESISTANCE:
 				case DARK_RESISTANCE:
 				case LIGHT_RESISTANCE:
-					value = -1150;
+					value = -1000;
 					break;
 			}
 			return value;
@@ -114,16 +145,8 @@ public class StatCapUtil {
 				case PVP_DEFEND_RATIO:
 					value = 900;
 					break;
-				case HEAL_BOOST:
+				case HEAL_BOOST, WATER_RESISTANCE, FIRE_RESISTANCE, EARTH_RESISTANCE, WIND_RESISTANCE, DARK_RESISTANCE, LIGHT_RESISTANCE:
 					value = 1000;
-					break;
-				case WATER_RESISTANCE:
-				case FIRE_RESISTANCE:
-				case EARTH_RESISTANCE:
-				case WIND_RESISTANCE:
-				case DARK_RESISTANCE:
-				case LIGHT_RESISTANCE:
-					value = 1150;
 					break;
 			}
 			return value;

--- a/game-server/src/com/aionemu/gameserver/model/stats/calc/StatCapUtil.java
+++ b/game-server/src/com/aionemu/gameserver/model/stats/calc/StatCapUtil.java
@@ -46,7 +46,7 @@ public class StatCapUtil {
 	}
 
 	public static int getUpperCap(StatEnum stat, Creature creature) {
-		boolean isSpeedUnrestricted = !(creature instanceof Player) || ((Player) creature).isStaff();
+		boolean isSpeedUnrestricted = !(creature instanceof Player player) || player.isStaff();
 		if ((stat == StatEnum.SPEED || stat == StatEnum.FLY_SPEED) && isSpeedUnrestricted)
 			return Integer.MAX_VALUE;
 		if (isElementalDefenseStat(stat)) {
@@ -84,7 +84,7 @@ public class StatCapUtil {
 	public static int clampStatValue(StatEnum stat, Creature creature, int value) {
 		int lower = getLowerCap(stat, creature);
 		int upper = getUpperCap(stat, creature);
-		return Math.min(upper, Math.max(lower, value));
+		return Math.clamp(value, lower, upper);
 	}
 
 	private static class StatLimits {

--- a/game-server/src/com/aionemu/gameserver/model/stats/container/CreatureGameStats.java
+++ b/game-server/src/com/aionemu/gameserver/model/stats/container/CreatureGameStats.java
@@ -291,7 +291,7 @@ public abstract class CreatureGameStats<T extends Creature> {
 
 	public abstract Stat2 getMpRegenRate();
 
-	public int getMagicalDefenseFor(SkillElement element) {
+	public int getElementalDefendFor(SkillElement element) {
 		switch (element) {
 			case EARTH:
 				return getStat(StatEnum.EARTH_RESISTANCE, 0).getCurrent();

--- a/game-server/src/com/aionemu/gameserver/model/stats/container/CreatureGameStats.java
+++ b/game-server/src/com/aionemu/gameserver/model/stats/container/CreatureGameStats.java
@@ -291,7 +291,7 @@ public abstract class CreatureGameStats<T extends Creature> {
 
 	public abstract Stat2 getMpRegenRate();
 
-	public int getElementalDefendFor(SkillElement element) {
+	public int getElementalDefenseFor(SkillElement element) {
 		switch (element) {
 			case EARTH:
 				return getStat(StatEnum.EARTH_RESISTANCE, 0).getCurrent();

--- a/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
+++ b/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
@@ -336,13 +336,13 @@ public class StatFunctions {
 	}
 
 	/**
-	 * Applies elemental defend to incoming damage.
+	 * Applies elemental defense to incoming damage.
 	 *
-	 * <p>Elemental defend reduces damage linearly using a normalized scale
+	 * <p>Elemental defense reduces damage linearly using a normalized scale
 	 * (denominator) that depends on target type and level.</p>
 	 *
 	 * <ul>
-	 *   <li><b>Players:</b> defend is normalized against a level-scaled denominator
+	 *   <li><b>Players:</b> defense is normalized against a level-scaled denominator
 	 *       (base {@code 1300}, increasing by {@code +10} per level above {@code 50},
 	 *       using {@code min(attackerLevel, defenderLevel)}).</li>
 	 *   <li><b>NPCs and other creatures:</b> defend is normalized against a fixed
@@ -351,7 +351,7 @@ public class StatFunctions {
 	 *
 	 * <p>Damage reduction formula:</p>
 	 * <pre>
-	 *   finalDamage = damage * (1 - effectiveDefend / denominator)
+	 *   finalDamage = damage * (1 - effectiveDefense / denominator)
 	 * </pre>
 	 *
 	 * <p>Example (player(63) vs player(65), or npc(65) vs player(63)):</p>
@@ -369,20 +369,20 @@ public class StatFunctions {
 	 * @param damage base damage before elemental defend
 	 * @return damage reduced by elemental defend
 	 */
-	private static float reduceDamageByElementalDefend(Creature effector, Creature attacked, SkillElement element, float damage) {
-		float elementalDenominator = getElementalDefendDenominator(effector, attacked);
-		int rawDefend = attacked.getGameStats().getElementalDefendFor(element);
-		int adjustedDefend = (int) adjustStatByMovementModifier(attacked, element.getStatForElement(), rawDefend);
+	private static float reduceDamageByElementalDefense(Creature effector, Creature attacked, SkillElement element, float damage) {
+		float elementalDenominator = getElementalDefenseDenominator(effector, attacked);
+		int rawDefense = attacked.getGameStats().getElementalDefenseFor(element);
+		int adjustedDefend = (int) adjustStatByMovementModifier(attacked, element.getStatForElement(), rawDefense);
 		adjustedDefend = StatCapUtil.clampStatValue(element.getStatForElement(), attacked, adjustedDefend);
 		return damage * (1f - adjustedDefend / elementalDenominator);
 	}
 
-	private static int getElementalDefendDenominator(Creature effector, Creature attacked) {
+	private static int getElementalDefenseDenominator(Creature effector, Creature attacked) {
 		if (!(attacked instanceof Player)) {
-			return StatCapUtil.getElementalDefendBaseValue();
+			return StatCapUtil.getElementalDefenseBaseValue();
 		}
 		int level = Math.min(effector.getLevel(), attacked.getLevel());
-		return StatCapUtil.getElementalDefendBaseValue() + Math.max(0, level - 50) * 10;
+		return StatCapUtil.getElementalDefenseBaseValue() + Math.max(0, level - 50) * 10;
 	}
 
 	public static float calculateMagicalSkillDamage(Creature effector, Creature target, float baseDamage, int bonus, EffectTemplate template,
@@ -402,7 +402,7 @@ public class StatFunctions {
 		// add bonus damage
 		damage += bonus;
 		if (template.getElement() != SkillElement.NONE && !(template instanceof NoReduceSpellATKInstantEffect)) {
-			damage = reduceDamageByElementalDefend(effector, target, template.getElement(), damage);
+			damage = reduceDamageByElementalDefense(effector, target, template.getElement(), damage);
 			// damage is reduced by 100 per 1000 mdef
 			damage -= adjustStatByMovementModifier(target, StatEnum.MAGICAL_DEFEND, target.getGameStats().getMDef().getCurrent()) / 10f;
 		}

--- a/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
+++ b/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
@@ -336,53 +336,53 @@ public class StatFunctions {
 	}
 
 	/**
-	 * Applies elemental resistance to incoming damage.
+	 * Applies elemental defend to incoming damage.
 	 *
-	 * <p>Elemental resistance reduces damage linearly using a normalized scale
+	 * <p>Elemental defend reduces damage linearly using a normalized scale
 	 * (denominator) that depends on target type and level.</p>
 	 *
 	 * <ul>
-	 *   <li><b>Players:</b> resistance is normalized against a level-scaled denominator
+	 *   <li><b>Players:</b> defend is normalized against a level-scaled denominator
 	 *       (base {@code 1300}, increasing by {@code +10} per level above {@code 50},
 	 *       using {@code min(attackerLevel, defenderLevel)}).</li>
-	 *   <li><b>NPCs and other creatures:</b> resistance is normalized against a fixed
+	 *   <li><b>NPCs and other creatures:</b> defend is normalized against a fixed
 	 *       denominator of {@code 1300}.</li>
 	 * </ul>
 	 *
 	 * <p>Damage reduction formula:</p>
 	 * <pre>
-	 *   finalDamage = damage * (1 - effectiveResistance / denominator)
+	 *   finalDamage = damage * (1 - effectiveDefend / denominator)
 	 * </pre>
 	 *
 	 * <p>Example (player(63) vs player(65), or npc(65) vs player(63)):</p>
 	 * <ul>
 	 *   <li>Effective level = {@code min(63, 65) = 63}</li>
 	 *   <li>Denominator = {@code 1300 + (63 - 50) * 10 = 1430}</li>
-	 *   <li>{@code 143} elemental resistance reduces damage by {@code 10%}</li>
+	 *   <li>{@code 143} elemental defend reduces damage by {@code 10%}</li>
 	 * </ul>
-	 * <p>The resistance value is clamped to its valid stat caps after applying
+	 * <p>The defend value is clamped to its valid stat caps after applying
 	 * movement and situational modifiers.</p>
 	 *
 	 * @param effector the attacking creature
 	 * @param attacked the target receiving damage
 	 * @param element the elemental type of the damage
-	 * @param damage base damage before elemental resistance
-	 * @return damage reduced by elemental resistance
+	 * @param damage base damage before elemental defend
+	 * @return damage reduced by elemental defend
 	 */
-	private static float reduceDamageByElementalResistance(Creature effector, Creature attacked, SkillElement element, float damage) {
-		float elementalDenominator = getElementalResistanceDenominator(effector, attacked);
+	private static float reduceDamageByElementalDefend(Creature effector, Creature attacked, SkillElement element, float damage) {
+		float elementalDenominator = getElementalDefendDenominator(effector, attacked);
 		int rawDefend = attacked.getGameStats().getElementalDefendFor(element);
 		int adjustedDefend = (int) adjustStatByMovementModifier(attacked, element.getStatForElement(), rawDefend);
 		adjustedDefend = StatCapUtil.clampStatValue(element.getStatForElement(), attacked, adjustedDefend);
 		return damage * (1f - adjustedDefend / elementalDenominator);
 	}
 
-	private static int getElementalResistanceDenominator(Creature effector, Creature attacked) {
+	private static int getElementalDefendDenominator(Creature effector, Creature attacked) {
 		if (!(attacked instanceof Player)) {
-			return StatCapUtil.getElementalResistanceBaseValue();
+			return StatCapUtil.getElementalDefendBaseValue();
 		}
 		int level = Math.min(effector.getLevel(), attacked.getLevel());
-		return StatCapUtil.getElementalResistanceBaseValue() + Math.max(0, level - 50) * 10;
+		return StatCapUtil.getElementalDefendBaseValue() + Math.max(0, level - 50) * 10;
 	}
 
 	public static float calculateMagicalSkillDamage(Creature effector, Creature target, float baseDamage, int bonus, EffectTemplate template,
@@ -402,7 +402,7 @@ public class StatFunctions {
 		// add bonus damage
 		damage += bonus;
 		if (template.getElement() != SkillElement.NONE && !(template instanceof NoReduceSpellATKInstantEffect)) {
-			damage = reduceDamageByElementalResistance(effector, target, template.getElement(), damage);
+			damage = reduceDamageByElementalDefend(effector, target, template.getElement(), damage);
 			// damage is reduced by 100 per 1000 mdef
 			damage -= adjustStatByMovementModifier(target, StatEnum.MAGICAL_DEFEND, target.getGameStats().getMDef().getCurrent()) / 10f;
 		}

--- a/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
+++ b/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
@@ -338,15 +338,12 @@ public class StatFunctions {
 	/**
 	 * Applies elemental defense to incoming damage.
 	 *
-	 * <p>Elemental defense reduces damage linearly using a normalized scale
-	 * (denominator) that depends on target type and level.</p>
+	 * <p>Elemental defense reduces damage linearly using a normalized scale (denominator) that depends on target type and level.</p>
 	 *
 	 * <ul>
-	 *   <li><b>Players:</b> defense is normalized against a level-scaled denominator
-	 *       (base {@code 1300}, increasing by {@code +10} per level above {@code 50},
-	 *       using {@code min(attackerLevel, defenderLevel)}).</li>
-	 *   <li><b>NPCs and other creatures:</b> defend is normalized against a fixed
-	 *       denominator of {@code 1300}.</li>
+	 *   <li><b>Players:</b> defense is normalized against a level-scaled denominator (base {@code 1300}, increasing by {@code +10} per level above
+	 *   {@code 50}, using {@code min(attackerLevel, defenderLevel)}).</li>
+	 *   <li><b>NPCs and other creatures:</b> defense is normalized against a fixed denominator of {@code 1300}.</li>
 	 * </ul>
 	 *
 	 * <p>Damage reduction formula:</p>
@@ -358,31 +355,30 @@ public class StatFunctions {
 	 * <ul>
 	 *   <li>Effective level = {@code min(63, 65) = 63}</li>
 	 *   <li>Denominator = {@code 1300 + (63 - 50) * 10 = 1430}</li>
-	 *   <li>{@code 143} elemental defend reduces damage by {@code 10%}</li>
+	 *   <li>{@code 143} elemental defense reduces damage by {@code 10%}</li>
 	 * </ul>
-	 * <p>The defend value is clamped to its valid stat caps after applying
-	 * movement and situational modifiers.</p>
+	 * <p>The defense value is clamped to its valid stat caps after applying movement and situational modifiers.</p>
 	 *
 	 * @param effector the attacking creature
 	 * @param attacked the target receiving damage
 	 * @param element the elemental type of the damage
-	 * @param damage base damage before elemental defend
-	 * @return damage reduced by elemental defend
+	 * @param damage base damage before elemental defense
+	 * @return damage reduced by elemental defense
 	 */
 	private static float reduceDamageByElementalDefense(Creature effector, Creature attacked, SkillElement element, float damage) {
 		float elementalDenominator = getElementalDefenseDenominator(effector, attacked);
 		int rawDefense = attacked.getGameStats().getElementalDefenseFor(element);
-		int adjustedDefend = (int) adjustStatByMovementModifier(attacked, element.getStatForElement(), rawDefense);
-		adjustedDefend = StatCapUtil.clampStatValue(element.getStatForElement(), attacked, adjustedDefend);
-		return damage * (1f - adjustedDefend / elementalDenominator);
+		int adjustedDefense = (int) adjustStatByMovementModifier(attacked, element.getStatForElement(), rawDefense);
+		adjustedDefense = StatCapUtil.clampStatValue(element.getStatForElement(), attacked, adjustedDefense);
+		return damage * (1f - adjustedDefense / elementalDenominator);
 	}
 
 	private static int getElementalDefenseDenominator(Creature effector, Creature attacked) {
-		if (!(attacked instanceof Player)) {
-			return StatCapUtil.getElementalDefenseBaseValue();
+		if (attacked instanceof Player) {
+			int level = Math.min(effector.getLevel(), attacked.getLevel());
+			return StatCapUtil.getElementalDefenseBaseValue() + Math.max(0, level - 50) * 10;
 		}
-		int level = Math.min(effector.getLevel(), attacked.getLevel());
-		return StatCapUtil.getElementalDefenseBaseValue() + Math.max(0, level - 50) * 10;
+		return StatCapUtil.getElementalDefenseBaseValue();
 	}
 
 	public static float calculateMagicalSkillDamage(Creature effector, Creature target, float baseDamage, int bonus, EffectTemplate template,

--- a/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
+++ b/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
@@ -338,22 +338,51 @@ public class StatFunctions {
 	/**
 	 * Applies elemental resistance to incoming damage.
 	 *
-	 * Elemental resistance scales damage reduction linearly:
+	 * <p>Elemental resistance reduces damage linearly using a normalized scale
+	 * (denominator) that depends on target type and level.</p>
+	 *
 	 * <ul>
-	 *   <li>For players:   1450 elemental resist = 100% reduction</li>
-	 *   <li>For NPCs/others: 1300 elemental resist = 100% reduction</li>
+	 *   <li><b>Players:</b> resistance is normalized against a level-scaled denominator
+	 *       (base {@code 1300}, increasing by {@code +10} per level above {@code 50},
+	 *       using {@code min(attackerLevel, defenderLevel)}).</li>
+	 *   <li><b>NPCs and other creatures:</b> resistance is normalized against a fixed
+	 *       denominator of {@code 1300}.</li>
 	 * </ul>
 	 *
-	 * Example: 145 elemental resist reduces magical damage by 10% for players.
+	 * <p>Damage reduction formula:</p>
+	 * <pre>
+	 *   finalDamage = damage * (1 - effectiveResistance / denominator)
+	 * </pre>
 	 *
-	 * @param attacked target receiving damage
-	 * @param element damage element
+	 * <p>Example (player(63) vs player(65), or npc(65) vs player(63)):</p>
+	 * <ul>
+	 *   <li>Effective level = {@code min(63, 65) = 63}</li>
+	 *   <li>Denominator = {@code 1300 + (63 - 50) * 10 = 1430}</li>
+	 *   <li>{@code 143} elemental resistance reduces damage by {@code 10%}</li>
+	 * </ul>
+	 * <p>The resistance value is clamped to its valid stat caps after applying
+	 * movement and situational modifiers.</p>
+	 *
+	 * @param effector the attacking creature
+	 * @param attacked the target receiving damage
+	 * @param element the elemental type of the damage
 	 * @param damage base damage before elemental resistance
 	 * @return damage reduced by elemental resistance
 	 */
-	private static float reduceDamageByElementalResistance(Creature attacked, SkillElement element, float damage) {
-		float elementalDenominator = attacked instanceof Player ? 1450 : 1300;
-		return damage * (1 - adjustStatByMovementModifier(attacked, element.getStatForElement(), attacked.getGameStats().getMagicalDefenseFor(element)) / elementalDenominator);
+	private static float reduceDamageByElementalResistance(Creature effector, Creature attacked, SkillElement element, float damage) {
+		float elementalDenominator = getElementalResistanceDenominator(effector, attacked);
+		int rawDefend = attacked.getGameStats().getElementalDefendFor(element);
+		int adjustedDefend = (int) adjustStatByMovementModifier(attacked, element.getStatForElement(), rawDefend);
+		adjustedDefend = StatCapUtil.clampStatValue(element.getStatForElement(), attacked, adjustedDefend);
+		return damage * (1f - adjustedDefend / elementalDenominator);
+	}
+
+	private static int getElementalResistanceDenominator(Creature effector, Creature attacked) {
+		if (!(attacked instanceof Player)) {
+			return StatCapUtil.getElementalResistanceBaseValue();
+		}
+		int level = Math.min(effector.getLevel(), attacked.getLevel());
+		return StatCapUtil.getElementalResistanceBaseValue() + Math.max(0, level - 50) * 10;
 	}
 
 	public static float calculateMagicalSkillDamage(Creature effector, Creature target, float baseDamage, int bonus, EffectTemplate template,
@@ -373,7 +402,7 @@ public class StatFunctions {
 		// add bonus damage
 		damage += bonus;
 		if (template.getElement() != SkillElement.NONE && !(template instanceof NoReduceSpellATKInstantEffect)) {
-			damage = reduceDamageByElementalResistance(target, template.getElement(), damage);
+			damage = reduceDamageByElementalResistance(effector, target, template.getElement(), damage);
 			// damage is reduced by 100 per 1000 mdef
 			damage -= adjustStatByMovementModifier(target, StatEnum.MAGICAL_DEFEND, target.getGameStats().getMDef().getCurrent()) / 10f;
 		}


### PR DESCRIPTION
### Summary
Refactored elemental resistance handling to centralize caps, remove magic numbers, and prevent resistance values from exceeding valid bounds after situational modifiers.

### Key changes
- Centralized elemental resistance base value and level-based scaling logic.
- Unified elemental resistance caps for players and NPCs via `StatCapUtil`.
- Added explicit stat clamping after movement/situational modifiers in combat formulas.
- Moved elemental resistance normalization (denominator) logic into combat context.
- Improved method naming and JavaDoc to clearly reflect game mechanics.

### Behavior
- NPCs always use a fixed elemental resistance scale (1300).
- Player elemental resistance caps and damage normalization scale with level above 50.
- Elemental resistance is clamped both at stat calculation time and after combat modifiers.

For example, NPC can reduce all damage if he has 1300 elemental resistance, or he will be dealt double damage if he has -1300.

