### PR TITLE
Decrease the dispel counter only upon successful removal of a buff/debuff. 

### DIFF
--- a/game-server/src/com/aionemu/gameserver/controllers/effect/EffectController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/effect/EffectController.java
@@ -515,8 +515,8 @@ public class EffectController {
 							if (removePower(ef, power)) {
 								ef.setDesignatedDispelEffect(effect);
 								dispelledEffectCount++;
+								count--;
 							}
-							count--;
 						}
 						break;
 				}
@@ -579,10 +579,10 @@ public class EffectController {
 				if (remove) {
 					if (removePower(effect, power)) {
 						effectsToEnd.add(effect);
+						count--;
 					} else if (owner instanceof Player) {
 						insufficientDispelPower = true;
 					}
-					count--;
 				} else
 					insufficientDispelLevel = true;
 			}

--- a/game-server/src/com/aionemu/gameserver/controllers/effect/EffectController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/effect/EffectController.java
@@ -511,12 +511,10 @@ public class EffectController {
 				switch (dispelCat) {
 					case ALL:
 					case BUFF:// DispelBuffCounterAtkEffect
-						if (ef.getReqDispelLevel() <= dispelLevel) {
-							if (removePower(ef, power)) {
-								ef.setDesignatedDispelEffect(effect);
-								dispelledEffectCount++;
-								count--;
-							}
+						if (ef.getReqDispelLevel() <= dispelLevel && removePower(ef, power)) {
+							ef.setDesignatedDispelEffect(effect);
+							dispelledEffectCount++;
+							count--;
 						}
 						break;
 				}


### PR DESCRIPTION
The counter should only decrease if the buff/debuff was actually dispelled. Otherwise, the power of the buff/debuff still decreases, but the search for the next 'candidate' for dispel continues.