### PR TITLE
Fix incorrect skill mapping logic for req_dispel attributes

### DIFF
--- a/game-server/data/static_data/skills/skill_templates.xml
+++ b/game-server/data/static_data/skills/skill_templates.xml
@@ -27460,7 +27460,7 @@
 		</effects>
 		<motion name="pointfire2" delay="10" />
 	</skill_template>
-	<skill_template skill_id="1826" name="Tremor" nameId="2286476" cooldownId="1550" group="CH_TREMOR" stack="CH_TREMOR" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="3000" duration="0" penalty_skill_id="8999" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="1826" name="Tremor" nameId="2286476" cooldownId="1550" group="CH_TREMOR" stack="CH_TREMOR" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="3000" duration="0" penalty_skill_id="8999" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="12" effective_altitude="4" effective_range="20" />
 		<startconditions>
 			<dp value="4000" />
@@ -27475,7 +27475,7 @@
 		</actions>
 		<motion name="areafire" />
 	</skill_template>
-	<skill_template skill_id="1827" name="Tremor" nameId="2286476" cooldownId="1550" group="CH_TREMOR" stack="CH_TREMOR" lvl="2" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="3000" duration="0" penalty_skill_id="9000" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="1827" name="Tremor" nameId="2286476" cooldownId="1550" group="CH_TREMOR" stack="CH_TREMOR" lvl="2" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="3000" duration="0" penalty_skill_id="9000" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="12" effective_altitude="4" effective_range="20" />
 		<startconditions>
 			<dp value="4000" />
@@ -27490,7 +27490,7 @@
 		</actions>
 		<motion name="areafire" />
 	</skill_template>
-	<skill_template skill_id="1828" name="Tremor" nameId="2286476" cooldownId="1550" group="CH_TREMOR" stack="CH_TREMOR" lvl="3" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="3000" duration="0" penalty_skill_id="9001" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="1828" name="Tremor" nameId="2286476" cooldownId="1550" group="CH_TREMOR" stack="CH_TREMOR" lvl="3" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="3000" duration="0" penalty_skill_id="9001" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="12" effective_altitude="4" effective_range="20" />
 		<startconditions>
 			<dp value="4000" />
@@ -27505,7 +27505,7 @@
 		</actions>
 		<motion name="areafire" />
 	</skill_template>
-	<skill_template skill_id="1829" name="Tremor" nameId="2286476" cooldownId="1550" group="CH_TREMOR" stack="CH_TREMOR" lvl="4" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="3000" duration="0" penalty_skill_id="9002" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="1829" name="Tremor" nameId="2286476" cooldownId="1550" group="CH_TREMOR" stack="CH_TREMOR" lvl="4" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="3000" duration="0" penalty_skill_id="9002" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="12" effective_altitude="4" effective_range="20" />
 		<startconditions>
 			<dp value="4000" />
@@ -27520,7 +27520,7 @@
 		</actions>
 		<motion name="areafire" />
 	</skill_template>
-	<skill_template skill_id="1830" name="Tremor" nameId="2286476" cooldownId="1550" group="CH_TREMOR" stack="CH_TREMOR" lvl="5" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="3000" duration="0" penalty_skill_id="9003" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="1830" name="Tremor" nameId="2286476" cooldownId="1550" group="CH_TREMOR" stack="CH_TREMOR" lvl="5" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="3000" duration="0" penalty_skill_id="9003" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="12" effective_altitude="4" effective_range="20" />
 		<startconditions>
 			<dp value="4000" />
@@ -27535,7 +27535,7 @@
 		</actions>
 		<motion name="areafire" />
 	</skill_template>
-	<skill_template skill_id="1831" name="Tremor" nameId="2286476" cooldownId="1550" group="CH_TREMOR" stack="CH_TREMOR" lvl="6" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="3000" duration="0" penalty_skill_id="9004" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="1831" name="Tremor" nameId="2286476" cooldownId="1550" group="CH_TREMOR" stack="CH_TREMOR" lvl="6" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="3000" duration="0" penalty_skill_id="9004" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="12" effective_altitude="4" effective_range="20" />
 		<startconditions>
 			<dp value="4000" />
@@ -50695,7 +50695,7 @@
 		</effects>
 		<motion instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="3010" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="3010" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="6" awr="true" effective_altitude="4" effective_range="8" />
 		<endconditions>
 			<mp value="52" delta="0" />
@@ -50709,7 +50709,7 @@
 		</effects>
 		<motion name="phburst2" speed="70" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="3011" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="2" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="3011" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="2" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="6" awr="true" effective_altitude="4" effective_range="8" />
 		<endconditions>
 			<mp value="60" delta="0" />
@@ -50723,7 +50723,7 @@
 		</effects>
 		<motion name="phburst2" speed="70" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="3012" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="3" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="3012" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="3" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="6" awr="true" effective_altitude="4" effective_range="8" />
 		<endconditions>
 			<mp value="68" delta="0" />
@@ -50737,7 +50737,7 @@
 		</effects>
 		<motion name="phburst2" speed="70" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="3013" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="4" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="3013" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="4" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="6" awr="true" effective_altitude="4" effective_range="8" />
 		<endconditions>
 			<mp value="76" delta="0" />
@@ -50751,7 +50751,7 @@
 		</effects>
 		<motion name="phburst2" speed="70" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="3014" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="5" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="3014" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="5" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="6" awr="true" effective_altitude="4" effective_range="8" />
 		<endconditions>
 			<mp value="84" delta="0" />
@@ -50765,7 +50765,7 @@
 		</effects>
 		<motion name="phburst2" speed="70" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="3015" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="6" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="3015" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="6" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="6" awr="true" effective_altitude="4" effective_range="8" />
 		<endconditions>
 			<mp value="95" delta="0" />
@@ -50779,7 +50779,7 @@
 		</effects>
 		<motion name="phburst2" speed="70" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="3016" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="7" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="3016" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="7" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="6" awr="true" effective_altitude="4" effective_range="8" />
 		<endconditions>
 			<mp value="108" delta="0" />
@@ -50793,7 +50793,7 @@
 		</effects>
 		<motion name="phburst2" speed="70" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="3017" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="8" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="3017" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="8" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="6" awr="true" effective_altitude="4" effective_range="8" />
 		<endconditions>
 			<mp value="122" delta="0" />
@@ -50807,7 +50807,7 @@
 		</effects>
 		<motion name="phburst2" speed="70" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="3018" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="9" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="3018" name="Provoking Roar" nameId="2286953" cooldownId="442" group="KN_MASSIVEPROVOKE" stack="KN_MASSIVEPROVOKE" lvl="9" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="120" duration="0" penalty_skill_id="9041" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="6" awr="true" effective_altitude="4" effective_range="8" />
 		<endconditions>
 			<mp value="137" delta="0" />
@@ -50821,7 +50821,7 @@
 		</effects>
 		<motion name="phburst2" speed="70" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="3019" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9042" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="3019" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9042" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="ENEMY" target_type="ONLYONE" awr="true" />
 		<startconditions>
 			<dp value="2000" />
@@ -50841,7 +50841,7 @@
 		</actions>
 		<motion name="fidpatk" />
 	</skill_template>
-	<skill_template skill_id="3020" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="2" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9043" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="3020" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="2" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9043" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="ENEMY" target_type="ONLYONE" awr="true" />
 		<startconditions>
 			<dp value="2000" />
@@ -50861,7 +50861,7 @@
 		</actions>
 		<motion name="fidpatk" />
 	</skill_template>
-	<skill_template skill_id="3021" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="3" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9044" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="3021" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="3" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9044" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="ENEMY" target_type="ONLYONE" awr="true" />
 		<startconditions>
 			<dp value="2000" />
@@ -50881,7 +50881,7 @@
 		</actions>
 		<motion name="fidpatk" />
 	</skill_template>
-	<skill_template skill_id="3022" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="4" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9045" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="3022" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="4" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9045" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="ENEMY" target_type="ONLYONE" awr="true" />
 		<startconditions>
 			<dp value="2000" />
@@ -50901,7 +50901,7 @@
 		</actions>
 		<motion name="fidpatk" />
 	</skill_template>
-	<skill_template skill_id="3023" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="5" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9046" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="3023" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="5" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9046" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="ENEMY" target_type="ONLYONE" awr="true" />
 		<startconditions>
 			<dp value="2000" />
@@ -50921,7 +50921,7 @@
 		</actions>
 		<motion name="fidpatk" />
 	</skill_template>
-	<skill_template skill_id="3024" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="6" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9047" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="3024" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="6" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9047" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="ENEMY" target_type="ONLYONE" awr="true" />
 		<startconditions>
 			<dp value="2000" />
@@ -50941,7 +50941,7 @@
 		</actions>
 		<motion name="fidpatk" />
 	</skill_template>
-	<skill_template skill_id="3025" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="7" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9048" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="3025" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="7" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9048" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="ENEMY" target_type="ONLYONE" awr="true" />
 		<startconditions>
 			<dp value="2000" />
@@ -50961,7 +50961,7 @@
 		</actions>
 		<motion name="fidpatk" />
 	</skill_template>
-	<skill_template skill_id="3026" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="8" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9049" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="3026" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="8" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9049" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="ENEMY" target_type="ONLYONE" awr="true" />
 		<startconditions>
 			<dp value="2000" />
@@ -50981,7 +50981,7 @@
 		</actions>
 		<motion name="fidpatk" />
 	</skill_template>
-	<skill_template skill_id="3027" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="9" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9050" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="3027" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="9" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9050" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="ENEMY" target_type="ONLYONE" awr="true" />
 		<startconditions>
 			<dp value="2000" />
@@ -51001,7 +51001,7 @@
 		</actions>
 		<motion name="fidpatk" />
 	</skill_template>
-	<skill_template skill_id="3028" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="10" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9051" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="3028" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="10" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9051" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="ENEMY" target_type="ONLYONE" awr="true" />
 		<startconditions>
 			<dp value="2000" />
@@ -51021,7 +51021,7 @@
 		</actions>
 		<motion name="fidpatk" />
 	</skill_template>
-	<skill_template skill_id="3029" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="11" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9052" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="3029" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="11" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9052" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="ENEMY" target_type="ONLYONE" awr="true" />
 		<startconditions>
 			<dp value="2000" />
@@ -51041,7 +51041,7 @@
 		</actions>
 		<motion name="fidpatk" />
 	</skill_template>
-	<skill_template skill_id="3030" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="12" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9053" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="3030" name="Empyrean Chastisement" nameId="2286957" cooldownId="520" group="KN_ABYSALJUDGEMENT" stack="KN_DIVINEJUDGEMENT" lvl="12" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" penalty_skill_id="9053" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="ENEMY" target_type="ONLYONE" awr="true" />
 		<startconditions>
 			<dp value="2000" />
@@ -72044,7 +72044,7 @@
 		</effects>
 		<motion name="shockattack02" />
 	</skill_template>
-	<skill_template skill_id="4246" name="Thronesong" nameId="2285985" cooldownId="1260" group="BA_SONGOFWIND" stack="BA_SONGOFWIND" lvl="1" skilltype="MAGICAL" skill_category="CHAIN_SKILL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="0" ammospeed="30" penalty_skill_id="8892" penalty_skill_send_msg="true" cancel_rate="20" chain_skill_prob="100" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="4246" name="Thronesong" nameId="2285985" cooldownId="1260" group="BA_SONGOFWIND" stack="BA_SONGOFWIND" lvl="1" skilltype="MAGICAL" skill_category="CHAIN_SKILL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="0" ammospeed="30" penalty_skill_id="8892" penalty_skill_send_msg="true" cancel_rate="20" chain_skill_prob="100" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="25" target_relation="ENEMY" target_type="ONLYONE" revision_distance="6" />
 		<startconditions>
 			<weapon weapon="HARP" />
@@ -72061,7 +72061,7 @@
 		</effects>
 		<motion name="shockattack04" />
 	</skill_template>
-	<skill_template skill_id="4247" name="Thronesong" nameId="2285985" cooldownId="1260" group="BA_SONGOFWIND" stack="BA_SONGOFWIND" lvl="2" skilltype="MAGICAL" skill_category="CHAIN_SKILL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="0" ammospeed="30" penalty_skill_id="8893" penalty_skill_send_msg="true" cancel_rate="20" chain_skill_prob="100" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="4247" name="Thronesong" nameId="2285985" cooldownId="1260" group="BA_SONGOFWIND" stack="BA_SONGOFWIND" lvl="2" skilltype="MAGICAL" skill_category="CHAIN_SKILL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="0" ammospeed="30" penalty_skill_id="8893" penalty_skill_send_msg="true" cancel_rate="20" chain_skill_prob="100" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="25" target_relation="ENEMY" target_type="ONLYONE" revision_distance="6" />
 		<startconditions>
 			<weapon weapon="HARP" />
@@ -72078,7 +72078,7 @@
 		</effects>
 		<motion name="shockattack04" />
 	</skill_template>
-	<skill_template skill_id="4248" name="Thronesong" nameId="2285985" cooldownId="1260" group="BA_SONGOFWIND" stack="BA_SONGOFWIND" lvl="3" skilltype="MAGICAL" skill_category="CHAIN_SKILL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="0" ammospeed="30" penalty_skill_id="8894" penalty_skill_send_msg="true" cancel_rate="20" chain_skill_prob="100" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="4248" name="Thronesong" nameId="2285985" cooldownId="1260" group="BA_SONGOFWIND" stack="BA_SONGOFWIND" lvl="3" skilltype="MAGICAL" skill_category="CHAIN_SKILL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="0" ammospeed="30" penalty_skill_id="8894" penalty_skill_send_msg="true" cancel_rate="20" chain_skill_prob="100" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="25" target_relation="ENEMY" target_type="ONLYONE" revision_distance="6" />
 		<startconditions>
 			<weapon weapon="HARP" />
@@ -72095,7 +72095,7 @@
 		</effects>
 		<motion name="shockattack04" />
 	</skill_template>
-	<skill_template skill_id="4249" name="Thronesong" nameId="2285985" cooldownId="1260" group="BA_SONGOFWIND" stack="BA_SONGOFWIND" lvl="4" skilltype="MAGICAL" skill_category="CHAIN_SKILL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="0" ammospeed="30" penalty_skill_id="8895" penalty_skill_send_msg="true" cancel_rate="20" chain_skill_prob="100" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="4249" name="Thronesong" nameId="2285985" cooldownId="1260" group="BA_SONGOFWIND" stack="BA_SONGOFWIND" lvl="4" skilltype="MAGICAL" skill_category="CHAIN_SKILL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="0" ammospeed="30" penalty_skill_id="8895" penalty_skill_send_msg="true" cancel_rate="20" chain_skill_prob="100" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="25" target_relation="ENEMY" target_type="ONLYONE" revision_distance="6" />
 		<startconditions>
 			<weapon weapon="HARP" />
@@ -72112,7 +72112,7 @@
 		</effects>
 		<motion name="shockattack04" />
 	</skill_template>
-	<skill_template skill_id="4250" name="Thronesong" nameId="2285985" cooldownId="1260" group="BA_SONGOFWIND" stack="BA_SONGOFWIND" lvl="5" skilltype="MAGICAL" skill_category="CHAIN_SKILL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="0" ammospeed="30" penalty_skill_id="8896" penalty_skill_send_msg="true" cancel_rate="20" chain_skill_prob="100" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="4250" name="Thronesong" nameId="2285985" cooldownId="1260" group="BA_SONGOFWIND" stack="BA_SONGOFWIND" lvl="5" skilltype="MAGICAL" skill_category="CHAIN_SKILL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="0" ammospeed="30" penalty_skill_id="8896" penalty_skill_send_msg="true" cancel_rate="20" chain_skill_prob="100" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="25" target_relation="ENEMY" target_type="ONLYONE" revision_distance="6" />
 		<startconditions>
 			<weapon weapon="HARP" />
@@ -72129,7 +72129,7 @@
 		</effects>
 		<motion name="shockattack04" />
 	</skill_template>
-	<skill_template skill_id="4251" name="Thronesong" nameId="2285985" cooldownId="1260" group="BA_SONGOFWIND" stack="BA_SONGOFWIND" lvl="6" skilltype="MAGICAL" skill_category="CHAIN_SKILL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="0" ammospeed="30" penalty_skill_id="8897" penalty_skill_send_msg="true" cancel_rate="20" chain_skill_prob="100" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="4251" name="Thronesong" nameId="2285985" cooldownId="1260" group="BA_SONGOFWIND" stack="BA_SONGOFWIND" lvl="6" skilltype="MAGICAL" skill_category="CHAIN_SKILL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="0" ammospeed="30" penalty_skill_id="8897" penalty_skill_send_msg="true" cancel_rate="20" chain_skill_prob="100" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="25" target_relation="ENEMY" target_type="ONLYONE" revision_distance="6" />
 		<startconditions>
 			<weapon weapon="HARP" />
@@ -72146,7 +72146,7 @@
 		</effects>
 		<motion name="shockattack04" />
 	</skill_template>
-	<skill_template skill_id="4252" name="Thronesong" nameId="2285985" cooldownId="1260" group="BA_SONGOFWIND" stack="BA_SONGOFWIND" lvl="7" skilltype="MAGICAL" skill_category="CHAIN_SKILL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="0" ammospeed="30" penalty_skill_id="8898" penalty_skill_send_msg="true" cancel_rate="20" chain_skill_prob="100" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="4252" name="Thronesong" nameId="2285985" cooldownId="1260" group="BA_SONGOFWIND" stack="BA_SONGOFWIND" lvl="7" skilltype="MAGICAL" skill_category="CHAIN_SKILL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="0" ammospeed="30" penalty_skill_id="8898" penalty_skill_send_msg="true" cancel_rate="20" chain_skill_prob="100" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="25" target_relation="ENEMY" target_type="ONLYONE" revision_distance="6" />
 		<startconditions>
 			<weapon weapon="HARP" />
@@ -122727,7 +122727,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="16719" name="Stanch" nameId="285773" cooldownId="10" stack="NGR_DISPELBLEEDSDHP_NR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="16400" cancel_rate="40" hostile_type="INDIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="16719" name="Stanch" nameId="285773" cooldownId="10" stack="NGR_DISPELBLEEDSDHP_NR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="16400" cancel_rate="40" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -122742,7 +122742,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="16720" name="Regenerate Body" nameId="285774" cooldownId="10" stack="NGR_DISPELBLEEDSDHP_TROLL" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="16400" cancel_rate="40" hostile_type="INDIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="16720" name="Regenerate Body" nameId="285774" cooldownId="10" stack="NGR_DISPELBLEEDSDHP_TROLL" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="16400" cancel_rate="40" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -123994,7 +123994,7 @@
 		</effects>
 		<motion name="chainatk1" speed="70" />
 	</skill_template>
-	<skill_template skill_id="16799" name="Test_SkillMotionSpeed_30" nameId="287515" cooldownId="1" stack="TEST_SKILLANIAPEED_30" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2000" cancel_rate="25" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="16799" name="Test_SkillMotionSpeed_30" nameId="287515" cooldownId="1" stack="TEST_SKILLANIAPEED_30" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2000" cancel_rate="25" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -124020,7 +124020,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="16801" name="Test_NormalFire" nameId="287531" cooldownId="1" stack="TEST_NORMALFIRE" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" cancel_rate="25" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="16801" name="Test_NormalFire" nameId="287531" cooldownId="1" stack="TEST_NORMALFIRE" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" cancel_rate="25" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ALL" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -124072,7 +124072,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="16805" name="Test_ChainAttack1" nameId="287525" cooldownId="1" stack="TEST_CHAINATK1" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" cancel_rate="25" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="16805" name="Test_ChainAttack1" nameId="287525" cooldownId="1" stack="TEST_CHAINATK1" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" cancel_rate="25" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ALL" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -124085,7 +124085,7 @@
 		</effects>
 		<motion name="chainatk1" />
 	</skill_template>
