### PR TITLE
fix: align cumulative resist logic with retail (№2)

### DIFF
--- a/game-server/config/main/custom.properties
+++ b/game-server/config/main/custom.properties
@@ -240,3 +240,8 @@ gameserver.rates.godstone.activation.rate = 1.0
 # Wait time in milliseconds between evaluations of a Godstone activation.
 # Default: 750
 gameserver.rates.godstone.evaluation.cooldown_millis = 750
+
+
+# Count summon-applied abnormal effects for cumulative resist.
+# Retail behavior: false
+gameserver.pvp.cumulative_resist.count_summon_effects = false

--- a/game-server/src/com/aionemu/gameserver/configs/main/CustomConfig.java
+++ b/game-server/src/com/aionemu/gameserver/configs/main/CustomConfig.java
@@ -269,4 +269,10 @@ public class CustomConfig {
 
 	@Property(key = "gameserver.rates.godstone.evaluation.cooldown_millis", defaultValue = "750")
 	public static int GODSTONE_EVALUATION_COOLDOWN_MILLIS;
+
+	/**
+	 * PvP config
+	 */
+	@Property(key = "gameserver.pvp.cumulative_resist.count_summon_effects", defaultValue = "false")
+	public static boolean COUNT_SUMMON_EFFECTS_FOR_CUMULATIVE_RESIST;
 }

