### PR TITLE
Fix heal cap and ProcHealInstantEffect debuff handling

### DIFF
--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/HealEffectTemplate.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/HealEffectTemplate.java
@@ -25,7 +25,7 @@ public interface HealEffectTemplate {
 				int healBoost = effect.getEffector().getGameStats().getStat(StatEnum.HEAL_BOOST, 0).getCurrent();
 				// caster's heal related effects (passive boosts, active buffs e.g. blessed shield)
 				int healSkillBoost = effect.getEffector().getGameStats().getStat(StatEnum.HEAL_SKILL_BOOST, 1000).getCurrent() - 1000;
-				healValue += Math.round(healValue * (healBoost + healSkillBoost) / 1000f);
+				healValue += Math.round(healValue * Math.min(2000, healBoost + healSkillBoost) / 1000f);
 			}
 			// apply target's heal related effects (e.g. brilliant protection)
 			if (allowHpHealSkillDeboost(effect))

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/HealOverTimeEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/HealOverTimeEffect.java
@@ -44,7 +44,7 @@ public abstract class HealOverTimeEffect extends AbstractOverTimeEffect implemen
 		if (healType == HealType.HP && effect.getItemTemplate() == null)
 			possibleHealValue = effected.getGameStats().getStat(StatEnum.HEAL_SKILL_DEBOOST, possibleHealValue).getCurrent();
 
-		int healValue = maxCurValue - currentValue < possibleHealValue ? (maxCurValue - currentValue) : possibleHealValue;
+		int healValue = Math.min(maxCurValue - currentValue, possibleHealValue);
 
 		if (healValue <= 0)
 			return;

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/ProcHealInstantEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/ProcHealInstantEffect.java
@@ -38,9 +38,4 @@ public class ProcHealInstantEffect extends AbstractHealEffect {
 	public boolean allowHpHealBoost(Effect effect) {
 		return false;
 	}
-
-	@Override
-	public boolean allowHpHealSkillDeboost(Effect effect) {
-		return false;
-	}
 }


### PR DESCRIPTION
- Enforced heal multiplier cap (BoostHealEffect% + healSkillBoost)
- Allowed DeBoostHealAmount% to affect ProcHealInstantEffect heals

Heal formula:
```
heal =
    max(0, skillBase
  * (1 - DeBoostHealAmount%/100)
  * min(3, 1 + BoostHealEffect%/100 + healSkillBoost / 1000))
```
where BoostHealEffect%/100 + healSkillBoost / 1000 cap is 2.
Proof: [HealCap](https://youtu.be/TjOIaq-2dbA), [HealCap 4.8 (5.8)](https://www.youtube.com/watch?v=0RFZ8W-ESdY)
Also fixed ProcHealInstantEffect: [ProcHealEffect](https://youtu.be/uDCHCj6Mi8g)

HealOverTimeEffect was not fully validated.
Observed behavior suggests that healing debuffs (DeBoostHealAmount)
may affect individual ticks, while the heal multiplier
`min(3, 1 + BoostHealEffect%/100 + healSkillBoost/1000)`
is evaluated once on application and remains constant.