-	<skill_template skill_id="16806" name="Test_ChainAttack2" nameId="287527" cooldownId="1" stack="TEST_CHAINATK2" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" cancel_rate="25" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="16806" name="Test_ChainAttack2" nameId="287527" cooldownId="1" stack="TEST_CHAINATK2" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" cancel_rate="25" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ALL" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -125030,7 +125030,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="16868" name="Soul Block" nameId="288013" cooldownId="5" stack="GNWI_BINDSLIENCETA_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="3000" ammospeed="25" cancel_rate="30" hostile_type="DIRECT">
+	<skill_template skill_id="16868" name="Soul Block" nameId="288013" cooldownId="5" stack="GNWI_BINDSLIENCETA_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="3000" ammospeed="25" cancel_rate="30" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="16" target_relation="ENEMY" target_type="AREA" target_maxcount="24" effective_altitude="5" effective_range="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -125198,7 +125198,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="16879" name="Self-Protection" nameId="288065" cooldownId="1" stack="GNWA_SUPPYDEFSHORT_SHANDUKA" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" ammospeed="25" penalty_skill_id="16415" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="20">
+	<skill_template skill_id="16879" name="Self-Protection" nameId="288065" cooldownId="1" stack="GNWA_SUPPYDEFSHORT_SHANDUKA" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" ammospeed="25" penalty_skill_id="16415" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="1" effective_altitude="25" effective_range="25" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -125447,7 +125447,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="16897" name="Taunt I" nameId="283316" cooldownId="16" stack="PEL_TAUNT" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="100" duration="0" cancel_rate="10" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="16897" name="Taunt I" nameId="283316" cooldownId="16" stack="PEL_TAUNT" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="100" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -125469,7 +125469,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="16899" name="Shock of Wind I" nameId="283320" cooldownId="15" stack="PEL_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="100" duration="0" cancel_rate="10" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="16899" name="Shock of Wind I" nameId="283320" cooldownId="15" stack="PEL_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="100" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -125842,7 +125842,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="16924" name="Earth Spirit: Special Attack I" nameId="284104" cooldownId="18" stack="PEL_UE_ASSAIL" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="16924" name="Earth Spirit: Special Attack I" nameId="284104" cooldownId="18" stack="PEL_UE_ASSAIL" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="4" effective_altitude="5" effective_range="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -125870,7 +125870,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="16926" name="Earth Spirit: Special Attack II" nameId="284108" cooldownId="18" stack="PEL_UE_ASSAIL" lvl="2" skilltype="MAGICAL" skillsubtype="NONE" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="20">
+	<skill_template skill_id="16926" name="Earth Spirit: Special Attack II" nameId="284108" cooldownId="18" stack="PEL_UE_ASSAIL" lvl="2" skilltype="MAGICAL" skillsubtype="NONE" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="4" effective_altitude="5" effective_range="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -126270,7 +126270,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="16952" name="Burn Wings" nameId="282957" cooldownId="1" stack="NWI_FLY_DEADSHOT_GARGOYLE_TEST" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" ammospeed="35" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="16952" name="Burn Wings" nameId="282957" cooldownId="1" stack="NWI_FLY_DEADSHOT_GARGOYLE_TEST" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" ammospeed="35" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="37" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -126298,7 +126298,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="16954" name="Test_Flying_NoFly" nameId="288616" cooldownId="1" stack="TEST_FLYING_NOFLY" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="2000" hostile_type="DIRECT">
+	<skill_template skill_id="16954" name="Test_Flying_NoFly" nameId="288616" cooldownId="1" stack="TEST_FLYING_NOFLY" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="2000" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="37" target_relation="ENEMY" target_type="AREA" target_maxcount="1" effective_altitude="20" effective_range="20" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -126313,7 +126313,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="16955" name="Test_Flying_AntiFlying" nameId="288617" cooldownId="1" stack="TEST_FLYING_ANTIFLYING" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="2000" hostile_type="INDIRECT">
+	<skill_template skill_id="16955" name="Test_Flying_AntiFlying" nameId="288617" cooldownId="1" stack="TEST_FLYING_ANTIFLYING" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="2000" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="1" effective_altitude="7" effective_range="7" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -126326,7 +126326,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="16956" name="Powerful Left Stomp" nameId="288629" cooldownId="1" stack="TEST_GB_STANCE0_LF" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="3000" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="16956" name="Powerful Left Stomp" nameId="288629" cooldownId="1" stack="TEST_GB_STANCE0_LF" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="3000" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="100" target_relation="ENEMY" target_type="AREA" target_maxcount="48" effective_altitude="30" effective_range="30" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -126353,7 +126353,7 @@
 		</effects>
 		<motion name="areaatklf" />
 	</skill_template>
-	<skill_template skill_id="16957" name="Powerful Right Stomp" nameId="288630" cooldownId="1" stack="TEST_GB_STANCE0_RF" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="3000" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="30">
+	<skill_template skill_id="16957" name="Powerful Right Stomp" nameId="288630" cooldownId="1" stack="TEST_GB_STANCE0_RF" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="300" duration="3000" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="100" target_relation="ENEMY" target_type="AREA" target_maxcount="48" effective_altitude="40" effective_range="40" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -126380,7 +126380,7 @@
 		</effects>
 		<motion name="areaatkrf" />
 	</skill_template>
-	<skill_template skill_id="16958" name="Hand Force Propagation" nameId="288631" cooldownId="2" stack="TEST_GB_STANCE0_TH" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="300" duration="4000" hostile_type="DIRECT">
+	<skill_template skill_id="16958" name="Hand Force Propagation" nameId="288631" cooldownId="2" stack="TEST_GB_STANCE0_TH" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="300" duration="4000" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="100" target_relation="ENEMY" target_type="AREA" target_maxcount="48" effective_altitude="70" effective_range="70" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -127570,7 +127570,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17041" name="Smoldering Vengeance" nameId="289099" cooldownId="1" stack="GNKN_SATKTA_MORTALWONSIC" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16390" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17041" name="Smoldering Vengeance" nameId="289099" cooldownId="1" stack="GNKN_SATKTA_MORTALWONSIC" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16390" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="8" effective_altitude="7" effective_angle="240" effective_dist="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -127651,7 +127651,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17046" name="Wide Swift Attack" nameId="289105" cooldownId="3" stack="NFI_SATKCHAINATK1TA_PENALTY" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="16389" cancel_rate="40" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17046" name="Wide Swift Attack" nameId="289105" cooldownId="3" stack="NFI_SATKCHAINATK1TA_PENALTY" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="16389" cancel_rate="40" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="8" effective_altitude="5" effective_angle="240" effective_dist="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -129512,7 +129512,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17163" name="Virago" nameId="289511" cooldownId="3" stack="NKN_AR_FPATKINSKDSDDEFSUATT_NR" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="500" ammospeed="25" penalty_skill_id="16397" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17163" name="Virago" nameId="289511" cooldownId="3" stack="NKN_AR_FPATKINSKDSDDEFSUATT_NR" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="500" ammospeed="25" penalty_skill_id="16397" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="27" target_relation="ENEMY" target_type="AREA" target_maxcount="8" effective_altitude="5" effective_range="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -129535,7 +129535,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17164" name="Fury Eruption" nameId="289515" cooldownId="2" stack="NKN_KDSDDEFSUATTTA_NR" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16397" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17164" name="Fury Eruption" nameId="289515" cooldownId="2" stack="NKN_KDSDDEFSUATTTA_NR" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16397" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="3" effective_altitude="5" effective_angle="240" effective_dist="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -130490,7 +130490,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17229" name="Soul Burn" nameId="289744" cooldownId="1" stack="BNSL_SPELLATKINSLR_MOTAL" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="2500" ammospeed="25" penalty_skill_id="16392" hostile_type="DIRECT">
+	<skill_template skill_id="17229" name="Soul Burn" nameId="289744" cooldownId="1" stack="BNSL_SPELLATKINSLR_MOTAL" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="2500" ammospeed="25" penalty_skill_id="16392" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="16" target_relation="ENEMY" target_type="AREA" target_maxcount="8" effective_altitude="27" effective_range="27" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -130535,7 +130535,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17232" name="Swift Attack Devotion" nameId="289768" cooldownId="3" stack="BNWA_SATKCHAIN1_DF1CH" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="16389" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17232" name="Swift Attack Devotion" nameId="289768" cooldownId="3" stack="BNWA_SATKCHAIN1_DF1CH" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="16389" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="8" effective_altitude="5" effective_range="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -130593,7 +130593,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17236" name="Test_StuckAttack" nameId="289847" cooldownId="1" stack="TEST_STUCKATK" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" cancel_rate="25" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17236" name="Test_StuckAttack" nameId="289847" cooldownId="1" stack="TEST_STUCKATK" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" cancel_rate="25" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ALL" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -130606,7 +130606,7 @@
 		</effects>
 		<motion name="stuckatk" />
 	</skill_template>
-	<skill_template skill_id="17237" name="Test_AreaAttack" nameId="289849" cooldownId="1" stack="TEST_AREAATK" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" cancel_rate="25" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17237" name="Test_AreaAttack" nameId="289849" cooldownId="1" stack="TEST_AREAATK" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" cancel_rate="25" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ALL" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -130619,7 +130619,7 @@
 		</effects>
 		<motion name="areaatk" />
 	</skill_template>
-	<skill_template skill_id="17238" name="Test_AreaFire" nameId="289851" cooldownId="1" stack="TEST_AREAFIRE" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" cancel_rate="25" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17238" name="Test_AreaFire" nameId="289851" cooldownId="1" stack="TEST_AREAFIRE" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" cancel_rate="25" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ALL" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -130632,7 +130632,7 @@
 		</effects>
 		<motion name="areafire" />
 	</skill_template>
-	<skill_template skill_id="17239" name="Test_PHBuff" nameId="289853" cooldownId="1" stack="TEST_PHBUFF" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" cancel_rate="25" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17239" name="Test_PHBuff" nameId="289853" cooldownId="1" stack="TEST_PHBUFF" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" cancel_rate="25" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ALL" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -130645,7 +130645,7 @@
 		</effects>
 		<motion name="phbuff" />
 	</skill_template>
-	<skill_template skill_id="17240" name="Test_PHBurst" nameId="289855" cooldownId="1" stack="TEST_PHBURST" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" cancel_rate="25" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17240" name="Test_PHBurst" nameId="289855" cooldownId="1" stack="TEST_PHBURST" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" cancel_rate="25" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ALL" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -130920,7 +130920,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17259" name="Whirring with Energy" nameId="289953" cooldownId="1" stack="NWA_SATKLR_ADDSDWSLOW" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="16402" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17259" name="Whirring with Energy" nameId="289953" cooldownId="1" stack="NWA_SATKLR_ADDSDWSLOW" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="16402" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -130960,7 +130960,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="17262" name="Flame Slash" nameId="285433" cooldownId="15" stack="PEL_FIRESLASH" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="100" duration="0" cancel_rate="10" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17262" name="Flame Slash" nameId="285433" cooldownId="15" stack="PEL_FIRESLASH" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="100" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -131156,7 +131156,7 @@
 		</effects>
 		<motion name="poweratk" speed="50" />
 	</skill_template>
-	<skill_template skill_id="17276" name="Loud Shout" nameId="289913" cooldownId="6" stack="NCH_SUPPHYATTTA_ADDHEALINS_SC" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16401" cancel_rate="30" hostile_type="INDIRECT">
+	<skill_template skill_id="17276" name="Loud Shout" nameId="289913" cooldownId="6" stack="NCH_SUPPHYATTTA_ADDHEALINS_SC" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16401" cancel_rate="30" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="FRIEND" target_type="AREA" target_maxcount="8" effective_altitude="3" effective_range="3" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -131172,7 +131172,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="17277" name="Pathogen Transfer" nameId="289950" cooldownId="4" stack="NPR_BLINDDISPOI_ADDSUPHYATT" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="2500" ammospeed="25" penalty_skill_id="16399" cancel_rate="35" hostile_type="DIRECT">
+	<skill_template skill_id="17277" name="Pathogen Transfer" nameId="289950" cooldownId="4" stack="NPR_BLINDDISPOI_ADDSUPHYATT" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="2500" ammospeed="25" penalty_skill_id="16399" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="16" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -133209,7 +133209,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="17411" name="Fever" nameId="290330" cooldownId="13" stack="GNAS_DELAYNOFLY_ADDHIDESHI_LC" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" ammospeed="25" penalty_skill_id="16411" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17411" name="Fever" nameId="290330" cooldownId="13" stack="GNAS_DELAYNOFLY_ADDHIDESHI_LC" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" ammospeed="25" penalty_skill_id="16411" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="37" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="6" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -133367,7 +133367,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17422" name="Spirit Detonation Claw I Water" nameId="286542" stack="ORDER_ASSAIL_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17422" name="Spirit Detonation Claw I Water" nameId="286542" stack="ORDER_ASSAIL_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -133377,7 +133377,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17423" name="Spirit Detonation Claw I Wind" nameId="286543" stack="ORDER_ASSAIL_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17423" name="Spirit Detonation Claw I Wind" nameId="286543" stack="ORDER_ASSAIL_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -133664,7 +133664,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17444" name="Wrath Bombing" nameId="290358" cooldownId="17" stack="GNAS_SIGNETBURTA_ADDSUA" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16399" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17444" name="Wrath Bombing" nameId="290358" cooldownId="17" stack="GNAS_SIGNETBURTA_ADDSUA" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16399" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="8" effective_altitude="5" effective_angle="240" effective_dist="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -133747,7 +133747,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="17450" name="Strike of Protection" nameId="290369" cooldownId="1" stack="GNCH_SATKTA_ADDSHIELD" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16409" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17450" name="Strike of Protection" nameId="290369" cooldownId="1" stack="GNCH_SATKTA_ADDSHIELD" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16409" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="8" effective_altitude="5" effective_angle="240" effective_dist="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -133841,7 +133841,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17456" name="Nightmare" nameId="290386" cooldownId="10" stack="GNEL_SLEEPTA_ADDREF" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="3000" ammospeed="25" penalty_skill_id="16407" cancel_rate="40" hostile_type="DIRECT">
+	<skill_template skill_id="17456" name="Nightmare" nameId="290386" cooldownId="10" stack="GNEL_SLEEPTA_ADDREF" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="3000" ammospeed="25" penalty_skill_id="16407" cancel_rate="40" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="16" target_relation="ENEMY" target_type="AREA" target_maxcount="2" effective_altitude="5" effective_range="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -133887,7 +133887,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="17459" name="Powerful Knockdown" nameId="290394" cooldownId="2" stack="GNFI_KDTA_ADDSUPHYATT_STU" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="16399" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17459" name="Powerful Knockdown" nameId="290394" cooldownId="2" stack="GNFI_KDTA_ADDSUPHYATT_STU" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="16399" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="3" effective_altitude="7" effective_angle="120" effective_dist="7" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -133902,7 +133902,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17460" name="Aerial Thrust" nameId="290396" cooldownId="2" stack="GNFI_OPENARTA_ADDSHSUATT" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="16406" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17460" name="Aerial Thrust" nameId="290396" cooldownId="2" stack="GNFI_OPENARTA_ADDSHSUATT" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="16406" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="2" effective_altitude="5" effective_angle="240" effective_dist="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -133920,7 +133920,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17461" name="Electric Current Shock" nameId="290398" cooldownId="12" stack="GNFI_PARABOLTHTA_ADDSUPHYATT" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="16399" cancel_rate="35" hostile_type="DIRECT">
+	<skill_template skill_id="17461" name="Electric Current Shock" nameId="290398" cooldownId="12" stack="GNFI_PARABOLTHTA_ADDSUPHYATT" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="16399" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="2" effective_altitude="7" effective_angle="120" effective_dist="7" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -134179,7 +134179,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17478" name="Lightburst" nameId="290438" cooldownId="2" stack="GNKN_SATKTA_ADDSUATTHEALINS" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16404" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17478" name="Lightburst" nameId="290438" cooldownId="2" stack="GNKN_SATKTA_ADDSUATTHEALINS" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16404" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="4" effective_altitude="5" effective_angle="240" effective_dist="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -134326,7 +134326,7 @@
 		</effects>
 		<motion name="chainatk1" speed="70" />
 	</skill_template>
-	<skill_template skill_id="17488" name="Divine Shock" nameId="290467" cooldownId="2" stack="GNPR_SPSTUNTA_ADDSUDEF_STU" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="500" ammospeed="25" penalty_skill_id="16405" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17488" name="Divine Shock" nameId="290467" cooldownId="2" stack="GNPR_SPSTUNTA_ADDSUDEF_STU" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="500" ammospeed="25" penalty_skill_id="16405" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="16" target_relation="ENEMY" target_type="AREA" target_maxcount="3" effective_altitude="7" effective_range="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -134470,7 +134470,7 @@
 		</effects>
 		<motion name="chainatk1" speed="70" />
 	</skill_template>