--- a/game-server/src/com/aionemu/gameserver/configs/main/CustomConfig.java
+++ b/game-server/src/com/aionemu/gameserver/configs/main/CustomConfig.java
@@ -271,7 +271,7 @@ public class CustomConfig {
 	public static int GODSTONE_EVALUATION_COOLDOWN_MILLIS;
 
 	/**
-	 * PvP config
+	 * Count summon-applied abnormal effects for cumulative resist.
 	 */
 	@Property(key = "gameserver.pvp.cumulative_resist.count_summon_effects", defaultValue = "false")
 	public static boolean COUNT_SUMMON_EFFECTS_FOR_CUMULATIVE_RESIST;

--- a/game-server/src/com/aionemu/gameserver/controllers/effect/CumulativeResist.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/effect/CumulativeResist.java
@@ -11,8 +11,9 @@ class CumulativeResist {
 			level++;
 		this.expirationTime = System.currentTimeMillis() + maxDurationMillis;
 	}
-	//time_value* from repeated_abnormal_status_immune.xml retail file
+
 	float getDurationMultiplier() {
+		//time_value* from repeated_abnormal_status_immune.xml retail file
 		return switch (level) {
 			case 0, 1 -> 1;
 			case 2 -> 0.9f;
@@ -21,16 +22,17 @@ class CumulativeResist {
 			default -> 0;
 		};
 	}
-
-	//holding_time2 from repeated_abnormal_status_immune.xml retail file
+	
 	int getCooldownTimeOffset(CumulativeResistType type) {
+		//holding_time2 from repeated_abnormal_status_immune.xml retail file
 		return switch (type) {
 			case SLEEP, PARALYZE -> 0;
 			case FEAR -> 2000;
 		};
 	}
-	//resist_value* from repeated_abnormal_status_immune.xml retail file
+
 	int getResistance() {
+		//resist_value* from repeated_abnormal_status_immune.xml retail file
 		resetIfExpired();
 		return switch (level) {
 			case 0, 1, 2 -> 0;

--- a/game-server/src/com/aionemu/gameserver/controllers/effect/CumulativeResist.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/effect/CumulativeResist.java
@@ -22,7 +22,7 @@ class CumulativeResist {
 			default -> 0;
 		};
 	}
-	
+
 	int getCooldownTimeOffset(CumulativeResistType type) {
 		//holding_time2 from repeated_abnormal_status_immune.xml retail file
 		return switch (type) {
@@ -32,8 +32,8 @@ class CumulativeResist {
 	}
 
 	int getResistance() {
-		//resist_value* from repeated_abnormal_status_immune.xml retail file
 		resetIfExpired();
+		//resist_value* from repeated_abnormal_status_immune.xml retail file
 		return switch (level) {
 			case 0, 1, 2 -> 0;
 			case 3 -> 200;

--- a/game-server/src/com/aionemu/gameserver/controllers/effect/CumulativeResist.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/effect/CumulativeResist.java
@@ -11,7 +11,7 @@ class CumulativeResist {
 			level++;
 		this.expirationTime = System.currentTimeMillis() + maxDurationMillis;
 	}
-
+	//time_value* from repeated_abnormal_status_immune.xml retail file
 	float getDurationMultiplier() {
 		return switch (level) {
 			case 0, 1 -> 1;
@@ -22,13 +22,14 @@ class CumulativeResist {
 		};
 	}
 
+	//holding_time2 from repeated_abnormal_status_immune.xml retail file
 	int getCooldownTimeOffset(CumulativeResistType type) {
 		return switch (type) {
 			case SLEEP, PARALYZE -> 0;
 			case FEAR -> 2000;
 		};
 	}
-
+	//resist_value* from repeated_abnormal_status_immune.xml retail file
 	int getResistance() {
 		resetIfExpired();
 		return switch (level) {

--- a/game-server/src/com/aionemu/gameserver/controllers/effect/CumulativeResist.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/effect/CumulativeResist.java
@@ -12,13 +12,24 @@ class CumulativeResist {
 		this.expirationTime = System.currentTimeMillis() + maxDurationMillis;
 	}
 
-	float getDurationMultiplier() {
-		resetIfExpired();
+	float getDurationMultiplier(CumulativeResistType type) {
 		return switch (level) {
-			case 0, 1, 2 -> 1f;
-			case 3 -> 0.9f;
-			case 4 -> 0.85f;
-			default -> 0.8f;
+			case 0, 1 -> 1;
+			case 2 -> 0.9f;
+			case 3 -> 0.85f;
+			case 4 -> 0.8f;
+			default -> 0;
+		};
+	}
+
+	int getCooldownMultiplier(CumulativeResistType type) {
+		return 1;
+	}
+
+	int getCooldownTimeOffset(CumulativeResistType type) {
+		return switch (type) {
+			case SLEEP, PARALYZE -> 0;
+			case FEAR -> 2000;
 		};
 	}
 

--- a/game-server/src/com/aionemu/gameserver/controllers/effect/CumulativeResist.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/effect/CumulativeResist.java
@@ -22,10 +22,6 @@ class CumulativeResist {
 		};
 	}
 
-	int getCooldownMultiplier(CumulativeResistType type) {
-		return 1;
-	}
-
 	int getCooldownTimeOffset(CumulativeResistType type) {
 		return switch (type) {
 			case SLEEP, PARALYZE -> 0;

--- a/game-server/src/com/aionemu/gameserver/controllers/effect/CumulativeResist.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/effect/CumulativeResist.java
@@ -12,7 +12,7 @@ class CumulativeResist {
 		this.expirationTime = System.currentTimeMillis() + maxDurationMillis;
 	}
 
-	float getDurationMultiplier(CumulativeResistType type) {
+	float getDurationMultiplier() {
 		return switch (level) {
 			case 0, 1 -> 1;
 			case 2 -> 0.9f;

--- a/game-server/src/com/aionemu/gameserver/controllers/effect/PlayerEffectController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/effect/PlayerEffectController.java
@@ -142,7 +142,7 @@ public class PlayerEffectController extends EffectController {
 	public long calculateAndApplyCumulativeResistDuration(CumulativeResistType type, long duration) {
 		synchronized (cumulativeResistInfo) {
 			CumulativeResist cumulativeResist = cumulativeResistInfo.computeIfAbsent(type, _ -> new CumulativeResist());
-			long cooldownAfterProc = duration * cumulativeResist.getCooldownMultiplier(type) + cumulativeResist.getCooldownTimeOffset(type); 
+			long cooldownAfterProc = duration + cumulativeResist.getCooldownTimeOffset(type); 
 			cumulativeResist.tryIncrementLevel(cooldownAfterProc);
 			return (long) (duration * cumulativeResist.getDurationMultiplier(type));
 		}

--- a/game-server/src/com/aionemu/gameserver/controllers/effect/PlayerEffectController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/effect/PlayerEffectController.java
@@ -142,9 +142,9 @@ public class PlayerEffectController extends EffectController {
 	public long calculateAndApplyCumulativeResistDuration(CumulativeResistType type, long duration) {
 		synchronized (cumulativeResistInfo) {
 			CumulativeResist cumulativeResist = cumulativeResistInfo.computeIfAbsent(type, _ -> new CumulativeResist());
-			// retail uses a dynamic duration after the last successful fear/para/sleep, which we approximate by multiplying the base duration * 2 for now
-			cumulativeResist.tryIncrementLevel(duration * 2);
-			return (long) (duration * cumulativeResist.getDurationMultiplier());
+			long cooldownAfterProc = duration * cumulativeResist.getCooldownMultiplier(type) + cumulativeResist.getCooldownTimeOffset(type); 
+			cumulativeResist.tryIncrementLevel(cooldownAfterProc);
+			return (long) (duration * cumulativeResist.getDurationMultiplier(type));
 		}
 	}
 

--- a/game-server/src/com/aionemu/gameserver/controllers/effect/PlayerEffectController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/effect/PlayerEffectController.java
@@ -144,7 +144,7 @@ public class PlayerEffectController extends EffectController {
 			CumulativeResist cumulativeResist = cumulativeResistInfo.computeIfAbsent(type, _ -> new CumulativeResist());
 			long cooldownAfterProc = duration + cumulativeResist.getCooldownTimeOffset(type); 
 			cumulativeResist.tryIncrementLevel(cooldownAfterProc);
-			return (long) (duration * cumulativeResist.getDurationMultiplier(type));
+			return (long) (duration * cumulativeResist.getDurationMultiplier());
 		}
 	}
 

--- a/game-server/src/com/aionemu/gameserver/controllers/effect/PlayerEffectController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/effect/PlayerEffectController.java
@@ -142,9 +142,10 @@ public class PlayerEffectController extends EffectController {
 	public long calculateAndApplyCumulativeResistDuration(CumulativeResistType type, long duration) {
 		synchronized (cumulativeResistInfo) {
 			CumulativeResist cumulativeResist = cumulativeResistInfo.computeIfAbsent(type, _ -> new CumulativeResist());
-			long cooldownAfterProc = duration + cumulativeResist.getCooldownTimeOffset(type); 
+			long cooldownAfterProc = duration + cumulativeResist.getCooldownTimeOffset(type);
+			long finalDuration = (long) (duration * cumulativeResist.getDurationMultiplier());
 			cumulativeResist.tryIncrementLevel(cooldownAfterProc);
-			return (long) (duration * cumulativeResist.getDurationMultiplier());
+			return finalDuration;
 		}
 	}
 

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/EffectTemplate.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/EffectTemplate.java
@@ -518,8 +518,7 @@ public abstract class EffectTemplate {
 		effectPower -= effected.getGameStats().getResistance(statEnum).getCurrent();
 
 		// calculate cumulative resist chance for fear, sleep and paralyze if effector and effected are players
-		boolean isEffectorPlayer =
-			CustomConfig.COUNT_SUMMON_EFFECTS_FOR_CUMULATIVE_RESIST ? effector.getMaster() instanceof Player : effector instanceof Player;
+		boolean isEffectorPlayer = (CustomConfig.COUNT_SUMMON_EFFECTS_FOR_CUMULATIVE_RESIST ? effector.getMaster() : effector) instanceof Player;
 		if (isEffectorPlayer && effected instanceof Player player)
 			effectPower -= player.getEffectController().getCumulativeResistance(CumulativeResistType.get(statEnum));
 

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/EffectTemplate.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/EffectTemplate.java
@@ -5,12 +5,11 @@ import java.util.List;
 
 import javax.xml.bind.annotation.*;
 
-import com.aionemu.gameserver.configs.main.CustomConfig;
-
 import org.slf4j.LoggerFactory;
 
 import com.aionemu.commons.utils.Rnd;
 import com.aionemu.gameserver.ai.poll.AIQuestion;
+import com.aionemu.gameserver.configs.main.CustomConfig;
 import com.aionemu.gameserver.controllers.attack.AttackResult;
 import com.aionemu.gameserver.controllers.effect.CumulativeResistType;
 import com.aionemu.gameserver.dataholders.DataManager;

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/EffectTemplate.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/EffectTemplate.java
@@ -308,7 +308,7 @@ public abstract class EffectTemplate {
 				return false;
 			if (!validatePreEffects(effect))
 				return false;
-			if (getPosition() == 1 ? !checkPrimaryEffectApplication(effect, statEnum) : !checkSecondaryEffectApplication(effect, statEnum))
+			if (getPosition() == 1 ? !validateFirstEffect(effect, statEnum) : !validateSecondaryEffect(effect, statEnum))
 				return false;
 		}
 		addSuccessEffect(effect, spellStatus);
@@ -332,18 +332,17 @@ public abstract class EffectTemplate {
 		return true;
 	}
 
-	private boolean checkPrimaryEffectApplication(Effect effect, StatEnum statEnum) {
-		if (!canDodgeOrResist(effect)) {
-			return true;
+	private boolean validateFirstEffect(Effect effect, StatEnum statEnum) {
+		if (canDodgeOrResist(effect)) {
+			if (!calculateEffectResistRate(effect, statEnum))
+				return false;
+			return !isDodgedOrResisted(effect);
 		}
-		if (!passesEffectResistRateCheck(effect, statEnum)) {
-			return false;
-		}
-		return !isDodgedOrResisted(effect);
+		return true;
 	}
 
-	private boolean checkSecondaryEffectApplication(Effect effect, StatEnum statEnum) {
-		if (canDodgeOrResist(effect) && (!passesEffectResistRateCheck(effect, statEnum) || isDodgedOrResisted(effect))) {
+	private boolean validateSecondaryEffect(Effect effect, StatEnum statEnum) {
+		if (canDodgeOrResist(effect) && (!calculateEffectResistRate(effect, statEnum) || isDodgedOrResisted(effect))) {
 			EffectTemplate firstEffect = effect.effectInPos(1);
 			if (!(firstEffect instanceof DamageEffect)) {
 				effect.getSuccessEffects().remove(firstEffect);
@@ -499,7 +498,7 @@ public abstract class EffectTemplate {
 	 * @return true = no resist, false = resisted
 	 */
 	@SuppressWarnings("lossy-conversions")
-	public boolean passesEffectResistRateCheck(Effect effect, StatEnum statEnum) {
+	public boolean calculateEffectResistRate(Effect effect, StatEnum statEnum) {
 		if (statEnum == null)
 			return true;
 

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/EffectTemplate.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/EffectTemplate.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import javax.xml.bind.annotation.*;
 
+import com.aionemu.gameserver.configs.main.CustomConfig;
+
 import org.slf4j.LoggerFactory;
 
 import com.aionemu.commons.utils.Rnd;
@@ -516,7 +518,9 @@ public abstract class EffectTemplate {
 		effectPower -= effected.getGameStats().getResistance(statEnum).getCurrent();
 
 		// calculate cumulative resist chance for fear, sleep and paralyze if effector and effected are players
-		if (effector instanceof Player && effected instanceof Player player)
+		boolean isEffectorPlayer =
+			CustomConfig.COUNT_SUMMON_EFFECTS_FOR_CUMULATIVE_RESIST ? effector.getMaster() instanceof Player : effector instanceof Player;
+		if (isEffectorPlayer && effected instanceof Player player)
 			effectPower -= player.getEffectController().getCumulativeResistance(CumulativeResistType.get(statEnum));
 
 		// penetration

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/EffectTemplate.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/EffectTemplate.java
@@ -184,6 +184,12 @@ public abstract class EffectTemplate {
 	}
 
 	/**
+	 * @return the noResist
+	 */
+	public boolean isNoResist() {
+		return noResist;
+	}
+	/**
 	 * @return the critProbMod2
 	 */
 	public int getCritProbMod2() {
@@ -304,7 +310,7 @@ public abstract class EffectTemplate {
 				return false;
 			if (!validatePreEffects(effect))
 				return false;
-			if (getPosition() == 1 ? !validateFirstEffect(effect, statEnum) : !validateSecondaryEffect(effect, statEnum))
+			if (getPosition() == 1 ? !checkPrimaryEffectApplication(effect, statEnum) : !checkSecondaryEffectApplication(effect, statEnum))
 				return false;
 		}
 		addSuccessEffect(effect, spellStatus);
@@ -328,18 +334,18 @@ public abstract class EffectTemplate {
 		return true;
 	}
 
-	private boolean validateFirstEffect(Effect effect, StatEnum statEnum) {
-		if (!calculateEffectResistRate(effect, statEnum)) {
+	private boolean checkPrimaryEffectApplication(Effect effect, StatEnum statEnum) {
+		if (!canDodgeOrResist(effect)) {
+			return true;
+		}
+		if (!passesEffectResistRateCheck(effect, statEnum)) {
 			return false;
 		}
-		if (canDodgeOrResist(effect) && isDodgedOrResisted(effect)) {
-			return false;
-		}
-		return true;
+		return !isDodgedOrResisted(effect);
 	}
 
-	private boolean validateSecondaryEffect(Effect effect, StatEnum statEnum) {
-		if (canDodgeOrResist(effect) && (!calculateEffectResistRate(effect, statEnum) || isDodgedOrResisted(effect))) {
+	private boolean checkSecondaryEffectApplication(Effect effect, StatEnum statEnum) {
+		if (canDodgeOrResist(effect) && (!passesEffectResistRateCheck(effect, statEnum) || isDodgedOrResisted(effect))) {
 			EffectTemplate firstEffect = effect.effectInPos(1);
 			if (!(firstEffect instanceof DamageEffect)) {
 				effect.getSuccessEffects().remove(firstEffect);
@@ -495,7 +501,7 @@ public abstract class EffectTemplate {
 	 * @return true = no resist, false = resisted
 	 */
 	@SuppressWarnings("lossy-conversions")
-	public boolean calculateEffectResistRate(Effect effect, StatEnum statEnum) {
+	public boolean passesEffectResistRateCheck(Effect effect, StatEnum statEnum) {
 		if (statEnum == null)
 			return true;
 

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/EffectTemplate.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/EffectTemplate.java
@@ -516,7 +516,7 @@ public abstract class EffectTemplate {
 		effectPower -= effected.getGameStats().getResistance(statEnum).getCurrent();
 
 		// calculate cumulative resist chance for fear, sleep and paralyze if effector and effected are players
-		if (effector.getMaster() instanceof Player && effected instanceof Player player)
+		if (effector instanceof Player && effected instanceof Player player)
 			effectPower -= player.getEffectController().getCumulativeResistance(CumulativeResistType.get(statEnum));
 
 		// penetration

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/EffectTemplate.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/EffectTemplate.java
@@ -183,12 +183,10 @@ public abstract class EffectTemplate {
 		return preEffects;
 	}
 
-	/**
-	 * @return the noResist
-	 */
 	public boolean isNoResist() {
 		return noResist;
 	}
+
 	/**
 	 * @return the critProbMod2
 	 */

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
@@ -6,6 +6,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.aionemu.commons.utils.Rnd;
+import com.aionemu.gameserver.configs.main.CustomConfig;
 import com.aionemu.gameserver.controllers.attack.AggroList;
 import com.aionemu.gameserver.controllers.attack.AttackStatus;
 import com.aionemu.gameserver.controllers.effect.CumulativeResistType;
@@ -846,7 +847,9 @@ public class Effect implements StatOwner {
 		long duration = calculateTemplateDuration();
 
 		if (getEffected() instanceof Player effectedPlayer) {
-			if (getEffector() instanceof Player) {
+			boolean isEffectorPlayer =
+				CustomConfig.COUNT_SUMMON_EFFECTS_FOR_CUMULATIVE_RESIST ? getEffector().getMaster() instanceof Player : getEffector() instanceof Player;
+			if (isEffectorPlayer) {
 				duration = applyCumulativeResistDurationMultiplier(duration, effectedPlayer);
 			}
 			if (skillTemplate.getPvpDuration() != 0 && !effector.equals(effected)) {

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
@@ -845,14 +845,14 @@ public class Effect implements StatOwner {
 	private int calculateEffectsDuration() {
 		long duration = calculateTemplateDuration();
 
-		// adjust with pvp duration (not sure why some self target skills have pvp duration o.O idk how to handle that)
 		if (getEffected() instanceof Player effectedPlayer) {
-			if (skillTemplate.getPvpDuration() != 0 && !effector.equals(effected))
-				duration = duration * skillTemplate.getPvpDuration() / 100;
-			if (getEffector().getMaster() instanceof Player)
+			if (getEffector().getMaster() instanceof Player) {
 				duration = applyCumulativeResistDurationMultiplier(duration, effectedPlayer);
+			}
+			if (skillTemplate.getPvpDuration() != 0 && !effector.equals(effected)) {
+				duration = duration * skillTemplate.getPvpDuration() / 100;
+			}
 		}
-
 		return (int) Math.min(Integer.MAX_VALUE, duration);
 	}
 

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
@@ -847,8 +847,7 @@ public class Effect implements StatOwner {
 		long duration = calculateTemplateDuration();
 
 		if (getEffected() instanceof Player effectedPlayer) {
-			boolean isEffectorPlayer =
-				CustomConfig.COUNT_SUMMON_EFFECTS_FOR_CUMULATIVE_RESIST ? getEffector().getMaster() instanceof Player : getEffector() instanceof Player;
+			boolean isEffectorPlayer = (CustomConfig.COUNT_SUMMON_EFFECTS_FOR_CUMULATIVE_RESIST ? effector.getMaster() : effector) instanceof Player;
 			if (isEffectorPlayer) {
 				duration = applyCumulativeResistDurationMultiplier(duration, effectedPlayer);
 			}

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
@@ -846,7 +846,7 @@ public class Effect implements StatOwner {
 		long duration = calculateTemplateDuration();
 
 		if (getEffected() instanceof Player effectedPlayer) {
-			if (getEffector().getMaster() instanceof Player) {
+			if (getEffector() instanceof Player) {
 				duration = applyCumulativeResistDurationMultiplier(duration, effectedPlayer);
 			}
 			if (skillTemplate.getPvpDuration() != 0 && !effector.equals(effected)) {

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
@@ -879,7 +879,7 @@ public class Effect implements StatOwner {
 				case SleepEffect _ -> CumulativeResistType.SLEEP;
 				default -> null;
 			};
-			if (cumulativeResistType != null)
+			if (cumulativeResistType != null && !et.isNoResist())
 				return effected.getEffectController().calculateAndApplyCumulativeResistDuration(cumulativeResistType, duration);
 		}
 		return duration;


### PR DESCRIPTION
Recreated from a clean branch because the previous PR history got polluted after I accidentally used merge instead of rebase.  
Previous PR: https://github.com/beyond-aion/aion-server/pull/135
## Summary
Fix cumulative resist calculation and align with retail formulas.

## Formulas

baseDuration = remain - rnd(0, randomTime)  
cooldown = baseDuration * multiplier + flat  
finalDuration = baseDuration * durationMultiplier * pvpRemain

Retail **repeated_abnormal_status_immune.xml**:
<details>
<summary>Retail XML reference</summary>

```xml
<repeated_abnormal_status_immunes>
	<repeated_abnormal_status_immune>
		<id>2</id>
		<name>PARALYZE</name>
		<holding_time1>1</holding_time1>
		<holding_time2>0</holding_time2>
		<resist_value1>0</resist_value1>
		<resist_value2>0</resist_value2>
		<resist_value3>200</resist_value3>
		<resist_value4>400</resist_value4>
		<resist_value5>1000</resist_value5>
		<time_value1>100</time_value1>
		<time_value2>90</time_value2>
		<time_value3>85</time_value3>
		<time_value4>80</time_value4>
		<time_value5>0</time_value5>
	</repeated_abnormal_status_immune>
	<repeated_abnormal_status_immune>
		<id>3</id>
		<name>SLEEP</name>
		<holding_time1>1</holding_time1>
		<holding_time2>0</holding_time2>
		<resist_value1>0</resist_value1>
		<resist_value2>0</resist_value2>
		<resist_value3>200</resist_value3>
		<resist_value4>400</resist_value4>
		<resist_value5>1000</resist_value5>
		<time_value1>100</time_value1>
		<time_value2>90</time_value2>
		<time_value3>85</time_value3>
		<time_value4>80</time_value4>
		<time_value5>0</time_value5>
	</repeated_abnormal_status_immune>
	<repeated_abnormal_status_immune>
		<id>9</id>
		<name>FEAR</name>
		<holding_time1>1</holding_time1>
		<holding_time2>2000</holding_time2>
		<resist_value1>0</resist_value1>
		<resist_value2>0</resist_value2>
		<resist_value3>200</resist_value3>
		<resist_value4>400</resist_value4>
		<resist_value5>1000</resist_value5>
		<time_value1>100</time_value1>
		<time_value2>90</time_value2>
		<time_value3>85</time_value3>
		<time_value4>80</time_value4>
		<time_value5>0</time_value5>
	</repeated_abnormal_status_immune>
</repeated_abnormal_status_immunes>

</details>