### PR TITLE
Wish commands fix

### DIFF
--- a/game-server/data/handlers/consolecommands/Wish.java
+++ b/game-server/data/handlers/consolecommands/Wish.java
@@ -73,9 +73,10 @@ public class Wish extends ConsoleCommand {
 			String objectName = visibleObject.getObjectTemplate().getName();
 			sendInfo(admin, objectName + " spawned");
 		} else { // add item
-			if (!(admin.getTarget() instanceof Player player)) {
-				PacketSendUtility.sendPacket(admin, SM_SYSTEM_MESSAGE.STR_INVALID_TARGET());
-				return;
+			Player target = admin;
+
+			if (admin.getTarget() instanceof Player targetPlayer){
+				target = targetPlayer;
 			}
 
 			String itemName = params[0];
@@ -98,7 +99,7 @@ public class Wish extends ConsoleCommand {
 
 			if (itemTemplate != null) {
 				itemId = itemTemplate.getTemplateId();
-				if (!AdminService.getInstance().canOperate(admin, player, itemId, "command ///wish"))
+				if (!AdminService.getInstance().canOperate(admin, target, itemId, "command ///wish"))
 					return;
 
 				long addedCount;
@@ -120,17 +121,17 @@ public class Wish extends ConsoleCommand {
 					} else {
 						newItem.setTempering(enchant);
 					}
-					addedCount = addCount - ItemService.addItem(player, newItem);
+					addedCount = addCount - ItemService.addItem(target, newItem);
 				} else {
-					addedCount = addCount - ItemService.addItem(player, itemId, addCount, true);
+					addedCount = addCount - ItemService.addItem(target, itemId, addCount, true);
 				}
 
 				if (addedCount <= 0) {
 					sendInfo(admin, "Item couldn't be added");
 				} else {
-					if (!admin.equals(player)) {
-						sendInfo(admin, "You gave " + addedCount + " " + ChatUtil.item(itemId) + " to " + player.getName() + ".");
-						sendInfo(player, "You received " + addedCount + " " + ChatUtil.item(itemId) + " from " + admin.getName() + ".");
+					if (!admin.equals(target)) {
+						sendInfo(admin, "You gave " + addedCount + " " + ChatUtil.item(itemId) + " to " + target.getName() + ".");
+						sendInfo(target, "You received " + addedCount + " " + ChatUtil.item(itemId) + " from " + admin.getName() + ".");
 					}
 				}
 			}

--- a/game-server/data/handlers/consolecommands/Wishid.java
+++ b/game-server/data/handlers/consolecommands/Wishid.java
@@ -24,12 +24,10 @@ public class Wishid extends ConsoleCommand {
 			return;
 		}
 
-		VisibleObject target = admin.getTarget();
-		if (target == null || !(target instanceof Player)) {
-			target = admin;
+		Player target = admin;
+		if (admin.getTarget() instanceof Player player) {
+			target = player;
 		}
-
-		final Player player = (Player) target;
 
 		long itemCount;
 		int itemId;
@@ -47,15 +45,15 @@ public class Wishid extends ConsoleCommand {
 			return;
 		}
 
-		if (!AdminService.getInstance().canOperate(admin, player, itemId, "command ///wishid"))
+		if (!AdminService.getInstance().canOperate(admin, target, itemId, "command ///wishid"))
 			return;
 
-		long count = ItemService.addItem(player, itemId, itemCount, true);
+		long count = ItemService.addItem(target, itemId, itemCount, true);
 
 		if (count == 0) {
-			if (admin != player) {
-				PacketSendUtility.sendMessage(admin, "You successfully gave " + itemCount + " x [item:" + itemId + "] to " + player.getName() + ".");
-				PacketSendUtility.sendMessage(player, "You successfully received " + itemCount + " x [item:" + itemId + "] from " + admin.getName() + ".");
+			if (admin != target) {
+				PacketSendUtility.sendMessage(admin, "You successfully gave " + itemCount + " x [item:" + itemId + "] to " + target.getName() + ".");
+				PacketSendUtility.sendMessage(target, "You successfully received " + itemCount + " x [item:" + itemId + "] from " + admin.getName() + ".");
 			} else
 				PacketSendUtility.sendMessage(admin, "You successfully received " + itemCount + " x [item:" + itemId + "]");
 		} else {

--- a/game-server/data/handlers/consolecommands/Wishid.java
+++ b/game-server/data/handlers/consolecommands/Wishid.java
@@ -24,15 +24,9 @@ public class Wishid extends ConsoleCommand {
 			return;
 		}
 
-		final VisibleObject target = admin.getTarget();
-		if (target == null) {
-			PacketSendUtility.sendMessage(admin, "No target selected.");
-			return;
-		}
-
-		if (!(target instanceof Player)) {
-			PacketSendUtility.sendMessage(admin, "This command can only be used on a player!");
-			return;
+		VisibleObject target = admin.getTarget();
+		if (target == null || !(target instanceof Player)) {
+			target = admin;
 		}
 
 		final Player player = (Player) target;


### PR DESCRIPTION
Align `wish `and `wishid `behavior with retail. The commands now default to the admin as the target when no player is selected instead of failing with an invalid target error.