-	<skill_template skill_id="17497" name="Magical Capture" nameId="290496" cooldownId="2" stack="GPRA_PULLEDTA_ADDSHIELD_POI" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="16409" cancel_rate="30" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17497" name="Magical Capture" nameId="290496" cooldownId="2" stack="GPRA_PULLEDTA_ADDSHIELD_POI" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="16409" cancel_rate="30" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="16" target_relation="ENEMY" target_type="AREA" target_maxcount="4" effective_altitude="5" effective_range="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -134842,7 +134842,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17524" name="Wrathful Strike" nameId="290536" cooldownId="1" stack="NPET_SATKLR_ADDSUATT" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="16399" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17524" name="Wrathful Strike" nameId="290536" cooldownId="1" stack="NPET_SATKLR_ADDSUATT" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="16399" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -134926,7 +134926,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17530" name="Endless Power" nameId="290553" cooldownId="1" stack="NWI_OPENAERIALTA_ADDREF" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" ammospeed="25" penalty_skill_id="16407" cancel_rate="30" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17530" name="Endless Power" nameId="290553" cooldownId="1" stack="NWI_OPENAERIALTA_ADDREF" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" ammospeed="25" penalty_skill_id="16407" cancel_rate="30" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="16" target_relation="ENEMY" target_type="AREA" target_maxcount="2" effective_altitude="5" effective_range="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -135254,7 +135254,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17551" name="Holy Wave" nameId="290609" cooldownId="2" stack="GNKN_KDLONGTA_ADDGUARDIAN_NC" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="500" ammospeed="25" penalty_skill_id="16394" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="20">
+	<skill_template skill_id="17551" name="Holy Wave" nameId="290609" cooldownId="2" stack="GNKN_KDLONGTA_ADDGUARDIAN_NC" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="500" ammospeed="25" penalty_skill_id="16394" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="16" target_relation="ENEMY" target_type="AREA" target_maxcount="3" effective_altitude="3" effective_range="3" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -135861,7 +135861,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17594" name="Spirit Wall of Protection II Fire" nameId="287745" stack="ORDER_ELEMENTALFIELD_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
+	<skill_template skill_id="17594" name="Spirit Wall of Protection II Fire" nameId="287745" stack="ORDER_ELEMENTALFIELD_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="FRIEND" target_type="AREA" target_maxcount="6" effective_altitude="4" effective_range="15" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -135877,7 +135877,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17595" name="Spirit Wall of Protection II Water" nameId="287747" stack="ORDER_ELEMENTALFIELD_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
+	<skill_template skill_id="17595" name="Spirit Wall of Protection II Water" nameId="287747" stack="ORDER_ELEMENTALFIELD_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="FRIEND" target_type="AREA" target_maxcount="6" effective_altitude="4" effective_range="15" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -135895,7 +135895,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17596" name="Spirit Wall of Protection II Wind" nameId="287749" stack="ORDER_ELEMENTALFIELD_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="5" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
+	<skill_template skill_id="17596" name="Spirit Wall of Protection II Wind" nameId="287749" stack="ORDER_ELEMENTALFIELD_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="FRIEND" target_type="AREA" target_maxcount="6" effective_altitude="4" effective_range="15" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -135913,7 +135913,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17597" name="Spirit Wall of Protection II Earth" nameId="287751" stack="ORDER_ELEMENTALFIELD_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="HEAL" tslot="NONE" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
+	<skill_template skill_id="17597" name="Spirit Wall of Protection II Earth" nameId="287751" stack="ORDER_ELEMENTALFIELD_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="HEAL" tslot="NONE" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="FRIEND" target_type="AREA" target_maxcount="6" effective_altitude="4" effective_range="15" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -135927,7 +135927,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17598" name="Spirit Erosion III Fire" nameId="290988" stack="ORDER_DECAYING_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17598" name="Spirit Erosion III Fire" nameId="290988" stack="ORDER_DECAYING_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -135943,7 +135943,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17599" name="Spirit Erosion III Water" nameId="290989" stack="ORDER_DECAYING_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17599" name="Spirit Erosion III Water" nameId="290989" stack="ORDER_DECAYING_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -135959,7 +135959,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17600" name="Spirit Erosion III Wind" nameId="290986" stack="ORDER_DECAYING_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17600" name="Spirit Erosion III Wind" nameId="290986" stack="ORDER_DECAYING_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -135975,7 +135975,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17601" name="Spirit Erosion III Earth" nameId="290987" stack="ORDER_DECAYING_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17601" name="Spirit Erosion III Earth" nameId="290987" stack="ORDER_DECAYING_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136159,7 +136159,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17616" name="Spirit Erosion IV Fire" nameId="290992" stack="ORDER_DECAYING_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17616" name="Spirit Erosion IV Fire" nameId="290992" stack="ORDER_DECAYING_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136175,7 +136175,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17617" name="Spirit Erosion IV Water" nameId="290993" stack="ORDER_DECAYING_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17617" name="Spirit Erosion IV Water" nameId="290993" stack="ORDER_DECAYING_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136191,7 +136191,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17618" name="Spirit Erosion IV Wind" nameId="290990" stack="ORDER_DECAYING_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17618" name="Spirit Erosion IV Wind" nameId="290990" stack="ORDER_DECAYING_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136207,7 +136207,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17619" name="Spirit Erosion IV Earth" nameId="290991" stack="ORDER_DECAYING_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17619" name="Spirit Erosion IV Earth" nameId="290991" stack="ORDER_DECAYING_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136223,7 +136223,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17620" name="Spirit Erosion I Tempest" nameId="290978" stack="ORDER_DECAYING_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17620" name="Spirit Erosion I Tempest" nameId="290978" stack="ORDER_DECAYING_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136242,7 +136242,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17621" name="Spirit Erosion I Lava" nameId="290976" stack="ORDER_DECAYING_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17621" name="Spirit Erosion I Lava" nameId="290976" stack="ORDER_DECAYING_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136261,7 +136261,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17622" name="Spirit Wall of Protection III Fire" nameId="287882" stack="ORDER_ELEMENTALFIELD_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
+	<skill_template skill_id="17622" name="Spirit Wall of Protection III Fire" nameId="287882" stack="ORDER_ELEMENTALFIELD_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="FRIEND" target_type="AREA" target_maxcount="6" effective_altitude="4" effective_range="15" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -136277,7 +136277,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17623" name="Spirit Wall of Protection III Water" nameId="287884" stack="ORDER_ELEMENTALFIELD_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
+	<skill_template skill_id="17623" name="Spirit Wall of Protection III Water" nameId="287884" stack="ORDER_ELEMENTALFIELD_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="FRIEND" target_type="AREA" target_maxcount="6" effective_altitude="4" effective_range="15" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -136313,7 +136313,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17625" name="Spirit Wall of Protection III Earth" nameId="287888" stack="ORDER_ELEMENTALFIELD_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="HEAL" tslot="NONE" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
+	<skill_template skill_id="17625" name="Spirit Wall of Protection III Earth" nameId="287888" stack="ORDER_ELEMENTALFIELD_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="HEAL" tslot="NONE" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="FRIEND" target_type="AREA" target_maxcount="6" effective_altitude="4" effective_range="15" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -136327,7 +136327,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17626" name="Spirit Wall of Protection IV Fire" nameId="287890" stack="ORDER_ELEMENTALFIELD_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
+	<skill_template skill_id="17626" name="Spirit Wall of Protection IV Fire" nameId="287890" stack="ORDER_ELEMENTALFIELD_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="FRIEND" target_type="AREA" target_maxcount="6" effective_altitude="4" effective_range="15" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -136343,7 +136343,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17627" name="Spirit Wall of Protection IV Water" nameId="287892" stack="ORDER_ELEMENTALFIELD_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
+	<skill_template skill_id="17627" name="Spirit Wall of Protection IV Water" nameId="287892" stack="ORDER_ELEMENTALFIELD_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="FRIEND" target_type="AREA" target_maxcount="6" effective_altitude="4" effective_range="15" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -136361,7 +136361,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17628" name="Spirit Wall of Protection IV Wind" nameId="287894" stack="ORDER_ELEMENTALFIELD_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
+	<skill_template skill_id="17628" name="Spirit Wall of Protection IV Wind" nameId="287894" stack="ORDER_ELEMENTALFIELD_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="FRIEND" target_type="AREA" target_maxcount="6" effective_altitude="4" effective_range="15" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -136379,7 +136379,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17629" name="Spirit Wall of Protection IV Earth" nameId="287896" stack="ORDER_ELEMENTALFIELD_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="HEAL" tslot="NONE" dispel_category="BUFF" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
+	<skill_template skill_id="17629" name="Spirit Wall of Protection IV Earth" nameId="287896" stack="ORDER_ELEMENTALFIELD_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="HEAL" tslot="NONE" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="FRIEND" target_type="AREA" target_maxcount="6" effective_altitude="4" effective_range="15" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -136393,7 +136393,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17630" name="Spirit Wall of Protection I Tempest" nameId="287898" stack="ORDER_ELEMENTALFIELD_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
+	<skill_template skill_id="17630" name="Spirit Wall of Protection I Tempest" nameId="287898" stack="ORDER_ELEMENTALFIELD_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="FRIEND" target_type="AREA" target_maxcount="6" effective_altitude="4" effective_range="15" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -136417,7 +136417,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17631" name="Spirit Wall of Protection I Lava" nameId="287900" stack="ORDER_ELEMENTALFIELD_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
+	<skill_template skill_id="17631" name="Spirit Wall of Protection I Lava" nameId="287900" stack="ORDER_ELEMENTALFIELD_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="FRIEND" target_type="AREA" target_maxcount="6" effective_altitude="4" effective_range="15" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -136433,7 +136433,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17632" name="Spirit Detonation Claw III Fire" nameId="287902" stack="ORDER_ASSAIL_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17632" name="Spirit Detonation Claw III Fire" nameId="287902" stack="ORDER_ASSAIL_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136443,7 +136443,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17633" name="Spirit Detonation Claw III Water" nameId="287903" stack="ORDER_ASSAIL_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17633" name="Spirit Detonation Claw III Water" nameId="287903" stack="ORDER_ASSAIL_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136453,7 +136453,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17634" name="Spirit Detonation Claw III Wind" nameId="287904" stack="ORDER_ASSAIL_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17634" name="Spirit Detonation Claw III Wind" nameId="287904" stack="ORDER_ASSAIL_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136463,7 +136463,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17635" name="Spirit Detonation Claw III Earth" nameId="287905" stack="ORDER_ASSAIL_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17635" name="Spirit Detonation Claw III Earth" nameId="287905" stack="ORDER_ASSAIL_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136473,7 +136473,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17636" name="Spirit Detonation Claw IV Fire" nameId="287906" stack="ORDER_ASSAIL_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17636" name="Spirit Detonation Claw IV Fire" nameId="287906" stack="ORDER_ASSAIL_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136483,7 +136483,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17637" name="Spirit Detonation Claw IV Water" nameId="287907" stack="ORDER_ASSAIL_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17637" name="Spirit Detonation Claw IV Water" nameId="287907" stack="ORDER_ASSAIL_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136493,7 +136493,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17638" name="Spirit Detonation Claw IV Wind" nameId="287908" stack="ORDER_ASSAIL_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17638" name="Spirit Detonation Claw IV Wind" nameId="287908" stack="ORDER_ASSAIL_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136513,7 +136513,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17640" name="Spirit Detonation Claw I Tempest" nameId="287910" stack="ORDER_ASSAIL_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17640" name="Spirit Detonation Claw I Tempest" nameId="287910" stack="ORDER_ASSAIL_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136523,7 +136523,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17641" name="Spirit Detonation Claw I Lava" nameId="287911" stack="ORDER_ASSAIL_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17641" name="Spirit Detonation Claw I Lava" nameId="287911" stack="ORDER_ASSAIL_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136533,7 +136533,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17642" name="Spirit Defense Position II Fire" nameId="291008" stack="EL_PET_DEFENCEPOSITION_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17642" name="Spirit Defense Position II Fire" nameId="291008" stack="EL_PET_DEFENCEPOSITION_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136546,7 +136546,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17643" name="Spirit Defense Position II Water" nameId="291009" stack="EL_PET_DEFENCEPOSITION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17643" name="Spirit Defense Position II Water" nameId="291009" stack="EL_PET_DEFENCEPOSITION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136559,7 +136559,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17644" name="Spirit Defense Position II Wind" nameId="291006" stack="EL_PET_DEFENCEPOSITION_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17644" name="Spirit Defense Position II Wind" nameId="291006" stack="EL_PET_DEFENCEPOSITION_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136575,7 +136575,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17645" name="Spirit Defense Position II Earth" nameId="291007" stack="EL_PET_DEFENCEPOSITION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17645" name="Spirit Defense Position II Earth" nameId="291007" stack="EL_PET_DEFENCEPOSITION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136614,7 +136614,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17648" name="Spirit Defense Position III Wind" nameId="291010" stack="EL_PET_DEFENCEPOSITION_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17648" name="Spirit Defense Position III Wind" nameId="291010" stack="EL_PET_DEFENCEPOSITION_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136630,7 +136630,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17649" name="Spirit Defense Position III Earth" nameId="291011" stack="EL_PET_DEFENCEPOSITION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17649" name="Spirit Defense Position III Earth" nameId="291011" stack="EL_PET_DEFENCEPOSITION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136656,7 +136656,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17651" name="Spirit Defense Position IV Water" nameId="291017" stack="EL_PET_DEFENCEPOSITION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17651" name="Spirit Defense Position IV Water" nameId="291017" stack="EL_PET_DEFENCEPOSITION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136747,7 +136747,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17658" name="Spirit Thunderbolt Claw II Wind" nameId="291024" stack="EL_PET_ELEMENTALSHOCK_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17658" name="Spirit Thunderbolt Claw II Wind" nameId="291024" stack="EL_PET_ELEMENTALSHOCK_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136789,7 +136789,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17662" name="Spirit Thunderbolt Claw III Wind" nameId="291028" stack="EL_PET_ELEMENTALSHOCK_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17662" name="Spirit Thunderbolt Claw III Wind" nameId="291028" stack="EL_PET_ELEMENTALSHOCK_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136800,7 +136800,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17663" name="Spirit Thunderbolt Claw III Earth" nameId="291029" stack="EL_PET_ELEMENTALSHOCK_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17663" name="Spirit Thunderbolt Claw III Earth" nameId="291029" stack="EL_PET_ELEMENTALSHOCK_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136821,7 +136821,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17665" name="Spirit Thunderbolt Claw IV Water" nameId="291035" stack="EL_PET_ELEMENTALSHOCK_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17665" name="Spirit Thunderbolt Claw IV Water" nameId="291035" stack="EL_PET_ELEMENTALSHOCK_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136831,7 +136831,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17666" name="Spirit Thunderbolt Claw IV Wind" nameId="291032" stack="EL_PET_ELEMENTALSHOCK_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17666" name="Spirit Thunderbolt Claw IV Wind" nameId="291032" stack="EL_PET_ELEMENTALSHOCK_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136893,7 +136893,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17672" name="Flame Resolve III" nameId="287978" stack="PEL_FIRE" lvl="3" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17672" name="Flame Resolve III" nameId="287978" stack="PEL_FIRE" lvl="3" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136903,7 +136903,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17673" name="Flame Resolve IV" nameId="287980" stack="PEL_FIRE" lvl="4" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17673" name="Flame Resolve IV" nameId="287980" stack="PEL_FIRE" lvl="4" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136953,7 +136953,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17678" name="Earth Recovery I" nameId="287986" stack="PEL_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17678" name="Earth Recovery I" nameId="287986" stack="PEL_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="AREA" target_maxcount="4" effective_altitude="10" effective_range="10" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136963,7 +136963,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17679" name="Earth Recovery II" nameId="287987" stack="PEL_EARTH" lvl="2" skilltype="MAGICAL" skillsubtype="BUFF" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17679" name="Earth Recovery II" nameId="287987" stack="PEL_EARTH" lvl="2" skilltype="MAGICAL" skillsubtype="BUFF" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="AREA" target_maxcount="4" effective_altitude="10" effective_range="10" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136973,7 +136973,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17680" name="Earth Recovery III" nameId="287988" stack="PEL_EARTH" lvl="3" skilltype="MAGICAL" skillsubtype="BUFF" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17680" name="Earth Recovery III" nameId="287988" stack="PEL_EARTH" lvl="3" skilltype="MAGICAL" skillsubtype="BUFF" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="AREA" target_maxcount="4" effective_altitude="10" effective_range="10" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -136983,7 +136983,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17681" name="Earth Recovery IV" nameId="287989" stack="PEL_EARTH" lvl="4" skilltype="MAGICAL" skillsubtype="BUFF" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="17681" name="Earth Recovery IV" nameId="287989" stack="PEL_EARTH" lvl="4" skilltype="MAGICAL" skillsubtype="BUFF" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="AREA" target_maxcount="4" effective_altitude="10" effective_range="10" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -137464,7 +137464,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="17714" name="Accurate Hit" nameId="290840" cooldownId="2" stack="NFI_SATKKDTA_MORTAL_ADDLEH" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16412" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17714" name="Accurate Hit" nameId="290840" cooldownId="2" stack="NFI_SATKKDTA_MORTAL_ADDLEH" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16412" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="3" effective_altitude="5" effective_angle="240" effective_dist="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -137506,7 +137506,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17717" name="Wonderful Magic" nameId="290867" cooldownId="2" stack="NWI_SPELLONGPARTA_MORTAL_ADDLEH" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="2500" ammospeed="25" penalty_skill_id="16412" cancel_rate="35" hostile_type="DIRECT">
+	<skill_template skill_id="17717" name="Wonderful Magic" nameId="290867" cooldownId="2" stack="NWI_SPELLONGPARTA_MORTAL_ADDLEH" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="2500" ammospeed="25" penalty_skill_id="16412" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="16" target_relation="ENEMY" target_type="AREA" target_maxcount="2" effective_altitude="5" effective_range="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -137520,7 +137520,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17718" name="Wonderful Mysterious Explosion" nameId="290858" cooldownId="2" stack="NPR_SPELLKBMORTA_ADDHEALLEH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" ammospeed="25" penalty_skill_id="16413" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17718" name="Wonderful Mysterious Explosion" nameId="290858" cooldownId="2" stack="NPR_SPELLKBMORTA_ADDHEALLEH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" ammospeed="25" penalty_skill_id="16413" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="16" target_relation="ENEMY" target_type="AREA" target_maxcount="3" effective_altitude="5" effective_range="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -137566,7 +137566,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17721" name="Strike Mind" nameId="290900" cooldownId="10" stack="NPR_MPATTLRHTA_ADDHEAL" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="2500" ammospeed="25" penalty_skill_id="16401" cancel_rate="35" hostile_type="DIRECT">
+	<skill_template skill_id="17721" name="Strike Mind" nameId="290900" cooldownId="10" stack="NPR_MPATTLRHTA_ADDHEAL" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="2500" ammospeed="25" penalty_skill_id="16401" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="16" target_relation="ENEMY" target_type="AREA" target_maxcount="8" effective_altitude="30" effective_range="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -137853,7 +137853,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="17740" name="Spirit Threat I Wind" nameId="291036" stack="EL_PET_ELEMENTALTAUNT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17740" name="Spirit Threat I Wind" nameId="291036" stack="EL_PET_ELEMENTALTAUNT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="18" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -137863,7 +137863,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17741" name="Spirit Threat II Wind" nameId="291037" stack="EL_PET_ELEMENTALTAUNT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17741" name="Spirit Threat II Wind" nameId="291037" stack="EL_PET_ELEMENTALTAUNT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="18" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -137873,7 +137873,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17742" name="Spirit Threat III Wind" nameId="291038" stack="EL_PET_ELEMENTALTAUNT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17742" name="Spirit Threat III Wind" nameId="291038" stack="EL_PET_ELEMENTALTAUNT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="18" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -137883,7 +137883,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17743" name="Spirit Threat IV Wind" nameId="291039" stack="EL_PET_ELEMENTALTAUNT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17743" name="Spirit Threat IV Wind" nameId="291039" stack="EL_PET_ELEMENTALTAUNT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="18" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -137893,7 +137893,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17744" name="Spirit Threat I Earth" nameId="291040" stack="EL_PET_ELEMENTALTAUNT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17744" name="Spirit Threat I Earth" nameId="291040" stack="EL_PET_ELEMENTALTAUNT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="18" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -137903,7 +137903,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17745" name="Spirit Threat II Earth" nameId="291041" stack="EL_PET_ELEMENTALTAUNT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17745" name="Spirit Threat II Earth" nameId="291041" stack="EL_PET_ELEMENTALTAUNT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="18" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -137913,7 +137913,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17746" name="Spirit Threat III Earth" nameId="291042" stack="EL_PET_ELEMENTALTAUNT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17746" name="Spirit Threat III Earth" nameId="291042" stack="EL_PET_ELEMENTALTAUNT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="18" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -137923,7 +137923,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17747" name="Spirit Threat IV Earth" nameId="291043" stack="EL_PET_ELEMENTALTAUNT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17747" name="Spirit Threat IV Earth" nameId="291043" stack="EL_PET_ELEMENTALTAUNT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="18" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -137933,7 +137933,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17748" name="Spirit Threat I Fire" nameId="291044" stack="EL_PET_ELEMENTALTAUNT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17748" name="Spirit Threat I Fire" nameId="291044" stack="EL_PET_ELEMENTALTAUNT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="18" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -137953,7 +137953,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17750" name="Spirit Threat III Fire" nameId="291046" stack="EL_PET_ELEMENTALTAUNT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17750" name="Spirit Threat III Fire" nameId="291046" stack="EL_PET_ELEMENTALTAUNT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="18" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -137973,7 +137973,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17752" name="Spirit Threat I Water" nameId="291048" stack="EL_PET_ELEMENTALTAUNT_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17752" name="Spirit Threat I Water" nameId="291048" stack="EL_PET_ELEMENTALTAUNT_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="18" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -137983,7 +137983,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17753" name="Spirit Threat II Water" nameId="291049" stack="EL_PET_ELEMENTALTAUNT_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17753" name="Spirit Threat II Water" nameId="291049" stack="EL_PET_ELEMENTALTAUNT_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="18" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138033,7 +138033,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17758" name="Spirit Wrath Position I Wind" nameId="291054" stack="EL_PET_ELEMENTALWRAITH_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="17758" name="Spirit Wrath Position I Wind" nameId="291054" stack="EL_PET_ELEMENTALWRAITH_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138048,7 +138048,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17759" name="Spirit Wrath Position II Wind" nameId="291056" stack="EL_PET_ELEMENTALWRAITH_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="17759" name="Spirit Wrath Position II Wind" nameId="291056" stack="EL_PET_ELEMENTALWRAITH_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138063,7 +138063,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17760" name="Spirit Wrath Position III Wind" nameId="291057" stack="EL_PET_ELEMENTALWRAITH_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="17760" name="Spirit Wrath Position III Wind" nameId="291057" stack="EL_PET_ELEMENTALWRAITH_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138078,7 +138078,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17761" name="Spirit Wrath Position IV Wind" nameId="291058" stack="EL_PET_ELEMENTALWRAITH_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="5" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="17761" name="Spirit Wrath Position IV Wind" nameId="291058" stack="EL_PET_ELEMENTALWRAITH_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138111,7 +138111,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17763" name="Spirit Wrath Position II Earth" nameId="291061" stack="EL_PET_ELEMENTALWRAITH_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="17763" name="Spirit Wrath Position II Earth" nameId="291061" stack="EL_PET_ELEMENTALWRAITH_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138129,7 +138129,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17764" name="Spirit Wrath Position III Earth" nameId="291062" stack="EL_PET_ELEMENTALWRAITH_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="17764" name="Spirit Wrath Position III Earth" nameId="291062" stack="EL_PET_ELEMENTALWRAITH_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138147,7 +138147,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17765" name="Spirit Wrath Position IV Earth" nameId="291063" stack="EL_PET_ELEMENTALWRAITH_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="5" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="17765" name="Spirit Wrath Position IV Earth" nameId="291063" stack="EL_PET_ELEMENTALWRAITH_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138165,7 +138165,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17766" name="Spirit Wrath Position I Fire" nameId="291064" stack="EL_PET_ELEMENTALWRAITH_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="17766" name="Spirit Wrath Position I Fire" nameId="291064" stack="EL_PET_ELEMENTALWRAITH_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138181,7 +138181,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17767" name="Spirit Wrath Position II Fire" nameId="291066" stack="EL_PET_ELEMENTALWRAITH_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="17767" name="Spirit Wrath Position II Fire" nameId="291066" stack="EL_PET_ELEMENTALWRAITH_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138197,7 +138197,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17768" name="Spirit Wrath Position III Fire" nameId="291067" stack="EL_PET_ELEMENTALWRAITH_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="17768" name="Spirit Wrath Position III Fire" nameId="291067" stack="EL_PET_ELEMENTALWRAITH_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138213,7 +138213,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17769" name="Spirit Wrath Position IV Fire" nameId="291068" stack="EL_PET_ELEMENTALWRAITH_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="17769" name="Spirit Wrath Position IV Fire" nameId="291068" stack="EL_PET_ELEMENTALWRAITH_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138229,7 +138229,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17770" name="Spirit Wrath Position I Water" nameId="291069" stack="EL_PET_ELEMENTALWRAITH_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="17770" name="Spirit Wrath Position I Water" nameId="291069" stack="EL_PET_ELEMENTALWRAITH_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138245,7 +138245,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17771" name="Spirit Wrath Position II Water" nameId="291071" stack="EL_PET_ELEMENTALWRAITH_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="17771" name="Spirit Wrath Position II Water" nameId="291071" stack="EL_PET_ELEMENTALWRAITH_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138261,7 +138261,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17772" name="Spirit Wrath Position III Water" nameId="291072" stack="EL_PET_ELEMENTALWRAITH_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="40" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="17772" name="Spirit Wrath Position III Water" nameId="291072" stack="EL_PET_ELEMENTALWRAITH_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138277,7 +138277,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17773" name="Spirit Wrath Position IV Water" nameId="291073" stack="EL_PET_ELEMENTALWRAITH_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="5" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="17773" name="Spirit Wrath Position IV Water" nameId="291073" stack="EL_PET_ELEMENTALWRAITH_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138293,7 +138293,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17774" name="Spirit Wrath Position I Lava" nameId="291074" stack="EL_PET_ELEMENTALWRAITH_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="5" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="17774" name="Spirit Wrath Position I Lava" nameId="291074" stack="EL_PET_ELEMENTALWRAITH_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138309,7 +138309,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17775" name="Spirit Wrath Position I Tempest" nameId="291076" stack="EL_PET_ELEMENTALWRAITH_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="17775" name="Spirit Wrath Position I Tempest" nameId="291076" stack="EL_PET_ELEMENTALWRAITH_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138324,7 +138324,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17776" name="Spirit Disturbance I Wind" nameId="291080" stack="EL_PET_INTERUPT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="STUN" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17776" name="Spirit Disturbance I Wind" nameId="291080" stack="EL_PET_INTERUPT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="STUN" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138335,7 +138335,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17777" name="Spirit Disturbance II Wind" nameId="291082" stack="EL_PET_INTERUPT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="STUN" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17777" name="Spirit Disturbance II Wind" nameId="291082" stack="EL_PET_INTERUPT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="STUN" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138346,7 +138346,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17778" name="Spirit Disturbance III Wind" nameId="291083" stack="EL_PET_INTERUPT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="STUN" req_dispel_level="5" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17778" name="Spirit Disturbance III Wind" nameId="291083" stack="EL_PET_INTERUPT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="STUN" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138357,7 +138357,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17779" name="Spirit Disturbance IV Wind" nameId="291084" stack="EL_PET_INTERUPT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="STUN" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17779" name="Spirit Disturbance IV Wind" nameId="291084" stack="EL_PET_INTERUPT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="STUN" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138368,7 +138368,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17780" name="Spirit Disturbance I Earth" nameId="291085" stack="EL_PET_INTERUPT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17780" name="Spirit Disturbance I Earth" nameId="291085" stack="EL_PET_INTERUPT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138378,7 +138378,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17781" name="Spirit Disturbance II Earth" nameId="291087" stack="EL_PET_INTERUPT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17781" name="Spirit Disturbance II Earth" nameId="291087" stack="EL_PET_INTERUPT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138398,7 +138398,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="17783" name="Spirit Disturbance III Earth" nameId="291088" stack="EL_PET_INTERUPT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="5" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17783" name="Spirit Disturbance III Earth" nameId="291088" stack="EL_PET_INTERUPT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138521,7 +138521,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17792" name="Spirit Disturbance IV Earth" nameId="291089" stack="EL_PET_INTERUPT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17792" name="Spirit Disturbance IV Earth" nameId="291089" stack="EL_PET_INTERUPT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138531,7 +138531,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17793" name="Spirit Disturbance I Fire" nameId="291090" stack="EL_PET_INTERUPT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17793" name="Spirit Disturbance I Fire" nameId="291090" stack="EL_PET_INTERUPT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138544,7 +138544,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17794" name="Spirit Disturbance II Fire" nameId="291092" stack="EL_PET_INTERUPT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17794" name="Spirit Disturbance II Fire" nameId="291092" stack="EL_PET_INTERUPT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138557,7 +138557,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17795" name="Spirit Disturbance III Fire" nameId="291093" stack="EL_PET_INTERUPT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17795" name="Spirit Disturbance III Fire" nameId="291093" stack="EL_PET_INTERUPT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138570,7 +138570,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17796" name="Spirit Disturbance IV Fire" nameId="291094" stack="EL_PET_INTERUPT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
+	<skill_template skill_id="17796" name="Spirit Disturbance IV Fire" nameId="291094" stack="EL_PET_INTERUPT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="0" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138593,7 +138593,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17798" name="Spirit Disturbance II Water" nameId="291096" stack="EL_PET_INTERUPT_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" ammospeed="25" cancel_rate="10" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17798" name="Spirit Disturbance II Water" nameId="291096" stack="EL_PET_INTERUPT_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" ammospeed="25" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138603,7 +138603,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17799" name="Spirit Disturbance III Water" nameId="291097" stack="EL_PET_INTERUPT_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" ammospeed="25" cancel_rate="10" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="17799" name="Spirit Disturbance III Water" nameId="291097" stack="EL_PET_INTERUPT_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" ammospeed="25" cancel_rate="10" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -138834,7 +138834,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17819" name="Poison Gas" nameId="291398" cooldownId="11" stack="BNAS_POISTUN20HTA_ADDHIDE_POI" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16411" hostile_type="DIRECT">
+	<skill_template skill_id="17819" name="Poison Gas" nameId="291398" cooldownId="11" stack="BNAS_POISTUN20HTA_ADDHIDE_POI" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16411" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="8" effective_altitude="20" effective_angle="120" effective_dist="20" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -138850,7 +138850,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17820" name="Virulent Infection" nameId="291401" cooldownId="11" stack="BNAS_PRVPOISONGAS_NR" lvl="1" skilltype="PHYSICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="17811" hostile_type="INDIRECT">
+	<skill_template skill_id="17820" name="Virulent Infection" nameId="291401" cooldownId="11" stack="BNAS_PRVPOISONGAS_NR" lvl="1" skilltype="PHYSICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="17811" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -139149,7 +139149,7 @@
 		</effects>
 		<motion name="pointfire" delay="200" />
 	</skill_template>
