### PR TITLE
Q1075/Q14045: Fix fly position

### DIFF
--- a/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_MOVE_IN_AIR.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_MOVE_IN_AIR.java
@@ -60,5 +60,6 @@ public class CM_MOVE_IN_AIR extends AionClientPacket {
 
 		World.getInstance().updatePosition(player, x, y, z, heading);
 		player.getMoveController().onMoveFromClient();
+		player.getController().onMove();
 	}
 }


### PR DESCRIPTION
Death by Flame Gate (abyss core material skill) at the end of the flight teleport

<img width="1749" height="1124" alt="image" src="https://github.com/user-attachments/assets/e130b6bf-2f73-43be-99a2-d6555a4a3e2a" />
