### PR TITLE
Retail-accurate fear/confuse movement behavior.

### DIFF
--- a/game-server/src/com/aionemu/gameserver/controllers/movement/NpcMoveController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/movement/NpcMoveController.java
@@ -80,6 +80,22 @@ public class NpcMoveController extends CreatureMoveController<Npc> {
 		}
 	}
 
+	//Updates the destination without stopping.
+	//Otherwise, fear/confuse would cause stuttering "run-stop-run" movement each tick.
+	public void retargetPoint(float x, float y, float z) {
+		destination = Destination.POINT;
+		pointX = x;
+		pointY = y;
+		pointZ = z;
+		if (started.compareAndSet(false, true)) {
+			if (owner.getAi().isLogging()) {
+				AILogger.moveinfo(owner, "MC: retargetPoint started.");
+			}
+			owner.getController().onStartMove();
+		}
+		updateLastMove();
+	}
+	
 	public void moveToPoint(float x, float y, float z) {
 		if (started.compareAndSet(false, true)) {
 			if (owner.getAi().isLogging()) {

--- a/game-server/src/com/aionemu/gameserver/controllers/movement/NpcMoveController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/movement/NpcMoveController.java
@@ -80,34 +80,21 @@ public class NpcMoveController extends CreatureMoveController<Npc> {
 		}
 	}
 
-	//Updates the destination without stopping.
-	//Otherwise, fear/confuse would cause stuttering "run-stop-run" movement each tick.
-	public void retargetPoint(float x, float y, float z) {
+	public boolean moveToPoint(float x, float y, float z) {
+		boolean startedMoving = started.compareAndSet(false, true);
+		if (!startedMoving && destination != Destination.POINT)
+			return false;
+		if (owner.getAi().isLogging()) {
+			AILogger.moveinfo(owner, "MC: moveToPoint (startedMoving=" + startedMoving + ")");
+		}
 		destination = Destination.POINT;
 		pointX = x;
 		pointY = y;
 		pointZ = z;
-		if (started.compareAndSet(false, true)) {
-			if (owner.getAi().isLogging()) {
-				AILogger.moveinfo(owner, "MC: retargetPoint started.");
-			}
-			owner.getController().onStartMove();
-		}
 		updateLastMove();
-	}
-	
-	public void moveToPoint(float x, float y, float z) {
-		if (started.compareAndSet(false, true)) {
-			if (owner.getAi().isLogging()) {
-				AILogger.moveinfo(owner, "MC: moveToPoint started");
-			}
-			destination = Destination.POINT;
-			pointX = x;
-			pointY = y;
-			pointZ = z;
-			updateLastMove();
+		if (startedMoving)
 			owner.getController().onStartMove();
-		}
+		return true;
 	}
 
 	public void forcedMoveToPoint(float x, float y, float z) {

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/ConfuseEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/ConfuseEffect.java
@@ -27,8 +27,9 @@ import com.aionemu.gameserver.utils.ThreadPoolManager;
 import com.aionemu.gameserver.world.geo.GeoService;
 
 /**
- * @author Yeats
+ * @author Yeats, SVDNESS
  */
+
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "ConfuseEffect")
 public class ConfuseEffect extends EffectTemplate {
@@ -37,7 +38,7 @@ public class ConfuseEffect extends EffectTemplate {
 	public void applyEffect(Effect effect) {
 		Creature effected = effect.getEffected();
 		effected.getEffectController().removeHideEffects();
-
+		//If the target is gliding, then we remove this condition.
 		if (effected instanceof Player && ((Player) effected).isInGlidingState()) {
 			((Player) effected).getFlyController().onStopGliding();
 		}
@@ -56,7 +57,6 @@ public class ConfuseEffect extends EffectTemplate {
 		effected.getController().cancelCurrentSkill(effect.getEffector());
 		effected.getEffectController().setAbnormal(AbnormalState.CONFUSE);
 		effect.setAbnormal(AbnormalState.CONFUSE);
-
 		effected.getMoveController().abortMove();
 		if (effected instanceof Npc) {
 			EmoteManager.emoteStartAttacking((Npc) effected, effector);
@@ -66,7 +66,7 @@ public class ConfuseEffect extends EffectTemplate {
 			PacketSendUtility.broadcastPacket((Player) effected, new SM_EMOTION(effected, EmotionType.RUN), true);
 		}
 		if (GeoDataConfig.FEAR_ENABLE) {
-			ScheduledFuture<?> confuseTask = ThreadPoolManager.getInstance().scheduleAtFixedRate(new ConfuseTask(effected), 0, 1000);
+			ScheduledFuture<?> confuseTask = ThreadPoolManager.getInstance().scheduleAtFixedRate(new ConfuseTask(effected), 0, 1_000);
 			effect.setPeriodicTask(confuseTask, position);
 		}
 	}
@@ -76,29 +76,26 @@ public class ConfuseEffect extends EffectTemplate {
 		effect.getEffected().getEffectController().unsetAbnormal(AbnormalState.CONFUSE);
 		effect.getEffected().getMoveController().abortMove();
 		PacketSendUtility.broadcastPacketAndReceive(effect.getEffected(), new SM_POSITION(effect.getEffected()));
-
 		if (effect.getEffected() instanceof Npc) {
 			effect.getEffected().getAi().setStateIfNot(AIState.IDLE);
 			effect.getEffected().getAi().onCreatureEvent(AIEventType.ATTACK, effect.getEffected());
 		}
 	}
 
-	class ConfuseTask implements Runnable {
-		private Creature effected;
-
-		ConfuseTask(Creature effected) {
-			this.effected = effected;
-		}
+	record ConfuseTask (Creature effected) implements Runnable {
+		//The flee point is farther than the target travels per tick (1 sec):
+		//the target never reaches it between ticks and keeps running smoothly — same as retail behavior.
+		private static final float FLEE_SECONDS = 2.5f;
 
 		@Override
 		public void run() {
 			if (effected.getEffectController().isConfused()) {
 				float angle = Rnd.nextFloat(360f);
-				float maxDistance = effected.getGameStats().getMovementSpeedFloat();
+				float maxDistance = effected.getGameStats().getMovementSpeedFloat() * FLEE_SECONDS;
 				Vector3f closestCollision = GeoService.getInstance().findMovementCollision(effected, angle, maxDistance);
-				if (effected instanceof Npc) {
-					((Npc) effected).getMoveController().resetMove();
-					((Npc) effected).getMoveController().moveToPoint(closestCollision.getX(), closestCollision.getY(), closestCollision.getZ());
+				if (effected instanceof Npc npc) {
+					//Updates destination on the fly (no resetMove): movement stays continuous.
+					npc.getMoveController().retargetPoint(closestCollision.getX(), closestCollision.getY(), closestCollision.getZ());
 				} else {
 					byte heading = PositionUtil.convertAngleToHeading(angle);
 					effected.getMoveController().setNewDirection(closestCollision.getX(), closestCollision.getY(), closestCollision.getZ(), heading);
@@ -107,5 +104,4 @@ public class ConfuseEffect extends EffectTemplate {
 			}
 		}
 	}
-
 }

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/ConfuseEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/ConfuseEffect.java
@@ -29,7 +29,6 @@ import com.aionemu.gameserver.world.geo.GeoService;
 /**
  * @author Yeats, SVDNESS
  */
-
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "ConfuseEffect")
 public class ConfuseEffect extends EffectTemplate {
@@ -38,7 +37,7 @@ public class ConfuseEffect extends EffectTemplate {
 	public void applyEffect(Effect effect) {
 		Creature effected = effect.getEffected();
 		effected.getEffectController().removeHideEffects();
-		//If the target is gliding, then we remove this condition.
+
 		if (effected instanceof Player && ((Player) effected).isInGlidingState()) {
 			((Player) effected).getFlyController().onStopGliding();
 		}
@@ -66,7 +65,7 @@ public class ConfuseEffect extends EffectTemplate {
 			PacketSendUtility.broadcastPacket((Player) effected, new SM_EMOTION(effected, EmotionType.RUN), true);
 		}
 		if (GeoDataConfig.FEAR_ENABLE) {
-			ScheduledFuture<?> confuseTask = ThreadPoolManager.getInstance().scheduleAtFixedRate(new ConfuseTask(effected), 0, 1_000);
+			ScheduledFuture<?> confuseTask = ThreadPoolManager.getInstance().scheduleAtFixedRate(new ConfuseTask(effected), 0, 1000);
 			effect.setPeriodicTask(confuseTask, position);
 		}
 	}
@@ -82,7 +81,7 @@ public class ConfuseEffect extends EffectTemplate {
 		}
 	}
 
-	record ConfuseTask (Creature effected) implements Runnable {
+	record ConfuseTask(Creature effected) implements Runnable {
 		//The flee point is farther than the target travels per tick (1 sec):
 		//the target never reaches it between ticks and keeps running smoothly — same as retail behavior.
 		private static final float FLEE_SECONDS = 2.5f;
@@ -94,8 +93,7 @@ public class ConfuseEffect extends EffectTemplate {
 				float maxDistance = effected.getGameStats().getMovementSpeedFloat() * FLEE_SECONDS;
 				Vector3f closestCollision = GeoService.getInstance().findMovementCollision(effected, angle, maxDistance);
 				if (effected instanceof Npc npc) {
-					//Updates destination on the fly (no resetMove): movement stays continuous.
-					npc.getMoveController().retargetPoint(closestCollision.getX(), closestCollision.getY(), closestCollision.getZ());
+					npc.getMoveController().moveToPoint(closestCollision.getX(), closestCollision.getY(), closestCollision.getZ());
 				} else {
 					byte heading = PositionUtil.convertAngleToHeading(angle);
 					effected.getMoveController().setNewDirection(closestCollision.getX(), closestCollision.getY(), closestCollision.getZ(), heading);

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/FearEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/FearEffect.java
@@ -32,10 +32,10 @@ import com.aionemu.gameserver.world.geo.GeoService;
 /**
  * @author Sarynth, SVDNESS
  */
-
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "FearEffect")
 public class FearEffect extends EffectTemplate {
+
 	@XmlAttribute
 	protected int resistchance = 100;
 
@@ -43,7 +43,7 @@ public class FearEffect extends EffectTemplate {
 	public void applyEffect(Effect effect) {
 		Creature effected = effect.getEffected();
 		effected.getEffectController().removeHideEffects();
-		//If the target is gliding, then we remove this condition.
+		// Fear stops gliding
 		if (effected instanceof Player && ((Player) effected).isInGlidingState()) {
 			((Player) effected).getFlyController().onStopGliding();
 		}
@@ -64,24 +64,25 @@ public class FearEffect extends EffectTemplate {
 		effected.getEffectController().setAbnormal(AbnormalState.FEAR);
 		effected.getMoveController().abortMove();
 		if (effected instanceof Npc) {
-			EmoteManager.emoteStartAttacking((Npc) effected, effector); //Set weapon_equipped for faster walk speed.
+			EmoteManager.emoteStartAttacking((Npc) effected, effector); // set weapon_equipped for faster walk speed
 			effected.getAi().setStateIfNot(AIState.FEAR);
 		} else if (effected instanceof Player && effected.isInState(CreatureState.WALK_MODE)) {
 			effected.unsetState(CreatureState.WALK_MODE);
 			PacketSendUtility.broadcastPacket((Player) effected, new SM_EMOTION(effected, EmotionType.RUN), true);
 		}
 		if (GeoDataConfig.FEAR_ENABLE) {
-			ScheduledFuture<?> fearTask = ThreadPoolManager.getInstance().scheduleAtFixedRate(new FearTask(effector, effected), 0, 1_000);
+			ScheduledFuture<?> fearTask = ThreadPoolManager.getInstance().scheduleAtFixedRate(new FearTask(effector, effected), 0, 1000);
 			effect.setPeriodicTask(fearTask, position);
 		}
-		//Resistchance of fear effect to damage, if value is lower than 100, fear can be interrupted bz damage (example skillId: Terrible howl).
+		// resistchance of fear effect to damage, if value is lower than 100, fear can be interrupted bz damage
+		// example skillId: 540 Terrible howl
 		if (resistchance < 100) {
 			effect.addObserver(effected, new ActionObserver(ObserverType.ATTACKED) {
+
 				@Override
 				public void attacked(Creature creature, int skillId) {
-					if (Rnd.chance() >= resistchance) {
+					if (Rnd.chance() >= resistchance)
 						effected.getEffectController().removeEffect(effect.getSkillId());
-					}
 				}
 			});
 		}
@@ -110,8 +111,7 @@ public class FearEffect extends EffectTemplate {
 				float maxDistance = effected.getGameStats().getMovementSpeedFloat() * FLEE_SECONDS;
 				Vector3f closestCollision = GeoService.getInstance().findMovementCollision(effected, angle, maxDistance);
 				if (effected instanceof Npc npc) {
-					//Updates destination on the fly (no resetMove): movement stays continuous.
-					npc.getMoveController().retargetPoint(closestCollision.getX(), closestCollision.getY(), closestCollision.getZ());
+					npc.getMoveController().moveToPoint(closestCollision.getX(), closestCollision.getY(), closestCollision.getZ());
 				} else {
 					byte moveAwayHeading = PositionUtil.convertAngleToHeading(angle);
 					effected.getMoveController().setNewDirection(closestCollision.getX(), closestCollision.getY(), closestCollision.getZ(), moveAwayHeading);

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/FearEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/FearEffect.java
@@ -30,12 +30,12 @@ import com.aionemu.gameserver.utils.ThreadPoolManager;
 import com.aionemu.gameserver.world.geo.GeoService;
 
 /**
- * @author Sarynth
+ * @author Sarynth, SVDNESS
  */
+
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "FearEffect")
 public class FearEffect extends EffectTemplate {
-
 	@XmlAttribute
 	protected int resistchance = 100;
 
@@ -43,11 +43,10 @@ public class FearEffect extends EffectTemplate {
 	public void applyEffect(Effect effect) {
 		Creature effected = effect.getEffected();
 		effected.getEffectController().removeHideEffects();
-		// Fear stops gliding
+		//If the target is gliding, then we remove this condition.
 		if (effected instanceof Player && ((Player) effected).isInGlidingState()) {
 			((Player) effected).getFlyController().onStopGliding();
 		}
-
 		effect.addToEffectedController();
 	}
 
@@ -63,30 +62,26 @@ public class FearEffect extends EffectTemplate {
 		effected.getController().cancelCurrentSkill(effector);
 		effect.setAbnormal(AbnormalState.FEAR);
 		effected.getEffectController().setAbnormal(AbnormalState.FEAR);
-
 		effected.getMoveController().abortMove();
-
 		if (effected instanceof Npc) {
-			EmoteManager.emoteStartAttacking((Npc) effected, effector); // set weapon_equipped for faster walk speed
+			EmoteManager.emoteStartAttacking((Npc) effected, effector); //Set weapon_equipped for faster walk speed.
 			effected.getAi().setStateIfNot(AIState.FEAR);
 		} else if (effected instanceof Player && effected.isInState(CreatureState.WALK_MODE)) {
 			effected.unsetState(CreatureState.WALK_MODE);
 			PacketSendUtility.broadcastPacket((Player) effected, new SM_EMOTION(effected, EmotionType.RUN), true);
 		}
 		if (GeoDataConfig.FEAR_ENABLE) {
-			ScheduledFuture<?> fearTask = ThreadPoolManager.getInstance().scheduleAtFixedRate(new FearTask(effector, effected), 0, 1000);
+			ScheduledFuture<?> fearTask = ThreadPoolManager.getInstance().scheduleAtFixedRate(new FearTask(effector, effected), 0, 1_000);
 			effect.setPeriodicTask(fearTask, position);
 		}
-
-		// resistchance of fear effect to damage, if value is lower than 100, fear can be interrupted bz damage
-		// example skillId: 540 Terrible howl
+		//Resistchance of fear effect to damage, if value is lower than 100, fear can be interrupted bz damage (example skillId: Terrible howl).
 		if (resistchance < 100) {
 			effect.addObserver(effected, new ActionObserver(ObserverType.ATTACKED) {
-
 				@Override
 				public void attacked(Creature creature, int skillId) {
-					if (Rnd.chance() >= resistchance)
+					if (Rnd.chance() >= resistchance) {
 						effected.getEffectController().removeEffect(effect.getSkillId());
+					}
 				}
 			});
 		}
@@ -95,35 +90,28 @@ public class FearEffect extends EffectTemplate {
 	@Override
 	public void endEffect(Effect effect) {
 		effect.getEffected().getEffectController().unsetAbnormal(AbnormalState.FEAR);
-
 		effect.getEffected().getMoveController().abortMove();
 		PacketSendUtility.broadcastPacketAndReceive(effect.getEffected(), new SM_POSITION(effect.getEffected()));
-
 		if (effect.getEffected() instanceof Npc) {
 			effect.getEffected().getAi().setStateIfNot(AIState.IDLE);
 			effect.getEffected().getAi().onCreatureEvent(AIEventType.ATTACK, effect.getEffected());
 		}
 	}
 
-	class FearTask implements Runnable {
-
-		private Creature effector;
-		private Creature effected;
-
-		FearTask(Creature effector, Creature effected) {
-			this.effector = effector;
-			this.effected = effected;
-		}
+	record FearTask(Creature effector, Creature effected) implements Runnable {
+		//The flee point is farther than the target travels per tick (1 sec):
+		//the target never reaches it between ticks and keeps running smoothly — same as retail behavior.
+		private static final float FLEE_SECONDS = 2.5f;
 
 		@Override
 		public void run() {
 			if (effected.getEffectController().isUnderFear() && PositionUtil.isInRange(effected, effector, 40)) {
 				float angle = PositionUtil.calculateAngleFrom(effector, effected);
-				float maxDistance = effected.getGameStats().getMovementSpeedFloat();
+				float maxDistance = effected.getGameStats().getMovementSpeedFloat() * FLEE_SECONDS;
 				Vector3f closestCollision = GeoService.getInstance().findMovementCollision(effected, angle, maxDistance);
-				if (effected instanceof Npc) {
-					((Npc) effected).getMoveController().resetMove();
-					((Npc) effected).getMoveController().moveToPoint(closestCollision.getX(), closestCollision.getY(), closestCollision.getZ());
+				if (effected instanceof Npc npc) {
+					//Updates destination on the fly (no resetMove): movement stays continuous.
+					npc.getMoveController().retargetPoint(closestCollision.getX(), closestCollision.getY(), closestCollision.getZ());
 				} else {
 					byte moveAwayHeading = PositionUtil.convertAngleToHeading(angle);
 					effected.getMoveController().setNewDirection(closestCollision.getX(), closestCollision.getY(), closestCollision.getZ(), moveAwayHeading);


### PR DESCRIPTION
Implements smooth NPC and player movement during fear and confuse effects,
matching retail behavior.

**Changes:**
- Flee destination updates every tick without stopping or resetting the current path
- Flee point is placed farther than the target can travel in one tick,
  so movement stays continuous and never stutters between ticks
- Eliminates the "run-stop-run" jitter caused by resetMove + moveToPoint on each tick