-	<skill_template skill_id="17838" name="Lunacy Explosion" nameId="291465" cooldownId="2" stack="BNFI_SPELLKDTA35_ASSSHIELD" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="16415" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="20">
+	<skill_template skill_id="17838" name="Lunacy Explosion" nameId="291465" cooldownId="2" stack="BNFI_SPELLKDTA35_ASSSHIELD" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="16415" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="72" effective_altitude="27" effective_range="27" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -139227,7 +139227,7 @@
 		</effects>
 		<motion name="chainatk1" speed="70" />
 	</skill_template>
-	<skill_template skill_id="17843" name="Wrath Explosion" nameId="291477" cooldownId="2" stack="GNFI_KDTA15_ADDSHIELD" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="16409" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17843" name="Wrath Explosion" nameId="291477" cooldownId="2" stack="GNFI_KDTA15_ADDSHIELD" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="16409" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="4" effective_altitude="15" effective_range="15" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -139245,7 +139245,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="17844" name="Head Wound" nameId="291479" cooldownId="5" stack="GNFI_NOSKILL_ADDSHIELD_STONE_LC" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="1000" ammospeed="25" penalty_skill_id="16409" hostile_type="DIRECT">
+	<skill_template skill_id="17844" name="Head Wound" nameId="291479" cooldownId="5" stack="GNFI_NOSKILL_ADDSHIELD_STONE_LC" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="1000" ammospeed="25" penalty_skill_id="16409" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="16" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -139510,7 +139510,7 @@
 		</effects>
 		<motion name="pointfire" speed="70" />
 	</skill_template>
-	<skill_template skill_id="17861" name="Sleep of Death" nameId="291530" cooldownId="12" stack="BNEL_MPATTSLEEPTA40_ADDREFLECT60" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="3000" ammospeed="25" penalty_skill_id="17857" hostile_type="DIRECT">
+	<skill_template skill_id="17861" name="Sleep of Death" nameId="291530" cooldownId="12" stack="BNEL_MPATTSLEEPTA40_ADDREFLECT60" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="3000" ammospeed="25" penalty_skill_id="17857" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="37" target_relation="ENEMY" target_type="AREA" target_maxcount="24" effective_altitude="27" effective_range="27" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -139636,7 +139636,7 @@
 		</effects>
 		<motion name="stuckatk" />
 	</skill_template>
-	<skill_template skill_id="17870" name="Stun Strike" nameId="291722" cooldownId="12" stack="BNKN_STUNATKTA30_ADDSHIELD_NO" lvl="1" skilltype="PHYSICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="17864" cancel_rate="40" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="20">
+	<skill_template skill_id="17870" name="Stun Strike" nameId="291722" cooldownId="12" stack="BNKN_STUNATKTA30_ADDSHIELD_NO" lvl="1" skilltype="PHYSICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="17864" cancel_rate="40" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="24" effective_altitude="27" effective_range="27" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -139650,7 +139650,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="17871" name="Battle Cry" nameId="291710" cooldownId="2" stack="BNKN_SATKKD30_ADDPHYATT_AREA" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="16399" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17871" name="Battle Cry" nameId="291710" cooldownId="2" stack="BNKN_SATKKD30_ADDPHYATT_AREA" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="16399" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="24" effective_altitude="27" effective_range="27" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -140032,7 +140032,7 @@
 		</effects>
 		<motion name="poweratk" speed="70" />
 	</skill_template>
-	<skill_template skill_id="17897" name="Endless Power" nameId="291758" cooldownId="12" stack="GNFI_PARABOLTTA30_ADDSUPHYATT" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="16399" cancel_rate="40" hostile_type="DIRECT">
+	<skill_template skill_id="17897" name="Endless Power" nameId="291758" cooldownId="12" stack="GNFI_PARABOLTTA30_ADDSUPHYATT" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="16399" cancel_rate="40" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="2" effective_altitude="27" effective_range="27" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -140251,7 +140251,7 @@
 		</effects>
 		<motion name="poweratk" speed="70" />
 	</skill_template>
-	<skill_template skill_id="17912" name="Toxic Rune" nameId="291666" cooldownId="17" stack="BNAS_SIGBURSTCONTA40C2_NO_ADDSUATT1" lvl="1" skilltype="PHYSICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="17866" cancel_rate="35" hostile_type="DIRECT">
+	<skill_template skill_id="17912" name="Toxic Rune" nameId="291666" cooldownId="17" stack="BNAS_SIGBURSTCONTA40C2_NO_ADDSUATT1" lvl="1" skilltype="PHYSICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="17866" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="2" effective_altitude="27" effective_range="27" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -140266,7 +140266,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="17913" name="Pain Rune" nameId="291668" cooldownId="17" stack="BNAS_SIGNETBURSTTA40_NO_ADDSUAT" lvl="2" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="17867" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17913" name="Pain Rune" nameId="291668" cooldownId="17" stack="BNAS_SIGNETBURSTTA40_NO_ADDSUAT" lvl="2" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="17867" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="24" effective_altitude="27" effective_range="27" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -140880,7 +140880,7 @@
 		</effects>
 		<motion name="poweratk" speed="70" />
 	</skill_template>
-	<skill_template skill_id="17955" name="Wound Explosion" nameId="291832" cooldownId="17" stack="BNAS_SIGNETBURTA40_ADDSUCRI" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="17929" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17955" name="Wound Explosion" nameId="291832" cooldownId="17" stack="BNAS_SIGNETBURTA40_ADDSUCRI" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="17929" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="24" effective_altitude="27" effective_range="27" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -140981,7 +140981,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17962" name="Holy Wave" nameId="290433" cooldownId="2" stack="GNKN_KDLONG_ADDGUARDIAN" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" ammospeed="35" penalty_skill_id="16394" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="20">
+	<skill_template skill_id="17962" name="Holy Wave" nameId="290433" cooldownId="2" stack="GNKN_KDLONG_ADDGUARDIAN" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" ammospeed="35" penalty_skill_id="16394" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="16" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="3" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -140996,7 +140996,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="17963" name="Deadly Chain of Blessing" nameId="292437" cooldownId="12" stack="BNFI_RSNARETA20M15S_ASSSHIELD" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="16409" cancel_rate="50" hostile_type="DIRECT">
+	<skill_template skill_id="17963" name="Deadly Chain of Blessing" nameId="292437" cooldownId="12" stack="BNFI_RSNARETA20M15S_ASSSHIELD" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="16409" cancel_rate="50" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="24" effective_altitude="20" effective_range="20" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -141024,7 +141024,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="17965" name="Protective Wave" nameId="292454" cooldownId="2" stack="BNKN_SATKKDTA30_ADDSHIELD_NO" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="16409" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="17965" name="Protective Wave" nameId="292454" cooldownId="2" stack="BNKN_SATKKDTA30_ADDSHIELD_NO" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="16409" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="3" effective_altitude="27" effective_range="27" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -141285,7 +141285,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="17983" name="Hindering for Defense" nameId="292462" cooldownId="8" stack="BNRA_SNARETA7S5_ADDSUPPMDEF" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="2500" ammospeed="35" penalty_skill_id="17982" cancel_rate="35" hostile_type="DIRECT">
+	<skill_template skill_id="17983" name="Hindering for Defense" nameId="292462" cooldownId="8" stack="BNRA_SNARETA7S5_ADDSUPPMDEF" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="2500" ammospeed="35" penalty_skill_id="17982" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="20" target_relation="ENEMY" target_type="AREA" target_maxcount="4" effective_altitude="5" effective_range="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -142066,7 +142066,7 @@
 		</effects>
 		<motion name="chainatk1" />
 	</skill_template>
-	<skill_template skill_id="18032" name="Soul Torrent" nameId="292411" cooldownId="12" stack="BNEL_PARMPATTTA3_ADDREFLECT60" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="3000" ammospeed="35" penalty_skill_id="17857" cancel_rate="30" hostile_type="DIRECT">
+	<skill_template skill_id="18032" name="Soul Torrent" nameId="292411" cooldownId="12" stack="BNEL_PARMPATTTA3_ADDREFLECT60" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="3000" ammospeed="35" penalty_skill_id="17857" cancel_rate="30" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="37" target_relation="ENEMY" target_type="AREA" target_maxcount="8" effective_altitude="3" effective_range="3" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -142159,7 +142159,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="18038" name="Spirit Burn-to-Ashes I Wind" nameId="293041" stack="EL_ORDER_ETHERERUPTION_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="20">
+	<skill_template skill_id="18038" name="Spirit Burn-to-Ashes I Wind" nameId="293041" stack="EL_ORDER_ETHERERUPTION_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142243,7 +142243,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18042" name="Spirit Burn-to-Ashes I Fire" nameId="293046" stack="EL_ORDER_ETHERERUPTION_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18042" name="Spirit Burn-to-Ashes I Fire" nameId="293046" stack="EL_ORDER_ETHERERUPTION_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142285,7 +142285,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18044" name="Spirit Burn-to-Ashes III Fire" nameId="293049" stack="EL_ORDER_ETHERERUPTION_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="18044" name="Spirit Burn-to-Ashes III Fire" nameId="293049" stack="EL_ORDER_ETHERERUPTION_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142327,7 +142327,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18046" name="Spirit Burn-to-Ashes I Earth" nameId="293051" stack="EL_ORDER_ETHERERUPTION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="18046" name="Spirit Burn-to-Ashes I Earth" nameId="293051" stack="EL_ORDER_ETHERERUPTION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142348,7 +142348,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18047" name="Spirit Burn-to-Ashes II Earth" nameId="293053" stack="EL_ORDER_ETHERERUPTION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="18047" name="Spirit Burn-to-Ashes II Earth" nameId="293053" stack="EL_ORDER_ETHERERUPTION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142390,7 +142390,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18049" name="Spirit Burn-to-Ashes IV Earth" nameId="293055" stack="EL_ORDER_ETHERERUPTION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="20">
+	<skill_template skill_id="18049" name="Spirit Burn-to-Ashes IV Earth" nameId="293055" stack="EL_ORDER_ETHERERUPTION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142453,7 +142453,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18052" name="Spirit Burn-to-Ashes III Water" nameId="293059" stack="EL_ORDER_ETHERERUPTION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="18052" name="Spirit Burn-to-Ashes III Water" nameId="293059" stack="EL_ORDER_ETHERERUPTION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142474,7 +142474,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18053" name="Spirit Burn-to-Ashes I Lava" nameId="293060" stack="EL_ORDER_ETHERERUPTION_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="18053" name="Spirit Burn-to-Ashes I Lava" nameId="293060" stack="EL_ORDER_ETHERERUPTION_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142495,7 +142495,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18054" name="Spirit Burn-to-Ashes I Tempest" nameId="293062" stack="EL_ORDER_ETHERERUPTION_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="18054" name="Spirit Burn-to-Ashes I Tempest" nameId="293062" stack="EL_ORDER_ETHERERUPTION_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142558,7 +142558,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18057" name="Spirit Explosion III Wind" nameId="293067" stack="EL_ORDER_SHADOWERUPTION_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18057" name="Spirit Explosion III Wind" nameId="293067" stack="EL_ORDER_SHADOWERUPTION_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142642,7 +142642,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18061" name="Spirit Explosion III Fire" nameId="293072" stack="EL_ORDER_SHADOWERUPTION_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18061" name="Spirit Explosion III Fire" nameId="293072" stack="EL_ORDER_SHADOWERUPTION_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142684,7 +142684,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18063" name="Element Storm I Earth" nameId="293074" stack="EL_ORDER_SHADOWERUPTION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18063" name="Element Storm I Earth" nameId="293074" stack="EL_ORDER_SHADOWERUPTION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142747,7 +142747,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18066" name="Element Storm IV Earth" nameId="293078" stack="EL_ORDER_SHADOWERUPTION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18066" name="Element Storm IV Earth" nameId="293078" stack="EL_ORDER_SHADOWERUPTION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142768,7 +142768,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18067" name="Element Storm I Water" nameId="293079" stack="EL_ORDER_SHADOWERUPTION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18067" name="Element Storm I Water" nameId="293079" stack="EL_ORDER_SHADOWERUPTION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142789,7 +142789,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18068" name="Element Storm II Water" nameId="293081" stack="EL_ORDER_SHADOWERUPTION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18068" name="Element Storm II Water" nameId="293081" stack="EL_ORDER_SHADOWERUPTION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142810,7 +142810,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18069" name="Element Storm III Water" nameId="293082" stack="EL_ORDER_SHADOWERUPTION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18069" name="Element Storm III Water" nameId="293082" stack="EL_ORDER_SHADOWERUPTION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142831,7 +142831,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18070" name="Spirit Explosion I Lava" nameId="293083" stack="EL_ORDER_SHADOWERUPTION_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18070" name="Spirit Explosion I Lava" nameId="293083" stack="EL_ORDER_SHADOWERUPTION_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142852,7 +142852,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18071" name="Spirit Explosion I Tempest" nameId="293085" stack="EL_ORDER_SHADOWERUPTION_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="3">
+	<skill_template skill_id="18071" name="Spirit Explosion I Tempest" nameId="293085" stack="EL_ORDER_SHADOWERUPTION_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142873,7 +142873,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18072" name="Spirit Wind Flow I" nameId="293300" stack="EL_STIGMA_ORDER_ETHEREMISSION_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="3">
+	<skill_template skill_id="18072" name="Spirit Wind Flow I" nameId="293300" stack="EL_STIGMA_ORDER_ETHEREMISSION_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142894,7 +142894,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18073" name="Spirit Wind Flow II" nameId="293301" stack="EL_STIGMA_ORDER_ETHEREMISSION_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="3">
+	<skill_template skill_id="18073" name="Spirit Wind Flow II" nameId="293301" stack="EL_STIGMA_ORDER_ETHEREMISSION_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142915,7 +142915,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18074" name="Spirit Wind Flow III" nameId="293302" stack="EL_STIGMA_ORDER_ETHEREMISSION_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="3">
+	<skill_template skill_id="18074" name="Spirit Wind Flow III" nameId="293302" stack="EL_STIGMA_ORDER_ETHEREMISSION_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142936,7 +142936,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18075" name="Spirit Wind Flow IV" nameId="293303" stack="EL_STIGMA_ORDER_ETHEREMISSION_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="18075" name="Spirit Wind Flow IV" nameId="293303" stack="EL_STIGMA_ORDER_ETHEREMISSION_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -142957,7 +142957,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18076" name="Spirit Fire Flow I" nameId="293304" stack="EL_STIGMA_ORDER_ETHEREMISSION_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="20">
+	<skill_template skill_id="18076" name="Spirit Fire Flow I" nameId="293304" stack="EL_STIGMA_ORDER_ETHEREMISSION_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143041,7 +143041,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18080" name="Spirit Earth Flow I" nameId="293308" stack="EL_STIGMA_ORDER_ETHEREMISSION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="18080" name="Spirit Earth Flow I" nameId="293308" stack="EL_STIGMA_ORDER_ETHEREMISSION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143062,7 +143062,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18081" name="Spirit Earth Flow II" nameId="293309" stack="EL_STIGMA_ORDER_ETHEREMISSION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="18081" name="Spirit Earth Flow II" nameId="293309" stack="EL_STIGMA_ORDER_ETHEREMISSION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143083,7 +143083,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18082" name="Spirit Earth Flow III" nameId="293310" stack="EL_STIGMA_ORDER_ETHEREMISSION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="20">
+	<skill_template skill_id="18082" name="Spirit Earth Flow III" nameId="293310" stack="EL_STIGMA_ORDER_ETHEREMISSION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143104,7 +143104,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18083" name="Spirit Earth Flow IV" nameId="293311" stack="EL_STIGMA_ORDER_ETHEREMISSION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="20">
+	<skill_template skill_id="18083" name="Spirit Earth Flow IV" nameId="293311" stack="EL_STIGMA_ORDER_ETHEREMISSION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143125,7 +143125,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18084" name="Spirit Water Flow I" nameId="293312" stack="EL_STIGMA_ORDER_ETHEREMISSION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18084" name="Spirit Water Flow I" nameId="293312" stack="EL_STIGMA_ORDER_ETHEREMISSION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143146,7 +143146,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18085" name="Spirit Water Flow II" nameId="293313" stack="EL_STIGMA_ORDER_ETHEREMISSION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18085" name="Spirit Water Flow II" nameId="293313" stack="EL_STIGMA_ORDER_ETHEREMISSION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143167,7 +143167,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18086" name="Spirit Water Flow III" nameId="293314" stack="EL_STIGMA_ORDER_ETHEREMISSION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18086" name="Spirit Water Flow III" nameId="293314" stack="EL_STIGMA_ORDER_ETHEREMISSION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143188,7 +143188,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18087" name="Spirit Lava Flow I" nameId="293315" stack="EL_STIGMA_ORDER_ETHEREMISSION_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18087" name="Spirit Lava Flow I" nameId="293315" stack="EL_STIGMA_ORDER_ETHEREMISSION_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143209,7 +143209,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18088" name="Spirit Tempest Flow I" nameId="293316" stack="EL_STIGMA_ORDER_ETHEREMISSION_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18088" name="Spirit Tempest Flow I" nameId="293316" stack="EL_STIGMA_ORDER_ETHEREMISSION_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143293,7 +143293,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18092" name="Spirit Wind Impact IV" nameId="293320" stack="EL_STIGMA_ORDER_ETHERIMPACT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="18092" name="Spirit Wind Impact IV" nameId="293320" stack="EL_STIGMA_ORDER_ETHERIMPACT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143314,7 +143314,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18093" name="Spirit Fire Impact I" nameId="293321" stack="EL_STIGMA_ORDER_ETHERIMPACT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="18093" name="Spirit Fire Impact I" nameId="293321" stack="EL_STIGMA_ORDER_ETHERIMPACT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143335,7 +143335,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18094" name="Spirit Fire Impact II" nameId="293322" stack="EL_STIGMA_ORDER_ETHERIMPACT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18094" name="Spirit Fire Impact II" nameId="293322" stack="EL_STIGMA_ORDER_ETHERIMPACT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143398,7 +143398,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18097" name="Spirit Self Destruct I Earth" nameId="293325" stack="EL_STIGMA_ORDER_ETHERIMPACT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18097" name="Spirit Self Destruct I Earth" nameId="293325" stack="EL_STIGMA_ORDER_ETHERIMPACT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143440,7 +143440,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18099" name="Spirit Earth Impact III" nameId="293327" stack="EL_STIGMA_ORDER_ETHERIMPACT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18099" name="Spirit Earth Impact III" nameId="293327" stack="EL_STIGMA_ORDER_ETHERIMPACT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143482,7 +143482,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18101" name="Spirit Water Impact I" nameId="293329" stack="EL_STIGMA_ORDER_ETHERIMPACT_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18101" name="Spirit Water Impact I" nameId="293329" stack="EL_STIGMA_ORDER_ETHERIMPACT_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143524,7 +143524,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18103" name="Spirit Water Impact III" nameId="293331" stack="EL_STIGMA_ORDER_ETHERIMPACT_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18103" name="Spirit Water Impact III" nameId="293331" stack="EL_STIGMA_ORDER_ETHERIMPACT_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143545,7 +143545,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18104" name="Spirit Self Destruct I Lava" nameId="293332" stack="EL_STIGMA_ORDER_ETHERIMPACT_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18104" name="Spirit Self Destruct I Lava" nameId="293332" stack="EL_STIGMA_ORDER_ETHERIMPACT_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -143566,7 +143566,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18105" name="Spirit Tempest Impact I" nameId="293333" stack="EL_STIGMA_ORDER_ETHERIMPACT_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18105" name="Spirit Tempest Impact I" nameId="293333" stack="EL_STIGMA_ORDER_ETHERIMPACT_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -144467,7 +144467,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="18165" name="Create Protective Shield" nameId="293775" cooldownId="1" stack="NFI_SPELLATKNTA5_ADDSHIELD_NO" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16409" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18165" name="Create Protective Shield" nameId="293775" cooldownId="1" stack="NFI_SPELLATKNTA5_ADDSHIELD_NO" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16409" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="8" effective_altitude="5" effective_range="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -145474,7 +145474,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="18232" name="Explosion of Wrath" nameId="294016" cooldownId="4" stack="BNWI_SPELLPFEARTA10_ADDSHI_NO" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="18214" hostile_type="DIRECT">
+	<skill_template skill_id="18232" name="Explosion of Wrath" nameId="294016" cooldownId="4" stack="BNWI_SPELLPFEARTA10_ADDSHI_NO" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="18214" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="25" target_relation="ENEMY" target_type="AREA" target_maxcount="7" effective_altitude="7" effective_range="7" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -145492,7 +145492,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="18233" name="Rise, my faithful servant." nameId="294008" cooldownId="2" stack="BNWI_SPELLATKKLRKDTA15_SU" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="16471" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18233" name="Rise, my faithful servant." nameId="294008" cooldownId="2" stack="BNWI_SPELLATKKLRKDTA15_SU" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="16471" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="25" target_relation="ENEMY" target_type="AREA" target_maxcount="7" effective_altitude="10" effective_range="10" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -145520,7 +145520,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18235" name="Crippling Wave of Protection" nameId="294045" cooldownId="1" stack="NKN_SPELLATKTA15_ADDGUARDIAN" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="16931" cancel_rate="30" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="20">
+	<skill_template skill_id="18235" name="Crippling Wave of Protection" nameId="294045" cooldownId="1" stack="NKN_SPELLATKTA15_ADDGUARDIAN" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="16931" cancel_rate="30" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="7" effective_altitude="10" effective_range="10" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -145533,7 +145533,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="18236" name="Eruption of Power" nameId="294012" cooldownId="1" stack="BNWI_SPELLATKTA10_ADDREF_NO" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="18213" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18236" name="Eruption of Power" nameId="294012" cooldownId="1" stack="BNWI_SPELLATKTA10_ADDREF_NO" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="18213" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="25" target_relation="ENEMY" target_type="AREA" target_maxcount="7" effective_altitude="7" effective_range="7" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -145901,7 +145901,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="18262" name="Spirit Substitution I Wind" nameId="292335" stack="EL_ORDER_SACRIFICE_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18262" name="Spirit Substitution I Wind" nameId="292335" stack="EL_ORDER_SACRIFICE_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -145911,7 +145911,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18263" name="Spirit Substitution II Wind" nameId="292337" stack="EL_ORDER_SACRIFICE_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18263" name="Spirit Substitution II Wind" nameId="292337" stack="EL_ORDER_SACRIFICE_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -145921,7 +145921,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18264" name="Spirit Substitution III Wind" nameId="292338" stack="EL_ORDER_SACRIFICE_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18264" name="Spirit Substitution III Wind" nameId="292338" stack="EL_ORDER_SACRIFICE_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -145931,7 +145931,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18265" name="Spirit Substitution IV Wind" nameId="292339" stack="EL_ORDER_SACRIFICE_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18265" name="Spirit Substitution IV Wind" nameId="292339" stack="EL_ORDER_SACRIFICE_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -145941,7 +145941,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18266" name="Spirit Substitution I Fire" nameId="292340" stack="EL_ORDER_SACRIFICE_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18266" name="Spirit Substitution I Fire" nameId="292340" stack="EL_ORDER_SACRIFICE_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -145951,7 +145951,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18267" name="Spirit Substitution II Fire" nameId="292341" stack="EL_ORDER_SACRIFICE_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18267" name="Spirit Substitution II Fire" nameId="292341" stack="EL_ORDER_SACRIFICE_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -145961,7 +145961,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18268" name="Spirit Substitution III Fire" nameId="292342" stack="EL_ORDER_SACRIFICE_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18268" name="Spirit Substitution III Fire" nameId="292342" stack="EL_ORDER_SACRIFICE_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -145971,7 +145971,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18269" name="Spirit Substitution IV Fire" nameId="292343" stack="EL_ORDER_SACRIFICE_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18269" name="Spirit Substitution IV Fire" nameId="292343" stack="EL_ORDER_SACRIFICE_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -145981,7 +145981,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18270" name="Spirit Substitution I Earth" nameId="292344" stack="EL_ORDER_SACRIFICE_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18270" name="Spirit Substitution I Earth" nameId="292344" stack="EL_ORDER_SACRIFICE_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -145991,7 +145991,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18271" name="Spirit Substitution II Earth" nameId="292345" stack="EL_ORDER_SACRIFICE_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18271" name="Spirit Substitution II Earth" nameId="292345" stack="EL_ORDER_SACRIFICE_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146001,7 +146001,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18272" name="Spirit Substitution III Earth" nameId="292346" stack="EL_ORDER_SACRIFICE_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18272" name="Spirit Substitution III Earth" nameId="292346" stack="EL_ORDER_SACRIFICE_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146011,7 +146011,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18273" name="Spirit Substitution IV Earth" nameId="292347" stack="EL_ORDER_SACRIFICE_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18273" name="Spirit Substitution IV Earth" nameId="292347" stack="EL_ORDER_SACRIFICE_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146021,7 +146021,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18274" name="Spirit Substitution I Water" nameId="292348" stack="EL_ORDER_SACRIFICE_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="20" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18274" name="Spirit Substitution I Water" nameId="292348" stack="EL_ORDER_SACRIFICE_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146031,7 +146031,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18275" name="Spirit Substitution II Water" nameId="292349" stack="EL_ORDER_SACRIFICE_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18275" name="Spirit Substitution II Water" nameId="292349" stack="EL_ORDER_SACRIFICE_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146041,7 +146041,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18276" name="Spirit Substitution III Water" nameId="292350" stack="EL_ORDER_SACRIFICE_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18276" name="Spirit Substitution III Water" nameId="292350" stack="EL_ORDER_SACRIFICE_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146051,7 +146051,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18277" name="Spirit Substitution I Lava" nameId="292351" stack="EL_ORDER_SACRIFICE_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18277" name="Spirit Substitution I Lava" nameId="292351" stack="EL_ORDER_SACRIFICE_MAGMA" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146061,7 +146061,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18278" name="Spirit Substitution I Tempest" nameId="292352" stack="EL_ORDER_SACRIFICE_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="5" req_dispel_count="100" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18278" name="Spirit Substitution I Tempest" nameId="292352" stack="EL_ORDER_SACRIFICE_TEMPEST" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146176,7 +146176,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18284" name="Spirit Fire Flow II" nameId="292358" stack="EL_ORDER_ETHEREMISSION_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="18284" name="Spirit Fire Flow II" nameId="292358" stack="EL_ORDER_ETHEREMISSION_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146218,7 +146218,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18286" name="Spirit Fire Flow IV" nameId="292360" stack="EL_ORDER_ETHEREMISSION_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18286" name="Spirit Fire Flow IV" nameId="292360" stack="EL_ORDER_ETHEREMISSION_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146239,7 +146239,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18287" name="Spirit Earth Flow I" nameId="292361" stack="EL_ORDER_ETHEREMISSION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18287" name="Spirit Earth Flow I" nameId="292361" stack="EL_ORDER_ETHEREMISSION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146260,7 +146260,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18288" name="Spirit Earth Flow II" nameId="292362" stack="EL_ORDER_ETHEREMISSION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="18288" name="Spirit Earth Flow II" nameId="292362" stack="EL_ORDER_ETHEREMISSION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146281,7 +146281,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18289" name="Spirit Earth Flow III" nameId="292363" stack="EL_ORDER_ETHEREMISSION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="3" req_dispel_count="50">
+	<skill_template skill_id="18289" name="Spirit Earth Flow III" nameId="292363" stack="EL_ORDER_ETHEREMISSION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146302,7 +146302,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18290" name="Spirit Earth Flow IV" nameId="292364" stack="EL_ORDER_ETHEREMISSION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18290" name="Spirit Earth Flow IV" nameId="292364" stack="EL_ORDER_ETHEREMISSION_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146323,7 +146323,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18291" name="Spirit Water Flow I" nameId="292365" stack="EL_ORDER_ETHEREMISSION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18291" name="Spirit Water Flow I" nameId="292365" stack="EL_ORDER_ETHEREMISSION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146344,7 +146344,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18292" name="Spirit Water Flow II" nameId="292366" stack="EL_ORDER_ETHEREMISSION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18292" name="Spirit Water Flow II" nameId="292366" stack="EL_ORDER_ETHEREMISSION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146365,7 +146365,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18293" name="Spirit Water Flow III" nameId="292367" stack="EL_ORDER_ETHEREMISSION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18293" name="Spirit Water Flow III" nameId="292367" stack="EL_ORDER_ETHEREMISSION_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146428,7 +146428,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18296" name="Spirit Wind Impact I" nameId="292370" stack="EL_ORDER_ETHERIMPACT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18296" name="Spirit Wind Impact I" nameId="292370" stack="EL_ORDER_ETHERIMPACT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146470,7 +146470,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18298" name="Spirit Wind Impact III" nameId="292372" stack="EL_ORDER_ETHERIMPACT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="18298" name="Spirit Wind Impact III" nameId="292372" stack="EL_ORDER_ETHERIMPACT_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146512,7 +146512,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18300" name="Spirit Fire Impact I" nameId="292374" stack="EL_ORDER_ETHERIMPACT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18300" name="Spirit Fire Impact I" nameId="292374" stack="EL_ORDER_ETHERIMPACT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146533,7 +146533,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18301" name="Spirit Fire Impact II" nameId="292375" stack="EL_ORDER_ETHERIMPACT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18301" name="Spirit Fire Impact II" nameId="292375" stack="EL_ORDER_ETHERIMPACT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146554,7 +146554,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18302" name="Spirit Fire Impact III" nameId="292376" stack="EL_ORDER_ETHERIMPACT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18302" name="Spirit Fire Impact III" nameId="292376" stack="EL_ORDER_ETHERIMPACT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146575,7 +146575,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18303" name="Spirit Fire Impact IV" nameId="292377" stack="EL_ORDER_ETHERIMPACT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18303" name="Spirit Fire Impact IV" nameId="292377" stack="EL_ORDER_ETHERIMPACT_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146659,7 +146659,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18307" name="Spirit Earth Impact IV" nameId="292381" stack="EL_ORDER_ETHERIMPACT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="18307" name="Spirit Earth Impact IV" nameId="292381" stack="EL_ORDER_ETHERIMPACT_EARTH" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146701,7 +146701,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18309" name="Spirit Water Impact II" nameId="292383" stack="EL_ORDER_ETHERIMPACT_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="18309" name="Spirit Water Impact II" nameId="292383" stack="EL_ORDER_ETHERIMPACT_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -146722,7 +146722,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18310" name="Spirit Water Impact III" nameId="292384" stack="EL_ORDER_ETHERIMPACT_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="18310" name="Spirit Water Impact III" nameId="292384" stack="EL_ORDER_ETHERIMPACT_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="7" effective_range="15" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -147405,7 +147405,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="18364" name="Holy Wave" nameId="292682" cooldownId="2" stack="GNKN_KDHTA_ADDGUARDIAN_NC" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="16394" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="20">
+	<skill_template skill_id="18364" name="Holy Wave" nameId="292682" cooldownId="2" stack="GNKN_KDHTA_ADDGUARDIAN_NC" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="16394" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="2" effective_altitude="7" effective_angle="120" effective_dist="7" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -147547,7 +147547,7 @@
 		</effects>
 		<motion name="alterfire" speed="70" />
 	</skill_template>
-	<skill_template skill_id="18375" name="Shock of Wrath" nameId="292797" cooldownId="2" stack="GNPR_SPSTUNTA_ADDSUATT_STU" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="500" ammospeed="25" penalty_skill_id="16399" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18375" name="Shock of Wrath" nameId="292797" cooldownId="2" stack="GNPR_SPSTUNTA_ADDSUATT_STU" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="500" ammospeed="25" penalty_skill_id="16399" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="16" target_relation="ENEMY" target_type="AREA" target_maxcount="3" effective_altitude="7" effective_range="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -147737,7 +147737,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="18388" name="Atrocity" nameId="292809" cooldownId="2" stack="BNAS_MORTALNOFLYKBC10TA20_SHIELD10S_NO" lvl="1" skilltype="PHYSICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="5000" penalty_skill_id="18381" hostile_type="DIRECT">
+	<skill_template skill_id="18388" name="Atrocity" nameId="292809" cooldownId="2" stack="BNAS_MORTALNOFLYKBC10TA20_SHIELD10S_NO" lvl="1" skilltype="PHYSICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="5000" penalty_skill_id="18381" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="10" effective_altitude="7" effective_range="7" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -147756,7 +147756,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="18389" name="Fire Wave" nameId="292842" cooldownId="11" stack="BNFI_SPELLDOTWEAKTA10_ADDREFLECT20S_MU" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="18380" hostile_type="DIRECT">
+	<skill_template skill_id="18389" name="Fire Wave" nameId="292842" cooldownId="11" stack="BNFI_SPELLDOTWEAKTA10_ADDREFLECT20S_MU" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="18380" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="12" effective_altitude="10" effective_range="10" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -147770,7 +147770,7 @@
 		</effects>
 		<motion name="multiatk" />
 	</skill_template>
-	<skill_template skill_id="18390" name="Powerful Fire Wave" nameId="292839" cooldownId="11" stack="BNFI_SPELLDOTSTRONGTA20_ADDREFLECT20S_MU" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="18380" hostile_type="DIRECT">
+	<skill_template skill_id="18390" name="Powerful Fire Wave" nameId="292839" cooldownId="11" stack="BNFI_SPELLDOTSTRONGTA20_ADDREFLECT20S_MU" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="18380" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="12" effective_altitude="20" effective_range="20" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -148444,7 +148444,7 @@
 		</effects>
 		<motion name="phbuff" />
 	</skill_template>
-	<skill_template skill_id="18435" name="Powerful Crippling Wave" nameId="293142" cooldownId="12" stack="CHF_SATKMNOFTA35_ADSHI_PHB" lvl="1" skilltype="PHYSICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="18431" hostile_type="DIRECT">
+	<skill_template skill_id="18435" name="Powerful Crippling Wave" nameId="293142" cooldownId="12" stack="CHF_SATKMNOFTA35_ADSHI_PHB" lvl="1" skilltype="PHYSICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="30" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="18431" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="40" target_relation="ENEMY" target_type="AREA" target_maxcount="96" effective_altitude="35" effective_range="35" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -148497,7 +148497,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="18439" name="Flame Bind" nameId="293168" cooldownId="12" stack="CHF_SPELLNOFSNADOTTA35_ADSUATT_PHB" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="18432" hostile_type="DIRECT">
+	<skill_template skill_id="18439" name="Flame Bind" nameId="293168" cooldownId="12" stack="CHF_SPELLNOFSNADOTTA35_ADSUATT_PHB" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="30" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="18432" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="40" target_relation="ENEMY" target_type="AREA" target_maxcount="96" effective_altitude="35" effective_range="35" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -148531,7 +148531,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="18441" name="Lunatic Silence" nameId="293165" cooldownId="12" stack="CHF_SPELLNOFSLI30TA35_ADSUATT_PHB" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="18432" hostile_type="DIRECT">
+	<skill_template skill_id="18441" name="Lunatic Silence" nameId="293165" cooldownId="12" stack="CHF_SPELLNOFSLI30TA35_ADSUATT_PHB" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="30" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="18432" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="40" target_relation="ENEMY" target_type="AREA" target_maxcount="96" effective_altitude="30" effective_range="30" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -148557,7 +148557,7 @@
 		</effects>
 		<motion name="pointfire" speed="75" delay="700" />
 	</skill_template>
-	<skill_template skill_id="18443" name="Reduce Strength" nameId="293159" cooldownId="12" stack="CHF_SPELLMNOBLISDHPTA35_ADSUATT" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="18432" hostile_type="DIRECT">
+	<skill_template skill_id="18443" name="Reduce Strength" nameId="293159" cooldownId="12" stack="CHF_SPELLMNOBLISDHPTA35_ADSUATT" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="30" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="18432" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="40" target_relation="ENEMY" target_type="AREA" target_maxcount="96" effective_altitude="35" effective_range="35" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -148594,7 +148594,7 @@
 		</effects>
 		<motion name="openaerial" />
 	</skill_template>
-	<skill_template skill_id="18445" name="Sleep of Fear" nameId="293162" cooldownId="12" stack="CHF_SPELLNOFSLEMPATTTA35_ADREF15_PHB" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="18433" hostile_type="DIRECT">
+	<skill_template skill_id="18445" name="Sleep of Fear" nameId="293162" cooldownId="12" stack="CHF_SPELLNOFSLEMPATTTA35_ADREF15_PHB" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="18433" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="40" target_relation="ENEMY" target_type="AREA" target_maxcount="96" effective_altitude="35" effective_range="35" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -148625,7 +148625,7 @@
 		</effects>
 		<motion name="debuff" />
 	</skill_template>
-	<skill_template skill_id="18447" name="Head Wound" nameId="293132" cooldownId="12" stack="CHF_KDNOSKILL25M_ADDREF_CLO" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="2000" penalty_skill_id="18433" hostile_type="DIRECT">
+	<skill_template skill_id="18447" name="Head Wound" nameId="293132" cooldownId="12" stack="CHF_KDNOSKILL25M_ADDREF_CLO" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="30" activation="ACTIVE" cooldown="0" duration="2000" penalty_skill_id="18433" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="40" target_relation="ENEMY" target_type="AREA" target_maxcount="96" effective_altitude="30" effective_range="35" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -148679,7 +148679,7 @@
 		</effects>
 		<motion name="closeaerial" />
 	</skill_template>
-	<skill_template skill_id="18450" name="Paralysis Attack" nameId="293182" cooldownId="3" stack="CSUM_AIMPAR_ADREF" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="18434" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="100">
+	<skill_template skill_id="18450" name="Paralysis Attack" nameId="293182" cooldownId="3" stack="CSUM_AIMPAR_ADREF" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="18434" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="40" target_relation="ENEMY" target_type="AREA" target_maxcount="96" effective_altitude="10" effective_range="10" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -149780,7 +149780,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="18529" name="Root Entangle" nameId="293447" cooldownId="8" stack="BNAS_SNARE15SESA_LR" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="1000" ammospeed="25" penalty_skill_id="17219" hostile_type="DIRECT">
+	<skill_template skill_id="18529" name="Root Entangle" nameId="293447" cooldownId="8" stack="BNAS_SNARE15SESA_LR" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="3" req_dispel_count="30" activation="ACTIVE" cooldown="0" duration="1000" ammospeed="25" penalty_skill_id="17219" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="16" target_relation="ENEMY" target_type="AREA" target_maxcount="8" effective_altitude="6" effective_range="25" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -149796,7 +149796,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="18530" name="Become Mist" nameId="293748" cooldownId="2" stack="BNPR_STUNSA_HIDE" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="16822" cancel_rate="40" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18530" name="Become Mist" nameId="293748" cooldownId="2" stack="BNPR_STUNSA_HIDE" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="16822" cancel_rate="40" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="4" target_relation="ENEMY" target_type="AREA" target_maxcount="3" effective_altitude="5" effective_angle="240" effective_dist="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -150803,7 +150803,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18606" name="Binding Web" nameId="294284" stack="BNAS_STAGSTDOWN_SR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="16400" hostile_type="INDIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18606" name="Binding Web" nameId="294284" stack="BNAS_STAGSTDOWN_SR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="16400" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="3" target_relation="ENEMY" target_type="AREA" target_maxcount="8" effective_altitude="6" effective_range="5" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -150845,7 +150845,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="18609" name="Exsanguinate" nameId="294292" cooldownId="12" stack="BNAS_SPELLATKDRAIN_HP" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1500" penalty_skill_id="18111" cancel_rate="30" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="10">
+	<skill_template skill_id="18609" name="Exsanguinate" nameId="294292" cooldownId="12" stack="BNAS_SPELLATKDRAIN_HP" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1500" penalty_skill_id="18111" cancel_rate="30" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -152992,7 +152992,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="18763" name="Become Mist" nameId="293748" cooldownId="2" stack="BNAS_STUNSA_HIDE" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="18762" cancel_rate="40" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="18763" name="Become Mist" nameId="293748" cooldownId="2" stack="BNAS_STUNSA_HIDE" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="18762" cancel_rate="40" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="4" target_relation="ENEMY" target_type="AREA" target_maxcount="3" effective_altitude="5" effective_angle="240" effective_dist="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -155628,7 +155628,7 @@
 		</effects>
 		<motion name="bashatk" />
 	</skill_template>
-	<skill_template skill_id="18945" name="Spirit Substitution IV Water" nameId="295656" stack="EL_ORDER_SACRIFICE_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="18945" name="Spirit Substitution IV Water" nameId="295656" stack="EL_ORDER_SACRIFICE_WATER" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="30" activation="MAINTAIN" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="15" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -157197,7 +157197,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="19051" name="Devour Soul" nameId="295886" cooldownId="1" stack="BNWI_NRSPELL_NR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1500" penalty_skill_id="19049" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="19051" name="Devour Soul" nameId="295886" cooldownId="1" stack="BNWI_NRSPELL_NR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1500" penalty_skill_id="19049" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="30" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -158186,7 +158186,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="19118" name="Implosion" nameId="296254" cooldownId="2" stack="NPC_SELFEXPLOSION" lvl="1" skilltype="PHYSICAL" skillsubtype="NONE" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="19117" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="10">
+	<skill_template skill_id="19118" name="Implosion" nameId="296254" cooldownId="2" stack="NPC_SELFEXPLOSION" lvl="1" skilltype="PHYSICAL" skillsubtype="NONE" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="19117" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="37" target_relation="ENEMY" target_type="AREA" target_maxcount="24" effective_altitude="14" effective_range="15" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -158365,7 +158365,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="19129" name="Infernal Rift" nameId="295825" cooldownId="1" stack="TEST_STUMBLETELEPORT_HANDBIND" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="3500" hostile_type="INDIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="19129" name="Infernal Rift" nameId="295825" cooldownId="1" stack="TEST_STUMBLETELEPORT_HANDBIND" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="3500" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="5" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -164930,7 +164930,7 @@
 		</effects>
 		<motion name="downatk" />
 	</skill_template>
-	<skill_template skill_id="19597" name="Divine Chastisement IV" nameId="297616" cooldownId="500" stack="NPC_DIVINEJUDGEMENT" lvl="4" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="8709" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="19597" name="Divine Chastisement IV" nameId="297616" cooldownId="500" stack="NPC_DIVINEJUDGEMENT" lvl="4" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="8709" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<effects>
 			<skillatk mode="PERCENT" value="120" delta="5" e="1" accmod2="0" hoptype="DAMAGE" />
@@ -165055,7 +165055,7 @@
 		</effects>
 		<motion name="elsummon2" />
 	</skill_template>
-	<skill_template skill_id="19610" name="Brand of Nemesis" nameId="297635" cooldownId="1323" stack="NPC_TREMOR" lvl="2" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="8593" cancel_rate="20" hostile_type="DIRECT" req_dispel_level="2" req_dispel_count="50">
+	<skill_template skill_id="19610" name="Brand of Nemesis" nameId="297635" cooldownId="1323" stack="NPC_TREMOR" lvl="2" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="8593" cancel_rate="20" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="12" effective_altitude="4" effective_range="20" />
 		<effects>
 			<skillatk mode="PERCENT" value="103" delta="7" e="1" accmod2="0" hoptype="SKILLLV">
@@ -165918,7 +165918,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="19673" name="Explosion of Wrath" nameId="294016" cooldownId="4" stack="IDARENA_S10_SPELLPFEARTA10_ADDSHI_NO" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="18214" hostile_type="DIRECT">
+	<skill_template skill_id="19673" name="Explosion of Wrath" nameId="294016" cooldownId="4" stack="IDARENA_S10_SPELLPFEARTA10_ADDSHI_NO" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="18214" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="25" target_relation="ENEMY" target_type="AREA" target_maxcount="7" effective_altitude="7" effective_range="7" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -165936,7 +165936,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="19674" name="Eruption of Power" nameId="294012" cooldownId="1" stack="IDARENA_S10_SPELLATKTA10_ADDREF_NO" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="18213" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="19674" name="Eruption of Power" nameId="294012" cooldownId="1" stack="IDARENA_S10_SPELLATKTA10_ADDREF_NO" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="18213" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="25" target_relation="ENEMY" target_type="AREA" target_maxcount="7" effective_altitude="7" effective_range="7" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -166086,7 +166086,7 @@
 		</effects>
 		<motion name="chainatk2" speed="70" />
 	</skill_template>
-	<skill_template skill_id="19685" name="Self-Protection" nameId="288065" cooldownId="1" stack="IDARENA_SUPPYDEFSHORT_SHANDUKA" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" ammospeed="25" penalty_skill_id="17547" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="20">
+	<skill_template skill_id="19685" name="Self-Protection" nameId="288065" cooldownId="1" stack="IDARENA_SUPPYDEFSHORT_SHANDUKA" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" ammospeed="25" penalty_skill_id="17547" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="1" effective_altitude="25" effective_range="18" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -166170,7 +166170,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="19690" name="Wound Explosion" nameId="291832" cooldownId="17" stack="IDARENA_SIGNETBURTA40_ADDSUCRI" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="17929" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="19690" name="Wound Explosion" nameId="291832" cooldownId="17" stack="IDARENA_SIGNETBURTA40_ADDSUCRI" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="17929" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="24" effective_altitude="27" effective_range="12" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -166443,7 +166443,7 @@
 		</effects>
 		<motion name="areafire" />
 	</skill_template>
-	<skill_template skill_id="19711" name="Sleep of Death" nameId="291530" cooldownId="12" stack="IDARENA_MPATTSLEEPTA40_ADDREFLECT60" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="3000" ammospeed="25" penalty_skill_id="19686" hostile_type="DIRECT">
+	<skill_template skill_id="19711" name="Sleep of Death" nameId="291530" cooldownId="12" stack="IDARENA_MPATTSLEEPTA40_ADDREFLECT60" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="3000" ammospeed="25" penalty_skill_id="19686" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="37" target_relation="ENEMY" target_type="AREA" target_maxcount="24" effective_altitude="27" effective_angle="240" effective_dist="15" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -167957,7 +167957,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="19825" name="Ability Drain" nameId="298031" cooldownId="2" stack="IDARENA_SOLO_PMDEFDOWN" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="2000" penalty_skill_id="19265" hostile_type="INDIRECT">
+	<skill_template skill_id="19825" name="Ability Drain" nameId="298031" cooldownId="2" stack="IDARENA_SOLO_PMDEFDOWN" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="2000" penalty_skill_id="19265" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="16" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -170553,7 +170553,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="20036" name="DP Absorption" nameId="298501" cooldownId="3" stack="IDYUN_POLYMORPH_DEALER_DPDRAIN" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" ammospeed="20" penalty_skill_id="20035" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="20036" name="DP Absorption" nameId="298501" cooldownId="3" stack="IDYUN_POLYMORPH_DEALER_DPDRAIN" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" ammospeed="20" penalty_skill_id="20035" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="40" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -172464,7 +172464,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="20172" name="Collapsing Earth" nameId="298948" cooldownId="1" stack="LDF4B_TIAMATAVATAR_CRACK_DRAKAN_AREASNARE" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="20476" hostile_type="DIRECT">
+	<skill_template skill_id="20172" name="Collapsing Earth" nameId="298948" cooldownId="1" stack="LDF4B_TIAMATAVATAR_CRACK_DRAKAN_AREASNARE" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="20476" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="96" effective_altitude="50" effective_range="5" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -172926,7 +172926,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="20209" name="HP Absorption" nameId="299102" cooldownId="2" stack="LDF4B_CRYSTALPRIME_DRAINCRYSTAL" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="10000" penalty_skill_id="20208" req_dispel_level="5" req_dispel_count="10">
+	<skill_template skill_id="20209" name="HP Absorption" nameId="299102" cooldownId="2" stack="LDF4B_CRYSTALPRIME_DRAINCRYSTAL" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="10000" penalty_skill_id="20208">
 		<properties first_target="ME" first_target_range="2" target_relation="ALL" target_type="AREA" target_maxcount="96" effective_altitude="100" effective_range="100" target_species="NPC" />
 		<startconditions>
 			<target value="NPC" />
@@ -173194,7 +173194,7 @@
 		</effects>
 		<motion name="normalfire" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="20226" name="Snare Trap VI Effect" nameId="299276" cooldownId="1" stack="HEAVENSTRAP" lvl="6" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="500" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="20226" name="Snare Trap VI Effect" nameId="299276" cooldownId="1" stack="HEAVENSTRAP" lvl="6" skilltype="MAGICAL" skillsubtype="NONE" tslot="NONE" activation="ACTIVE" cooldown="0" duration="500" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="1" effective_altitude="5" effective_range="5" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -174042,7 +174042,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="20295" name="Spirit Wrath Position V Fire" nameId="299525" stack="EL_PET_ELEMENTALWRAITH_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="20295" name="Spirit Wrath Position V Fire" nameId="299525" stack="EL_PET_ELEMENTALWRAITH_FIRE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -174058,7 +174058,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="20296" name="Spirit Wrath Position V Wind" nameId="299526" stack="EL_PET_ELEMENTALWRAITH_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
+	<skill_template skill_id="20296" name="Spirit Wrath Position V Wind" nameId="299526" stack="EL_PET_ELEMENTALWRAITH_AIR" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -175969,7 +175969,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="20430" name="Fatal Fury" nameId="299758" cooldownId="1" stack="LDF4B_COMMANDER_DEADLYATK" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="20432" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="10">
+	<skill_template skill_id="20430" name="Fatal Fury" nameId="299758" cooldownId="1" stack="LDF4B_COMMANDER_DEADLYATK" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="20432" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="10" target_relation="ENEMY" target_type="AREA" target_maxcount="96" effective_altitude="50" effective_range="40" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -177540,7 +177540,7 @@
 		</effects>
 		<motion name="normalfire" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="20549" name="Activate Stun Trap" nameId="2280246" cooldownId="3" stack="IDARENA_TEAM01_S1_TRAP_01_STUN" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="19713" hostile_type="INDIRECT">
+	<skill_template skill_id="20549" name="Activate Stun Trap" nameId="2280246" cooldownId="3" stack="IDARENA_TEAM01_S1_TRAP_01_STUN" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="19713" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ALL" target_type="ONLYONE" target_maxcount="6" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -178574,7 +178574,7 @@
 			<fpatk percent="true" checktime="2000" value="100" duration2="6000" effectid="10206363" e="3" noresist="true" element="FIRE" preeffect="2" />
 		</effects>
 	</skill_template>
-	<skill_template skill_id="20637" name="Fiery Sea" nameId="2280389" stack="IDTIAMAT_NAGAQUEEN_INFERNOCAST" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="20638" req_dispel_level="5" req_dispel_count="30">
+	<skill_template skill_id="20637" name="Fiery Sea" nameId="2280389" stack="IDTIAMAT_NAGAQUEEN_INFERNOCAST" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="20638">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="48" effective_altitude="20" effective_range="80" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -178626,7 +178626,7 @@
 		</effects>
 		<motion instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="20643" name="Self Destruct" nameId="2280399" stack="IDTIAMAT_NAGAQUEEN_SUMSUICIDE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="5000" penalty_skill_id="19713">
+	<skill_template skill_id="20643" name="Self Destruct" nameId="2280399" stack="IDTIAMAT_NAGAQUEEN_SUMSUICIDE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="5000" penalty_skill_id="19713">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="48" effective_altitude="20" effective_range="80" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -180128,28 +180128,28 @@
 		</effects>
 		<motion name="pointfire2" />
 	</skill_template>
-	<skill_template skill_id="20762" name="Belonging to Panesterra Castle 1" nameId="2284743" stack="TEST_GAB1_01_TRIBE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="DEBUFF" dispel_category="EXTRA" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="0">
+	<skill_template skill_id="20762" name="Belonging to Panesterra Castle 1" nameId="2284743" stack="TEST_GAB1_01_TRIBE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="DEBUFF" dispel_category="EXTRA" req_dispel_level="" req_dispel_count="" activation="ACTIVE" cooldown="0" duration="0">
 		<properties first_target="TARGET" first_target_range="1" target_relation="ALL" target_type="ONLYONE" target_maxcount="1" />
 		<effects>
 			<deform model="202635" type="PC" duration2="30000" effectid="10215211" e="1" basiclvl="255" noresist="true" hoptype="SKILLLV" hopb="60" />
 		</effects>
 		<motion name="normalfire" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="20763" name="Belonging to Panesterra Castle 2" nameId="2284744" stack="TEST_GAB1_02_TRIBE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="DEBUFF" dispel_category="EXTRA" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="0">
+	<skill_template skill_id="20763" name="Belonging to Panesterra Castle 2" nameId="2284744" stack="TEST_GAB1_02_TRIBE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="DEBUFF" dispel_category="EXTRA" req_dispel_level="" req_dispel_count="" activation="ACTIVE" cooldown="0" duration="0">
 		<properties first_target="TARGET" first_target_range="1" target_relation="ALL" target_type="ONLYONE" target_maxcount="1" />
 		<effects>
 			<deform model="202635" type="PC" duration2="30000" effectid="10215211" e="1" basiclvl="255" noresist="true" hoptype="SKILLLV" hopb="60" />
 		</effects>
 		<motion name="normalfire" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="20764" name="Belonging to Panesterra Castle 3" nameId="2284745" stack="TEST_GAB1_03_TRIBE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="DEBUFF" dispel_category="EXTRA" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="0">
+	<skill_template skill_id="20764" name="Belonging to Panesterra Castle 3" nameId="2284745" stack="TEST_GAB1_03_TRIBE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="DEBUFF" dispel_category="EXTRA" req_dispel_level="" req_dispel_count="" activation="ACTIVE" cooldown="0" duration="0">
 		<properties first_target="TARGET" first_target_range="1" target_relation="ALL" target_type="ONLYONE" target_maxcount="1" />
 		<effects>
 			<deform model="251812" type="PC" duration2="30000" effectid="10215211" e="1" basiclvl="255" noresist="true" hoptype="SKILLLV" hopb="60" />
 		</effects>
 		<motion name="normalfire" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="20765" name="Belonging to Panesterra Castle 4" nameId="2284746" stack="TEST_GAB1_04_TRIBE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="DEBUFF" dispel_category="EXTRA" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="0">
+	<skill_template skill_id="20765" name="Belonging to Panesterra Castle 4" nameId="2284746" stack="TEST_GAB1_04_TRIBE" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="DEBUFF" dispel_category="EXTRA" req_dispel_level="" req_dispel_count="" activation="ACTIVE" cooldown="0" duration="0">
 		<properties first_target="TARGET" first_target_range="1" target_relation="ALL" target_type="ONLYONE" target_maxcount="1" />
 		<effects>
 			<deform model="251813" type="PC" duration2="30000" effectid="10215211" e="1" basiclvl="255" noresist="true" hoptype="SKILLLV" hopb="60" />
@@ -180375,7 +180375,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="20783" name="Ide Frenzy" nameId="2280667" stack="NWI_SUICIDE_ID_FX" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="19713">
+	<skill_template skill_id="20783" name="Ide Frenzy" nameId="2280667" stack="NWI_SUICIDE_ID_FX" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="19713">
 		<properties first_target="TARGET" first_target_range="37" target_relation="ALL" target_type="ONLYONE" target_maxcount="1" />
 		<effects>
 			<statup duration2="1000" e="1" noresist="true">
@@ -181076,7 +181076,7 @@
 		</effects>
 		<motion name="pointfire2" />
 	</skill_template>
-	<skill_template skill_id="20845" name="Stats absolute value correction test 13" nameId="2280929" cooldownId="1" stack="TESTSKILL_ABSOLUTESTATTOPC_13" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="100" cancel_rate="30" hostile_type="DIRECT">
+	<skill_template skill_id="20845" name="Stats absolute value correction test 13" nameId="2280929" cooldownId="1" stack="TESTSKILL_ABSOLUTESTATTOPC_13" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="100" cancel_rate="30" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="16" target_relation="ALL" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -181089,7 +181089,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="20846" name="Stats absolute value correction test 14" nameId="2280931" cooldownId="2" stack="TESTSKILL_ABSOLUTESTATTOPC_14" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="100" cancel_rate="30" hostile_type="DIRECT">
+	<skill_template skill_id="20846" name="Stats absolute value correction test 14" nameId="2280931" cooldownId="2" stack="TESTSKILL_ABSOLUTESTATTOPC_14" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="100" cancel_rate="30" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="16" target_relation="ALL" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -181374,7 +181374,7 @@
 		</effects>
 		<motion name="normalfire2" speed="60" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="20867" name="Flame Spirit Absorption" nameId="2280991" cooldownId="2" stack="IDTIAMAT_RAKSHAKA_POLYMORPH_DRAINENERGY" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="20868" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="20867" name="Flame Spirit Absorption" nameId="2280991" cooldownId="2" stack="IDTIAMAT_RAKSHAKA_POLYMORPH_DRAINENERGY" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="20868" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="12" effective_altitude="30" effective_range="4" />
 		<startconditions>
 			<form value="FORM1" />
@@ -181443,7 +181443,7 @@
 		</effects>
 		<motion name="pointfire" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="20873" name="Test Skill: Damage Sharing (SpellAtk_Instant)" nameId="2281023" cooldownId="1" stack="TESTSKILL_DMGSHARING_SPELLATK_INSTANT" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2000" ammospeed="25" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="20873" name="Test Skill: Damage Sharing (SpellAtk_Instant)" nameId="2281023" cooldownId="1" stack="TESTSKILL_DMGSHARING_SPELLATK_INSTANT" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2000" ammospeed="25">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="24" effective_altitude="30" effective_range="20" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -181645,7 +181645,7 @@
 		</effects>
 		<motion name="heal" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="20888" name="Abyssal Explosion" nameId="2281110" cooldownId="1" stack="AB1_CYCLOPS_DEADLYATK" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="20432" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="10">
+	<skill_template skill_id="20888" name="Abyssal Explosion" nameId="2281110" cooldownId="1" stack="AB1_CYCLOPS_DEADLYATK" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="4000" penalty_skill_id="20432" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="10" target_relation="ENEMY" target_type="AREA" target_maxcount="96" effective_altitude="50" effective_range="40" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -181893,7 +181893,7 @@
 		</effects>
 		<motion name="normalfire" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="20908" name="Test Skill: Class Check (SpellAtk_Instant)" nameId="2281037" cooldownId="1" stack="TESTSKILL_CLASSCHECKDMGSHRNG_AREASPELLATK_INSTANT" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1000" ammospeed="25" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="20908" name="Test Skill: Class Check (SpellAtk_Instant)" nameId="2281037" cooldownId="1" stack="TESTSKILL_CLASSCHECKDMGSHRNG_AREASPELLATK_INSTANT" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1000" ammospeed="25">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="96" effective_altitude="30" effective_range="20" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -181945,7 +181945,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="20911" name="Hallucinatory Victory" nameId="2281151" stack="IDTIAMAT_KALYNDI_AREAATK" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="20910">
+	<skill_template skill_id="20911" name="Hallucinatory Victory" nameId="2281151" stack="IDTIAMAT_KALYNDI_AREAATK" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="5" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="20910">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="36" effective_altitude="30" effective_range="100" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -181968,7 +181968,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="20913" name="Blaze Engraving" nameId="2281154" stack="IDTIAMAT_KALYNDI_TARGETAREAATK" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="1000" ammospeed="25" penalty_skill_id="20912">
+	<skill_template skill_id="20913" name="Blaze Engraving" nameId="2281154" stack="IDTIAMAT_KALYNDI_TARGETAREAATK" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="5" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="1000" ammospeed="25" penalty_skill_id="20912">
 		<properties first_target="TARGET" first_target_range="100" target_relation="ALL" target_type="AREA" target_maxcount="36" effective_altitude="10" effective_range="5" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -182575,7 +182575,7 @@
 			<hostileup value="5000000" delta="500000" e="1" noresist="true" element="FIRE" hoptype="SKILLLV" hopb="90000" hopa="9000" />
 		</effects>
 	</skill_template>
-	<skill_template skill_id="20957" name="Perfect Strike" nameId="2281305" cooldownId="1" stack="NRI_SKILLATK_SELFSHIELD_TS" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="16604" cancel_rate="35" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="20957" name="Perfect Strike" nameId="2281305" cooldownId="1" stack="NRI_SKILLATK_SELFSHIELD_TS" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="3500" penalty_skill_id="16604" cancel_rate="35" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -182729,7 +182729,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="20967" name="Oblivion Flame" nameId="2281336" stack="IDTIAMAT_TIAMAT_GRAVITYBOMB_SKILLDMG" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="19713">
+	<skill_template skill_id="20967" name="Oblivion Flame" nameId="2281336" stack="IDTIAMAT_TIAMAT_GRAVITYBOMB_SKILLDMG" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="19713">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="12" effective_altitude="5" effective_range="3" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -183211,7 +183211,7 @@
 		</effects>
 		<motion name="normalfire" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="20999" name="Ice Sheet V Effect" nameId="2281502" cooldownId="1" stack="FROSTPILLAR" lvl="5" skilltype="MAGICAL" skillsubtype="NONE" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
+	<skill_template skill_id="20999" name="Ice Sheet V Effect" nameId="2281502" cooldownId="1" stack="FROSTPILLAR" lvl="5" skilltype="MAGICAL" skillsubtype="NONE" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="8" effective_altitude="5" effective_range="5" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -186294,7 +186294,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="21224" name="Song of Fear" nameId="2283060" cooldownId="12" stack="BNBA_FEARSNARE_PENALTYBUFF_SA_LR" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16409" hostile_type="DIRECT">
+	<skill_template skill_id="21224" name="Song of Fear" nameId="2283060" cooldownId="12" stack="BNBA_FEARSNARE_PENALTYBUFF_SA_LR" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_MENTAL" req_dispel_level="1" req_dispel_count="30" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16409" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="4" target_relation="ENEMY" target_type="AREA" target_maxcount="4" effective_altitude="10" effective_range="10" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -186558,7 +186558,7 @@
 		</effects>
 		<motion name="areaatk" />
 	</skill_template>
-	<skill_template skill_id="21245" name="Eerie Howl" nameId="2283090" cooldownId="2" stack="BNFI_SPELL_SA_NR_IDRW" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="21335" hostile_type="DIRECT">
+	<skill_template skill_id="21245" name="Eerie Howl" nameId="2283090" cooldownId="2" stack="BNFI_SPELL_SA_NR_IDRW" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="30" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="21335" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="50" target_relation="ENEMY" target_type="AREA" target_maxcount="24" effective_altitude="10" effective_range="20" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -186572,7 +186572,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21246" name="Dreadful Howl" nameId="2283092" cooldownId="2" stack="BNFI_SPELL_SA_NR_PENALTY_IDRW" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="5" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="21256" hostile_type="DIRECT">
+	<skill_template skill_id="21246" name="Dreadful Howl" nameId="2283092" cooldownId="2" stack="BNFI_SPELL_SA_NR_PENALTY_IDRW" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="60" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="21256" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="50" target_relation="ENEMY" target_type="AREA" target_maxcount="24" effective_altitude="10" effective_range="20" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187116,7 +187116,7 @@
 		</effects>
 		<motion name="chainatk1" />
 	</skill_template>
-	<skill_template skill_id="21285" name="Accurate Hit" nameId="290840" cooldownId="2" stack="DNFI_SATKKDTA_MORTAL_ADDLEH" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16412" cancel_rate="25" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="21285" name="Accurate Hit" nameId="290840" cooldownId="2" stack="DNFI_SATKKDTA_MORTAL_ADDLEH" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2500" penalty_skill_id="16412" cancel_rate="25" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="3" effective_altitude="5" effective_angle="240" effective_dist="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -187525,7 +187525,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="21314" name="Shellshock" nameId="2283330" cooldownId="1" stack="IDSHULACK_GUIBOMB_SPELLATKSTUN_TA" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="STUN" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="19713" hostile_type="DIRECT">
+	<skill_template skill_id="21314" name="Shellshock" nameId="2283330" cooldownId="1" stack="IDSHULACK_GUIBOMB_SPELLATKSTUN_TA" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="STUN" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="3000" penalty_skill_id="19713" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="4" effective_altitude="5" effective_range="5" />
 		<startconditions>
 			<weapon weapon="GREATSWORD SPELLBOOK BOW DAGGER MACE ORB POLEARM STAFF SWORD GUN CANNON HARP KEYBLADE" />
@@ -187667,7 +187667,7 @@
 		</effects>
 		<motion name="fiareaatk2" />
 	</skill_template>
-	<skill_template skill_id="21325" name="Wind Slice" nameId="2283417" cooldownId="10" stack="IU_AREAATTACK" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="21325" name="Wind Slice" nameId="2283417" cooldownId="10" stack="IU_AREAATTACK" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="6" target_relation="ENEMY" target_type="AREA" target_maxcount="3" effective_altitude="4" effective_range="8" />
 		<startconditions>
 			<form value="FORM1" />
@@ -187698,7 +187698,7 @@
 		</effects>
 		<motion name="hellcurse" />
 	</skill_template>
-	<skill_template skill_id="21328" name="Together with IU!" nameId="2283424" stack="IU_HEART2" lvl="1" skilltype="MAGICAL" skillsubtype="HEAL" tslot="NONE" activation="ACTIVE" cooldown="900" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="21328" name="Together with IU!" nameId="2283424" stack="IU_HEART2" lvl="1" skilltype="MAGICAL" skillsubtype="HEAL" tslot="NONE" activation="ACTIVE" cooldown="900" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="10" target_relation="FRIEND" target_type="AREA" target_maxcount="5" effective_altitude="7" effective_range="50" target_species="NPC" />
 		<startconditions>
 			<target value="NPC" />
@@ -187709,7 +187709,7 @@
 		</effects>
 		<motion name="hellcurse" />
 	</skill_template>
-	<skill_template skill_id="21329" name="Polar Bear Form" nameId="2283426" cooldownId="2" stack="IU_POLYMORPH_BEARL" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="NPC_BUFF" activation="ACTIVE" cooldown="0" duration="0" noremoveatdie="true" hostile_type="DIRECT">
+	<skill_template skill_id="21329" name="Polar Bear Form" nameId="2283426" cooldownId="2" stack="IU_POLYMORPH_BEARL" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="NPC_BUFF" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="0" noremoveatdie="true" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187723,7 +187723,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21330" name="Tiger Form" nameId="2283427" cooldownId="2" stack="IU_POLYMORPH_TIGERL" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="NPC_BUFF" req_dispel_level="5" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="0" noremoveatdie="true" hostile_type="DIRECT">
+	<skill_template skill_id="21330" name="Tiger Form" nameId="2283427" cooldownId="2" stack="IU_POLYMORPH_TIGERL" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="NPC_BUFF" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="0" noremoveatdie="true" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187737,7 +187737,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21331" name="Transform into Jester" nameId="2283428" cooldownId="2" stack="IU_POLYMORPH_PIERROL" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="NPC_BUFF" req_dispel_level="5" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="0" noremoveatdie="true" hostile_type="DIRECT">
+	<skill_template skill_id="21331" name="Transform into Jester" nameId="2283428" cooldownId="2" stack="IU_POLYMORPH_PIERROL" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="NPC_BUFF" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="0" noremoveatdie="true" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187751,7 +187751,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21332" name="Polar Bear Form" nameId="2283429" cooldownId="2" stack="IU_POLYMORPH_BEARD" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="NPC_BUFF" req_dispel_level="5" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="0" noremoveatdie="true" hostile_type="DIRECT">
+	<skill_template skill_id="21332" name="Polar Bear Form" nameId="2283429" cooldownId="2" stack="IU_POLYMORPH_BEARD" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="NPC_BUFF" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="0" noremoveatdie="true" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187765,7 +187765,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21333" name="Tiger Form" nameId="2283430" cooldownId="2" stack="IU_POLYMORPH_TIGERD" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="NPC_BUFF" req_dispel_level="5" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="0" noremoveatdie="true" hostile_type="DIRECT">
+	<skill_template skill_id="21333" name="Tiger Form" nameId="2283430" cooldownId="2" stack="IU_POLYMORPH_TIGERD" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="NPC_BUFF" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="0" noremoveatdie="true" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187779,7 +187779,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21334" name="Transform into Jester" nameId="2283431" cooldownId="2" stack="IU_POLYMORPH_PIERROD" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="NPC_BUFF" req_dispel_level="5" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="0" noremoveatdie="true" hostile_type="DIRECT">
+	<skill_template skill_id="21334" name="Transform into Jester" nameId="2283431" cooldownId="2" stack="IU_POLYMORPH_PIERROD" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="NPC_BUFF" req_dispel_level="5" req_dispel_count="100" activation="ACTIVE" cooldown="0" duration="0" noremoveatdie="true" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="1" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187806,7 +187806,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21336" name="Daze Target" nameId="2283602" stack="IU_BOSS_STUN" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="2000" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="21336" name="Daze Target" nameId="2283602" stack="IU_BOSS_STUN" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="2000">
 		<properties first_target="TARGET" first_target_range="6" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187816,7 +187816,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21337" name="Crush Dreams" nameId="2283603" stack="IU_BOSS_AREAATTACK" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="2000" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="21337" name="Crush Dreams" nameId="2283603" stack="IU_BOSS_AREAATTACK" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="2000">
 		<properties first_target="ME" first_target_range="6" target_relation="ENEMY" target_type="AREA" target_maxcount="4" effective_altitude="4" effective_range="4" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187827,7 +187827,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="21338" name="Terror Smash" nameId="2283604" stack="IU_BOSS_SATTACK" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="2000" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="21338" name="Terror Smash" nameId="2283604" stack="IU_BOSS_SATTACK" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="2000">
 		<properties first_target="TARGET" first_target_range="6" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187838,7 +187838,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="21339" name="Root in Fear" nameId="2283605" stack="IU_BOSS_ROOT" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="2000" req_dispel_level="5" req_dispel_count="10">
+	<skill_template skill_id="21339" name="Root in Fear" nameId="2283605" stack="IU_BOSS_ROOT" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="2000">
 		<properties first_target="TARGET" first_target_range="6" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187848,7 +187848,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="21340" name="Open Magic Box" nameId="2283661" stack="IU_BOSS_GREATHEAL" lvl="1" skilltype="MAGICAL" skillsubtype="HEAL" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1000" hostile_type="INDIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="21340" name="Open Magic Box" nameId="2283661" stack="IU_BOSS_GREATHEAL" lvl="1" skilltype="MAGICAL" skillsubtype="HEAL" tslot="NONE" activation="ACTIVE" cooldown="0" duration="1000" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="10" target_relation="FRIEND" target_type="AREA" target_maxcount="12" effective_altitude="4" effective_range="100" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187858,7 +187858,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21341" name="Bolstered Attack" nameId="2283606" stack="IU_BOSS_ADBUFF" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="2000" hostile_type="INDIRECT">
+	<skill_template skill_id="21341" name="Bolstered Attack" nameId="2283606" stack="IU_BOSS_ADBUFF" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="2" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="2000" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="10" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187871,7 +187871,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21342" name="Feed the Nightmare" nameId="2283607" stack="IU_BOSS_HEAL" lvl="1" skilltype="MAGICAL" skillsubtype="HEAL" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2000" hostile_type="INDIRECT" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="21342" name="Feed the Nightmare" nameId="2283607" stack="IU_BOSS_HEAL" lvl="1" skilltype="MAGICAL" skillsubtype="HEAL" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2000" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="10" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187891,7 +187891,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21344" name="Hook Grab" nameId="2283609" stack="IU_BOSS_SNATCH" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2000" req_dispel_level="5" req_dispel_count="50">
+	<skill_template skill_id="21344" name="Hook Grab" nameId="2283609" stack="IU_BOSS_SNATCH" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2000">
 		<properties first_target="TARGET" first_target_range="15" target_relation="ENEMY" target_type="AREA" target_maxcount="2" effective_altitude="4" effective_range="10" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187903,7 +187903,7 @@
 		</effects>
 		<motion name="stuckatk" />
 	</skill_template>
-	<skill_template skill_id="21345" name="Fascination" nameId="2283610" stack="IU_BOSS_FEAR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="2000" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="21345" name="Fascination" nameId="2283610" stack="IU_BOSS_FEAR" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="2000">
 		<properties first_target="ME" first_target_range="10" target_relation="ENEMY" target_type="AREA" target_maxcount="3" effective_altitude="4" effective_range="4" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187914,7 +187914,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21346" name="Gone with the Dust" nameId="2283658" stack="IU_BOSS_FLEE2" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="80" duration="2000" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="21346" name="Gone with the Dust" nameId="2283658" stack="IU_BOSS_FLEE2" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="80" duration="2000" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="6" target_relation="ENEMY" target_type="AREA" target_maxcount="8" effective_altitude="5" effective_range="8" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187924,7 +187924,7 @@
 		</effects>
 		<motion name="poweratk" speed="90" />
 	</skill_template>
-	<skill_template skill_id="21347" name="Throw Speed Sword" nameId="2283460" stack="IU_PIERRO_THROW" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="9" duration="0" ammospeed="40" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="21347" name="Throw Speed Sword" nameId="2283460" stack="IU_PIERRO_THROW" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="9" duration="0" ammospeed="40" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="12" target_relation="ENEMY" target_type="AREA" target_maxcount="3" effective_altitude="5" effective_range="8" />
 		<startconditions>
 			<form value="FORM1" />
@@ -187934,7 +187934,7 @@
 		</effects>
 		<motion name="vacuumexplosion" />
 	</skill_template>
-	<skill_template skill_id="21348" name="Somersault" nameId="2283461" cooldownId="10" stack="IU_PIERRO_WINDMIL" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="21348" name="Somersault" nameId="2283461" cooldownId="10" stack="IU_PIERRO_WINDMIL" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="5" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="5" effective_range="8" />
 		<startconditions>
 			<form value="FORM1" />
@@ -187958,7 +187958,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="21350" name="Crushing Terror" nameId="2283612" stack="IU_BOSS_SSATTACK" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="2000" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="21350" name="Crushing Terror" nameId="2283612" stack="IU_BOSS_SSATTACK" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="2000">
 		<properties first_target="ME" first_target_range="6" target_relation="ENEMY" target_type="AREA" target_maxcount="4" effective_altitude="4" effective_range="3" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -187998,7 +187998,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21353" name="IU's Luster" nameId="2283496" stack="IU_SKILL_FX" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0">
+	<skill_template skill_id="21353" name="IU's Luster" nameId="2283496" stack="IU_SKILL_FX" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0">
 		<properties first_target="ME" first_target_range="1" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -188130,7 +188130,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21364" name="IU's Healing" nameId="2283526" stack="IU_HEAL2" lvl="1" skilltype="MAGICAL" skillsubtype="HEAL" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" ammospeed="25" hostile_type="INDIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="21364" name="IU's Healing" nameId="2283526" stack="IU_HEAL2" lvl="1" skilltype="MAGICAL" skillsubtype="HEAL" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" ammospeed="25" hostile_type="INDIRECT">
 		<properties first_target="ME" first_target_range="1" target_relation="FRIEND" target_type="AREA" target_maxcount="10" effective_altitude="10" effective_range="37" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -188185,7 +188185,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21368" name="IU's Healing" nameId="2283525" stack="IU_DAMAGE" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="21368" name="IU's Healing" nameId="2283525" stack="IU_DAMAGE" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="0">
 		<properties first_target="ME" first_target_range="6" target_relation="ENEMY" target_type="AREA" target_maxcount="4" effective_altitude="4" effective_range="8" />
 		<effects>
 			<noreducespellatk value="12000" e="1" noresist="true" element="EARTH" critprobmod2="0" />
@@ -188193,7 +188193,7 @@
 		</effects>
 		<motion name="normalfire" speed="50" />
 	</skill_template>
-	<skill_template skill_id="21369" name="I Love You, IU!" nameId="2283422" stack="IU_HEART3" lvl="1" skilltype="MAGICAL" skillsubtype="HEAL" tslot="NONE" activation="ACTIVE" cooldown="1200" duration="0" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="21369" name="I Love You, IU!" nameId="2283422" stack="IU_HEART3" lvl="1" skilltype="MAGICAL" skillsubtype="HEAL" tslot="NONE" activation="ACTIVE" cooldown="1200" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="10" target_relation="FRIEND" target_type="AREA" target_maxcount="5" effective_altitude="10" effective_range="50" target_species="NPC" />
 		<startconditions>
 			<target value="NPC" />
@@ -188272,7 +188272,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="21374" name="Storm Mine Effect" nameId="2280845" stack="RA_DARK_STORMMINETRAP" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="5" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="500">
+	<skill_template skill_id="21374" name="Storm Mine Effect" nameId="2280845" stack="RA_DARK_STORMMINETRAP" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="500">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="8" effective_altitude="10" effective_range="10" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -188294,7 +188294,7 @@
 		</effects>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="21375" name="Electric Shock" nameId="2283569" cooldownId="10" stack="IU_PIERRO_AERIAL" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="21375" name="Electric Shock" nameId="2283569" cooldownId="10" stack="IU_PIERRO_AERIAL" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="60" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="6" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<startconditions>
 			<form value="FORM1" />
@@ -188321,7 +188321,7 @@
 		</effects>
 		<motion name="normalfire" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="21377" name="Bearish Strike" nameId="2283413" stack="IU_NATTACK2" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="8" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="21377" name="Bearish Strike" nameId="2283413" stack="IU_NATTACK2" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="8" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="6" target_relation="ENEMY" target_type="AREA" target_maxcount="2" effective_altitude="4" effective_range="5" />
 		<startconditions>
 			<form value="FORM1" />
@@ -188331,7 +188331,7 @@
 		</effects>
 		<motion name="hurtatk" speed="50" />
 	</skill_template>
-	<skill_template skill_id="21378" name="Cartwheel" nameId="2283415" stack="IU_SATTACK2" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="40" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="21378" name="Cartwheel" nameId="2283415" stack="IU_SATTACK2" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="40" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="6" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" effective_altitude="4" effective_range="5" />
 		<startconditions>
 			<form value="FORM1" />
@@ -188341,7 +188341,7 @@
 		</effects>
 		<motion name="fiareaatk2" />
 	</skill_template>
-	<skill_template skill_id="21379" name="Wind Slice" nameId="2283417" stack="IU_AREAATTACK2" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="80" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="21379" name="Wind Slice" nameId="2283417" stack="IU_AREAATTACK2" lvl="1" skilltype="PHYSICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="80" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="6" target_relation="ENEMY" target_type="AREA" target_maxcount="4" effective_altitude="4" effective_range="8" />
 		<startconditions>
 			<form value="FORM1" />
@@ -188351,7 +188351,7 @@
 		</effects>
 		<motion name="upperatk2" speed="90" />
 	</skill_template>
-	<skill_template skill_id="21380" name="Bear's Roar" nameId="2283419" stack="IU_AREADOT2" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="100">
+	<skill_template skill_id="21380" name="Bear's Roar" nameId="2283419" stack="IU_AREADOT2" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="10" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="4" effective_range="7" />
 		<startconditions>
 			<dp value="1000" />
@@ -188595,7 +188595,7 @@
 		</actions>
 		<motion name="poweratk" />
 	</skill_template>
-	<skill_template skill_id="21397" name="Flatter the Nightmare" nameId="2283613" stack="IU_BOSS_ADBUFF2" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="2000" hostile_type="INDIRECT">
+	<skill_template skill_id="21397" name="Flatter the Nightmare" nameId="2283613" stack="IU_BOSS_ADBUFF2" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="2" req_dispel_count="50" activation="ACTIVE" cooldown="0" duration="2000" hostile_type="INDIRECT">
 		<properties first_target="TARGET" first_target_range="6" target_relation="FRIEND" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -188608,7 +188608,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21398" name="Smash" nameId="2283614" stack="IU_MAM_STUMBLE" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="1000" hostile_type="DIRECT" req_dispel_level="1" req_dispel_count="10">
+	<skill_template skill_id="21398" name="Smash" nameId="2283614" stack="IU_MAM_STUMBLE" lvl="1" skilltype="MAGICAL" skillsubtype="DEBUFF" tslot="DEBUFF" activation="ACTIVE" cooldown="0" duration="1000" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="6" target_relation="ENEMY" target_type="AREA" target_maxcount="6" effective_altitude="4" effective_range="4" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -189822,7 +189822,7 @@
 		</effects>
 		<motion name="normalfire" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="21494" name="Ide Frenzy" nameId="2280667" stack="NWI_SUICIDE_ID_NONEFX" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="19713">
+	<skill_template skill_id="21494" name="Ide Frenzy" nameId="2280667" stack="NWI_SUICIDE_ID_NONEFX" lvl="1" skilltype="MAGICAL" skillsubtype="BUFF" tslot="BUFF" dispel_category="BUFF" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" penalty_skill_id="19713">
 		<properties first_target="TARGET" first_target_range="37" target_relation="ALL" target_type="ONLYONE" target_maxcount="1" />
 		<effects>
 			<statup duration2="1000" e="1" noresist="true">
@@ -191690,7 +191690,7 @@
 		</effects>
 		<motion name="pointfire" />
 	</skill_template>
-	<skill_template skill_id="21638" name="Frozen Blur" nameId="2285555" stack="IDSEAL_IMMORTAL_SNARE" lvl="1" skilltype="MAGICAL" skill_category="PHYSICAL_DEBUFF" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="1500" penalty_skill_id="19713" hostile_type="DIRECT">
+	<skill_template skill_id="21638" name="Frozen Blur" nameId="2285555" stack="IDSEAL_IMMORTAL_SNARE" lvl="1" skilltype="MAGICAL" skill_category="PHYSICAL_DEBUFF" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="20" activation="ACTIVE" cooldown="0" duration="1500" penalty_skill_id="19713" hostile_type="DIRECT">
 		<properties first_target="TARGET" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="24" effective_altitude="30" effective_range="6" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -192625,7 +192625,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21721" name="Flame Bolt IV" nameId="297590" stack="TEST_HIT_FX_DAMAGE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2000" hostile_type="DIRECT" req_dispel_level="5" req_dispel_count="10">
+	<skill_template skill_id="21721" name="Flame Bolt IV" nameId="297590" stack="TEST_HIT_FX_DAMAGE" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="NONE" activation="ACTIVE" cooldown="0" duration="2000" hostile_type="DIRECT" req_dispel_level="" req_dispel_count="">
 		<properties first_target="TARGET" first_target_range="37" target_relation="ENEMY" target_type="ONLYONE" target_maxcount="1" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -194622,7 +194622,7 @@
 		</effects>
 		<motion name="normalfire" />
 	</skill_template>
-	<skill_template skill_id="21887" name="Hallucinatory Victory" nameId="2281151" stack="IDTIAMAT_HARD_KALYNDI_AREAATK" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="20910">
+	<skill_template skill_id="21887" name="Hallucinatory Victory" nameId="2281151" stack="IDTIAMAT_HARD_KALYNDI_AREAATK" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="5" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="1000" penalty_skill_id="20910">
 		<properties first_target="ME" first_target_range="1" target_relation="ENEMY" target_type="AREA" target_maxcount="36" effective_altitude="30" effective_range="100" />
 		<useconditions>
 			<move_casting allow="false" />
@@ -194633,7 +194633,7 @@
 		</effects>
 		<motion name="areafire" />
 	</skill_template>
-	<skill_template skill_id="21888" name="Blaze Engraving" nameId="2281154" stack="IDTIAMAT_HARD_KALYNDI_TARGETAREAATK" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" activation="ACTIVE" cooldown="0" duration="1000" ammospeed="25" penalty_skill_id="20912">
+	<skill_template skill_id="21888" name="Blaze Engraving" nameId="2281154" stack="IDTIAMAT_HARD_KALYNDI_TARGETAREAATK" lvl="1" skilltype="MAGICAL" skillsubtype="ATTACK" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="5" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="1000" ammospeed="25" penalty_skill_id="20912">
 		<properties first_target="TARGET" first_target_range="100" target_relation="ALL" target_type="AREA" target_maxcount="36" effective_altitude="10" effective_range="5" target_species="PC" />
 		<startconditions>
 			<target value="PC" />
@@ -195270,7 +195270,7 @@
 		</effects>
 		<motion name="normalfire" instant_skill="true" />
 	</skill_template>
-	<skill_template skill_id="21929" name="Ice Sheet V Effect" nameId="2281502" cooldownId="1" stack="FROSTPILLAR1" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="1" req_dispel_count="10" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
+	<skill_template skill_id="21929" name="Ice Sheet V Effect" nameId="2281502" cooldownId="1" stack="FROSTPILLAR1" lvl="1" skilltype="MAGICAL" skillsubtype="NONE" tslot="DEBUFF" dispel_category="DEBUFF_PHYSICAL" req_dispel_level="" req_dispel_count="" activation="ACTIVE" cooldown="0" duration="0" hostile_type="DIRECT">
 		<properties first_target="ME" first_target_range="2" target_relation="ENEMY" target_type="AREA" target_maxcount="8" effective_altitude="5" effective_range="5" />
 		<useconditions>
 			<move_casting allow="false" />


### PR DESCRIPTION
In the previous [PR ](https://github.com/beyond-aion/aion-server/pull/139) introducing **req_dispel_count** and **req_dispel_level**, several issues were found in the data mapping logic between PTS versions. 

The mapping was performed only by skill `id ` using data from PTS 5.8, without validating the `name `field. This was based on the assumption that all skills from 4.8 exist in 5.8 with identical structure.
In practice, some skills were modified between versions (including changes in name), which led to incorrect parameters from 5.8 being applied to certain 4.8 skills.

A corrected matching strategy has been introduced:
If there is a full match of skill `id `+ `name `between 4.8 and 5.8 (with only grade differences allowed), parameters are taken from PTS 5.8.
If the `name `does not match while skill `id `does, a fallback is applied using PTS 4.6 with full skill `id `+ `name `validation.
[skill_flags.csv](https://github.com/user-attachments/files/29174641/skill_flags.csv)
