### PR TITLE
Rework item use handling: casting delays, cancel bugs, quest dialogs, retail messages

### DIFF
--- a/game-server/data/handlers/playercommands/Decompose.java
+++ b/game-server/data/handlers/playercommands/Decompose.java
@@ -97,7 +97,7 @@ public class Decompose extends PlayerCommand {
 				remainingCount--;
 				totalCount++;
 			}
-		}, 10, DecomposeAction.USAGE_DELAY + 100));
+		}, 10, DataManager.ITEM_DATA.getItemTemplate(itemId).getCastingDelay() + 100));
 	}
 
 	private void cancelTask(Player player, ItemUseObserver observer, String message) {

--- a/game-server/data/handlers/quest/altgard/_2216MuMuGrassKnot.java
+++ b/game-server/data/handlers/quest/altgard/_2216MuMuGrassKnot.java
@@ -6,7 +6,6 @@ import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -14,7 +13,6 @@ import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author MrPoke
@@ -63,22 +61,12 @@ public class _2216MuMuGrassKnot extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182203210)
 			return HandlerResult.UNKNOWN;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/altgard/_2228AThornInItsSide.java
+++ b/game-server/data/handlers/quest/altgard/_2228AThornInItsSide.java
@@ -6,7 +6,6 @@ import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -14,7 +13,6 @@ import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author Dta3000, Majka
@@ -68,10 +66,9 @@ public class _2228AThornInItsSide extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		Player player = env.getPlayer();
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182203221)
 			return HandlerResult.UNKNOWN;
@@ -79,15 +76,7 @@ public class _2228AThornInItsSide extends AbstractQuestHandler {
 		QuestState qs = player.getQuestStateList().getQuestState(questId);
 		if (qs == null || qs.isStartable()) {
 
-			PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-			ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-				@Override
-				public void run() {
-					PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-					sendQuestDialog(env, 4);
-				}
-			}, 3000);
+			sendQuestDialog(env, 4);
 		}
 		return HandlerResult.SUCCESS;
 	}

--- a/game-server/data/handlers/quest/beluslan/_16909AMarkofDistinction.java
+++ b/game-server/data/handlers/quest/beluslan/_16909AMarkofDistinction.java
@@ -4,15 +4,12 @@ import static com.aionemu.gameserver.model.DialogAction.*;
 
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
 import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
-import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author Ritsu
@@ -65,22 +62,12 @@ public class _16909AMarkofDistinction extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182213274)
 			return HandlerResult.UNKNOWN;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/beluslan/_2578ARingforLuck.java
+++ b/game-server/data/handlers/quest/beluslan/_2578ARingforLuck.java
@@ -6,7 +6,6 @@ import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -14,7 +13,6 @@ import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author Altaress
@@ -89,22 +87,12 @@ public class _2578ARingforLuck extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182204453)
 			return HandlerResult.UNKNOWN;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/beluslan/_2670TheAncientBook.java
+++ b/game-server/data/handlers/quest/beluslan/_2670TheAncientBook.java
@@ -6,7 +6,6 @@ import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -14,7 +13,6 @@ import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author Altaress
@@ -76,22 +74,12 @@ public class _2670TheAncientBook extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182204501)
 			return HandlerResult.UNKNOWN;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/beluslan/_26909TribalEmblems.java
+++ b/game-server/data/handlers/quest/beluslan/_26909TribalEmblems.java
@@ -4,15 +4,12 @@ import static com.aionemu.gameserver.model.DialogAction.*;
 
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
 import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
-import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author Ritsu
@@ -65,22 +62,12 @@ public class _26909TribalEmblems extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182213276)
 			return HandlerResult.UNKNOWN;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/brusthonin/_4053GlossyHoe.java
+++ b/game-server/data/handlers/quest/brusthonin/_4053GlossyHoe.java
@@ -6,7 +6,6 @@ import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -14,7 +13,6 @@ import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author Aion Gates
@@ -89,22 +87,12 @@ public class _4053GlossyHoe extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182209031)
 			return HandlerResult.UNKNOWN;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/brusthonin/_4060TheZombiesDescendant.java
+++ b/game-server/data/handlers/quest/brusthonin/_4060TheZombiesDescendant.java
@@ -6,7 +6,6 @@ import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -14,7 +13,6 @@ import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author Aion Gates
@@ -102,22 +100,12 @@ public class _4060TheZombiesDescendant extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182209037)
 			return HandlerResult.UNKNOWN;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/esoterrace/_18405MemoriesInTheCornerOfHisMind.java
+++ b/game-server/data/handlers/quest/esoterrace/_18405MemoriesInTheCornerOfHisMind.java
@@ -5,7 +5,6 @@ import static com.aionemu.gameserver.model.DialogAction.*;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -13,7 +12,6 @@ import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author Vincas
@@ -71,22 +69,12 @@ public class _18405MemoriesInTheCornerOfHisMind extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182215002)
 			return HandlerResult.FAILED;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/esoterrace/_18406PlayingToTheHilt.java
+++ b/game-server/data/handlers/quest/esoterrace/_18406PlayingToTheHilt.java
@@ -5,7 +5,6 @@ import static com.aionemu.gameserver.model.DialogAction.*;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -13,7 +12,6 @@ import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author Ritsu
@@ -61,22 +59,12 @@ public class _18406PlayingToTheHilt extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182215003)
 			return HandlerResult.FAILED;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/esoterrace/_28405KexkrasPast.java
+++ b/game-server/data/handlers/quest/esoterrace/_28405KexkrasPast.java
@@ -5,7 +5,6 @@ import static com.aionemu.gameserver.model.DialogAction.*;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -13,7 +12,6 @@ import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author Vincas
@@ -71,22 +69,12 @@ public class _28405KexkrasPast extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182215014)
 			return HandlerResult.FAILED;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/esoterrace/_28406FindersFee.java
+++ b/game-server/data/handlers/quest/esoterrace/_28406FindersFee.java
@@ -5,7 +5,6 @@ import static com.aionemu.gameserver.model.DialogAction.*;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -13,7 +12,6 @@ import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author Ritsu
@@ -61,22 +59,12 @@ public class _28406FindersFee extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182215015)
 			return HandlerResult.FAILED;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/heiron/_1561TheMisersMap.java
+++ b/game-server/data/handlers/quest/heiron/_1561TheMisersMap.java
@@ -5,15 +5,12 @@ import static com.aionemu.gameserver.model.DialogAction.*;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
 import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
-import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * Find the place marked on the map (182201728).
@@ -33,25 +30,16 @@ public class _1561TheMisersMap extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
 		env.setQuestId(questId);
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+		Player player = env.getPlayer();
+		int id = item.getItemTemplate().getTemplateId();
 		QuestState qs = player.getQuestStateList().getQuestState(questId);
 
 		if (qs == null || qs.isStartable()) {
-			PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-			ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-				@Override
-				public void run() {
-					PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-					removeQuestItem(env, id, 1);
-					QuestService.startQuest(env);
-					// sendQuestDialog(env, 4);
-				}
-			}, 3000);
+			removeQuestItem(env, id, 1);
+			QuestService.startQuest(env);
+			// sendQuestDialog(env, 4);
 			return HandlerResult.SUCCESS;
 		}
 		return HandlerResult.UNKNOWN;

--- a/game-server/data/handlers/quest/heiron/_1644AVeryOldLetter.java
+++ b/game-server/data/handlers/quest/heiron/_1644AVeryOldLetter.java
@@ -6,7 +6,6 @@ import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -14,7 +13,6 @@ import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author Balthazar, Gigi
@@ -96,10 +94,9 @@ public class _1644AVeryOldLetter extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int itemObjId = item.getObjectId();
-		final int id = item.getItemTemplate().getTemplateId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		Player player = env.getPlayer();
+		int id = item.getItemTemplate().getTemplateId();
 		QuestState qs = player.getQuestStateList().getQuestState(questId);
 
 		if (id != 182201765) {
@@ -113,15 +110,7 @@ public class _1644AVeryOldLetter extends AbstractQuestHandler {
 			}
 		}
 
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/inggison/_11289VeillesGift.java
+++ b/game-server/data/handlers/quest/inggison/_11289VeillesGift.java
@@ -4,13 +4,11 @@ import static com.aionemu.gameserver.model.DialogAction.*;
 
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
 import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
-import com.aionemu.gameserver.utils.PacketSendUtility;
 
 /**
  * @author zhkchi
@@ -67,14 +65,12 @@ public class _11289VeillesGift extends AbstractQuestHandler {
 
 	@Override
 	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+		Player player = env.getPlayer();
+		int id = item.getItemTemplate().getTemplateId();
 		QuestState qs = player.getQuestStateList().getQuestState(questId);
 
 		if (id != 182213147)
 			return HandlerResult.UNKNOWN;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 20, 1, 0), true);
 		if (qs == null || qs.isStartable())
 			sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;

--- a/game-server/data/handlers/quest/ishalgen/_2136TheLostAxe.java
+++ b/game-server/data/handlers/quest/ishalgen/_2136TheLostAxe.java
@@ -6,7 +6,6 @@ import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -112,14 +111,12 @@ public class _2136TheLostAxe extends AbstractQuestHandler {
 
 	@Override
 	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+		Player player = env.getPlayer();
+		int id = item.getItemTemplate().getTemplateId();
 		QuestState qs = player.getQuestStateList().getQuestState(questId);
 
 		if (id != 182203130)
 			return HandlerResult.UNKNOWN;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 20, 1, 0), true);
 		if (qs == null || qs.isStartable()) {
 			QuestService.startQuest(env);
 		}

--- a/game-server/data/handlers/quest/morheim/_2316VivisBook.java
+++ b/game-server/data/handlers/quest/morheim/_2316VivisBook.java
@@ -6,7 +6,6 @@ import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -14,7 +13,6 @@ import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author MrPoke, Nephis (http://www.evolution-fr.com/)
@@ -63,22 +61,12 @@ public class _2316VivisBook extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182204115)
 			return HandlerResult.UNKNOWN;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/morheim/_2321SpyTheSpiritsLetter.java
+++ b/game-server/data/handlers/quest/morheim/_2321SpyTheSpiritsLetter.java
@@ -6,7 +6,6 @@ import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -14,7 +13,6 @@ import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author MrPoke, Nephis
@@ -76,25 +74,16 @@ public class _2321SpyTheSpiritsLetter extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		Player player = env.getPlayer();
+		int id = item.getItemTemplate().getTemplateId();
 		QuestState qs = player.getQuestStateList().getQuestState(questId);
 
 		if (id != 182204242)
 			return HandlerResult.UNKNOWN;
 
 		if (qs == null || qs.isStartable()) {
-			PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-			ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-				@Override
-				public void run() {
-					PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-					sendQuestDialog(env, 4);
-				}
-			}, 3000);
+			sendQuestDialog(env, 4);
 			return HandlerResult.SUCCESS;
 		}
 		return HandlerResult.UNKNOWN;

--- a/game-server/data/handlers/quest/morheim/_2324TheSpiritsNotebook.java
+++ b/game-server/data/handlers/quest/morheim/_2324TheSpiritsNotebook.java
@@ -6,14 +6,12 @@ import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
 import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author MrPoke, Nephis
@@ -66,22 +64,12 @@ public class _2324TheSpiritsNotebook extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182204123)
 			return HandlerResult.UNKNOWN;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/morheim/_2324TheSpiritsNotebook.java
+++ b/game-server/data/handlers/quest/morheim/_2324TheSpiritsNotebook.java
@@ -5,13 +5,12 @@ import static com.aionemu.gameserver.model.DialogAction.*;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
 import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
-import com.aionemu.gameserver.utils.PacketSendUtility;
+import com.aionemu.gameserver.services.QuestService;
 
 /**
  * @author MrPoke, Nephis
@@ -37,16 +36,12 @@ public class _2324TheSpiritsNotebook extends AbstractQuestHandler {
 		if (env.getVisibleObject() instanceof Npc)
 			targetId = ((Npc) env.getVisibleObject()).getNpcId();
 
-		if (qs == null)
-			return false;
-
 		if (targetId == 0) {
-			if (env.getDialogActionId() == QUEST_ACCEPT_1) {
-				qs.setStatus(QuestStatus.START);
-				PacketSendUtility.sendPacket(player, new SM_DIALOG_WINDOW(0, 0));
-				return true;
+			if (env.getDialogActionId() == QUEST_ACCEPT_1 && (qs == null || qs.isStartable())) {
+				QuestService.startQuest(env);
+				return closeDialogWindow(env);
 			}
-		} else if (targetId == 204373) {
+		} else if (qs != null && targetId == 204373) {
 			if (qs.getStatus() == QuestStatus.START) {
 				if (env.getDialogActionId() == QUEST_SELECT)
 					return sendQuestDialog(env, 2375);

--- a/game-server/data/handlers/quest/morheim/_2435TheBlueVineNecklace.java
+++ b/game-server/data/handlers/quest/morheim/_2435TheBlueVineNecklace.java
@@ -4,15 +4,12 @@ import static com.aionemu.gameserver.model.DialogAction.*;
 
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
 import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
-import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author MrPoke, Nephis
@@ -71,22 +68,12 @@ public class _2435TheBlueVineNecklace extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182204181)
 			return HandlerResult.UNKNOWN;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/poeta/_1114TheNymphsGown.java
+++ b/game-server/data/handlers/quest/poeta/_1114TheNymphsGown.java
@@ -6,7 +6,6 @@ import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -152,15 +151,13 @@ public class _1114TheNymphsGown extends AbstractQuestHandler {
 
 	@Override
 	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+		Player player = env.getPlayer();
+		int id = item.getItemTemplate().getTemplateId();
 		QuestState qs = player.getQuestStateList().getQuestState(questId);
 
 		if (id != 182200214)
 			return HandlerResult.UNKNOWN;
 
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 20, 1, 0), true);
 		if (qs == null || qs.isStartable()) {
 			QuestService.startQuest(env);
 		}

--- a/game-server/data/handlers/quest/reshanta/_1845OpeningDoors.java
+++ b/game-server/data/handlers/quest/reshanta/_1845OpeningDoors.java
@@ -11,6 +11,7 @@ import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
 import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
+import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
 
 /**
@@ -27,7 +28,7 @@ public class _1845OpeningDoors extends AbstractQuestHandler {
 		qe.registerQuestNpc(278591).addOnTalkEvent(questId);
 		qe.registerQuestNpc(278624).addOnTalkEvent(questId);
 		qe.registerQuestNpc(798316).addOnTalkEvent(questId);
-		qe.registerQuestItem(182204181, questId);
+		qe.registerQuestItem(182202181, questId);
 	}
 
 	@Override
@@ -39,10 +40,9 @@ public class _1845OpeningDoors extends AbstractQuestHandler {
 		if (env.getVisibleObject() instanceof Npc)
 			targetId = ((Npc) env.getVisibleObject()).getNpcId();
 		if (targetId == 0) {
-			if (env.getDialogActionId() == QUEST_ACCEPT_1) {
-				qs.setStatus(QuestStatus.START);
-				PacketSendUtility.sendPacket(player, new SM_DIALOG_WINDOW(0, 0));
-				return true;
+			if (env.getDialogActionId() == QUEST_ACCEPT_1 && (qs == null || qs.isStartable())) {
+				QuestService.startQuest(env);
+				return closeDialogWindow(env);
 			}
 		} else if (targetId == 278591) {
 			if (qs != null) {

--- a/game-server/data/handlers/quest/reshanta/_1845OpeningDoors.java
+++ b/game-server/data/handlers/quest/reshanta/_1845OpeningDoors.java
@@ -6,14 +6,12 @@ import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
 import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author MrPoke, Nephis
@@ -88,22 +86,12 @@ public class _1845OpeningDoors extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182202181)
 			return HandlerResult.UNKNOWN;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/talocs_hollow/_11465MysteriousSeed.java
+++ b/game-server/data/handlers/quest/talocs_hollow/_11465MysteriousSeed.java
@@ -5,7 +5,6 @@ import static com.aionemu.gameserver.model.DialogAction.*;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -13,7 +12,6 @@ import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author madison
@@ -70,22 +68,12 @@ public class _11465MysteriousSeed extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182209523)
 			return HandlerResult.UNKNOWN;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/talocs_hollow/_21465MysteriousSeed.java
+++ b/game-server/data/handlers/quest/talocs_hollow/_21465MysteriousSeed.java
@@ -5,7 +5,6 @@ import static com.aionemu.gameserver.model.DialogAction.*;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -13,7 +12,6 @@ import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author mr.madison
@@ -70,22 +68,12 @@ public class _21465MysteriousSeed extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182209527)
 			return HandlerResult.UNKNOWN;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/theobomos/_3060TheRedJournal.java
+++ b/game-server/data/handlers/quest/theobomos/_3060TheRedJournal.java
@@ -6,7 +6,6 @@ import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -14,7 +13,6 @@ import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author Altaress
@@ -110,22 +108,12 @@ public class _3060TheRedJournal extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182208043)
 			return HandlerResult.UNKNOWN;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/handlers/quest/verteron/_1197KrallBook.java
+++ b/game-server/data/handlers/quest/verteron/_1197KrallBook.java
@@ -6,7 +6,6 @@ import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.questEngine.handlers.AbstractQuestHandler;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -14,7 +13,6 @@ import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author MrPoke, Nephis, Rolandas
@@ -68,22 +66,12 @@ public class _1197KrallBook extends AbstractQuestHandler {
 	}
 
 	@Override
-	public HandlerResult onItemUseEvent(final QuestEnv env, Item item) {
-		final Player player = env.getPlayer();
-		final int id = item.getItemTemplate().getTemplateId();
-		final int itemObjId = item.getObjectId();
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		int id = item.getItemTemplate().getTemplateId();
 
 		if (id != 182200558)
 			return HandlerResult.UNKNOWN;
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 3000, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-				sendQuestDialog(env, 4);
-			}
-		}, 3000);
+		sendQuestDialog(env, 4);
 		return HandlerResult.SUCCESS;
 	}
 }

--- a/game-server/data/static_data/items/item_templates.xsd
+++ b/game-server/data/static_data/items/item_templates.xsd
@@ -134,14 +134,13 @@
 		<xs:attribute name="quality" type="itemQuality"/>
 		<xs:attribute name="item_type" type="itemType"/>
 		<xs:attribute name="max_stack_count" type="xs:int"/>
-		<xs:attribute name="drop" type="xs:boolean"/>
 		<xs:attribute name="item_group" type="ItemGroup"/>
 		<xs:attribute name="mask" type="xs:int"/>
 		<xs:attribute name="level" type="xs:int"/>
 		<xs:attribute name="id" type="itemId" use="required"/>
 		<xs:attribute name="name" type="xs:string"/>
-		<xs:attribute name="casting_delay" type="xs:int"/>
 		<xs:attribute name="cName" type="xs:string"/>
+		<xs:attribute name="casting_delay" type="xs:int"/>
 		<xs:attribute name="tempering_name" type="xs:string"/>
 		<xs:attribute name="enchant_name" type="xs:string" />
 		<xs:attribute name="multi_return" type="xs:string"/>

--- a/game-server/data/static_data/items/item_templates.xsd
+++ b/game-server/data/static_data/items/item_templates.xsd
@@ -126,15 +126,15 @@
 		<xs:attribute name="attack_type" type="ItemAttackType"/>
 		<xs:attribute name="desc" type="xs:int"/>
 		<xs:attribute name="restrict_max" type="ByteList"/>
-		<xs:attribute name="restrict" type="ByteList"/>
+		<xs:attribute name="restrict" type="ByteList" default="1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"/>
 		<xs:attribute name="rnd_bonus" type="xs:int"/>
-		<xs:attribute name="rnd_count" type="xs:int"/>
-		<xs:attribute name="race" type="itemRace"/>
+		<xs:attribute name="rnd_count" type="xs:int" default="-1"/>
+		<xs:attribute name="race" type="itemRace" default="PC_ALL"/>
 		<xs:attribute name="price" type="xs:int"/>
 		<xs:attribute name="quality" type="itemQuality"/>
-		<xs:attribute name="item_type" type="itemType"/>
-		<xs:attribute name="max_stack_count" type="xs:int"/>
-		<xs:attribute name="item_group" type="ItemGroup"/>
+		<xs:attribute name="item_type" type="itemType" default="NORMAL"/>
+		<xs:attribute name="max_stack_count" type="xs:int" default="1"/>
+		<xs:attribute name="item_group" type="ItemGroup" default="NONE"/>
 		<xs:attribute name="mask" type="xs:int"/>
 		<xs:attribute name="level" type="xs:int"/>
 		<xs:attribute name="id" type="itemId" use="required"/>

--- a/game-server/data/static_data/items/item_templates.xsd
+++ b/game-server/data/static_data/items/item_templates.xsd
@@ -140,7 +140,7 @@
 		<xs:attribute name="level" type="xs:int"/>
 		<xs:attribute name="id" type="itemId" use="required"/>
 		<xs:attribute name="name" type="xs:string"/>
-		<xs:attribute name="casting_delay" type="xs:string"/>
+		<xs:attribute name="casting_delay" type="xs:int"/>
 		<xs:attribute name="cName" type="xs:string"/>
 		<xs:attribute name="tempering_name" type="xs:string"/>
 		<xs:attribute name="enchant_name" type="xs:string" />

--- a/game-server/data/static_data/items/item_templates.xsd
+++ b/game-server/data/static_data/items/item_templates.xsd
@@ -179,7 +179,6 @@
 			<xs:element name="remodel" type="RemodelAction" minOccurs="0" maxOccurs="1"/>
 			<xs:element name="expextract" type="ExpExtractAction" minOccurs="0" maxOccurs="1"/>
 			<xs:element name="polish" type="PolishAction" minOccurs="0" maxOccurs="1"/>
-			<xs:element name="composition" type="CompositionAction" minOccurs="0" maxOccurs="1"/>
 			<xs:element name="tuning" type="TuningAction" minOccurs="0" maxOccurs="1"/>
 			<xs:element name="megaphone" type="MegaphoneAction" minOccurs="0" maxOccurs="1"/>
 			<xs:element name="pack" type="PackAction" minOccurs="0" maxOccurs="1"/>
@@ -404,11 +403,6 @@
 			<xs:extension base="AbstractItemAction">
 				<xs:attribute name="id" type="xs:int"/>
 			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-	<xs:complexType name="CompositionAction">
-		<xs:complexContent>
-			<xs:extension base="AbstractItemAction"/>
 		</xs:complexContent>
 	</xs:complexType>
 	<xs:complexType name="MegaphoneAction">

--- a/game-server/data/static_data/items/item_templates.xsd
+++ b/game-server/data/static_data/items/item_templates.xsd
@@ -140,6 +140,7 @@
 		<xs:attribute name="level" type="xs:int"/>
 		<xs:attribute name="id" type="itemId" use="required"/>
 		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="casting_delay" type="xs:string"/>
 		<xs:attribute name="cName" type="xs:string"/>
 		<xs:attribute name="tempering_name" type="xs:string"/>
 		<xs:attribute name="enchant_name" type="xs:string" />

--- a/game-server/data/static_data/items/item_templates.xsd
+++ b/game-server/data/static_data/items/item_templates.xsd
@@ -327,6 +327,7 @@
 		<xs:complexContent>
 			<xs:extension base="AbstractItemAction">
 				<xs:attribute name="sync_ids" type="IntListType"/>
+				<xs:attribute name="recovery_instance_count" type="xs:int" default="1"/>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>

--- a/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
@@ -534,7 +534,6 @@ public class PlayerController extends CreatureController<Player> {
 				PacketSendUtility.sendPacket(player, message);
 		} else if (castingSkill.getSkillMethod() == SkillMethod.ITEM) {
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
-			player.removeItemCoolDown(castingSkill.getItemTemplate().getUseLimits().getDelayId());
 			PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), castingSkill.getFirstTarget().getObjectId(),
 				castingSkill.getItemObjectId(), castingSkill.getItemTemplate().getTemplateId(), 0, 3, 0), true);
 		}

--- a/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
@@ -543,7 +543,7 @@ public class PlayerController extends CreatureController<Player> {
 	public void cancelUseItem() {
 		cancelUseItem(true);
 	}
-	
+
 	public void cancelUseItem(boolean sendCancelAnimation) {
 		Player player = getOwner();
 		Item usingItem = player.getUsingItem();

--- a/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
@@ -468,6 +468,9 @@ public class PlayerController extends CreatureController<Player> {
 			if (!PlayerRestrictions.canUseSkill(player, skill))
 				return;
 
+			if (player.isCasting()) // only item casts pass the restriction check, they get cancelled by the new skill
+				cancelCurrentSkill(null);
+
 			skill.setTargetType(targetType, x, y, z);
 			skill.setClientHitTime(clientHitTime);
 			skill.useSkill();

--- a/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
@@ -541,11 +541,14 @@ public class PlayerController extends CreatureController<Player> {
 
 	@Override
 	public void cancelUseItem() {
+		cancelUseItem(true);
+	}
+	
+	public void cancelUseItem(boolean sendCancelAnimation) {
 		Player player = getOwner();
 		Item usingItem = player.getUsingItem();
 		player.setUsingItem(null);
-		if (hasTask(TaskId.ITEM_USE)) {
-			cancelTask(TaskId.ITEM_USE);
+		if (cancelTask(TaskId.ITEM_USE) != null && sendCancelAnimation) {
 			PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), usingItem == null ? 0 : usingItem.getObjectId(),
 				usingItem == null ? 0 : usingItem.getItemTemplate().getTemplateId(), 0, 3, 0), true);
 		}

--- a/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
@@ -465,11 +465,13 @@ public class PlayerController extends CreatureController<Player> {
 		}
 
 		if (skill != null) {
+			// item casts get interrupted by skill usage (skill casts don't, see PlayerRestrictions#canUseSkill). this must
+			// happen before checking the restrictions, since Creature#canAttack returns false as long as we are casting
+			if (player.isCasting() && player.getCastingSkill().getItemTemplate() != null)
+				cancelCurrentSkill(null);
+
 			if (!PlayerRestrictions.canUseSkill(player, skill))
 				return;
-
-			if (player.isCasting()) // only item casts pass the restriction check, they get cancelled by the new skill
-				cancelCurrentSkill(null);
 
 			skill.setTargetType(targetType, x, y, z);
 			skill.setClientHitTime(clientHitTime);

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Equipment.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Equipment.java
@@ -740,7 +740,7 @@ public class Equipment implements Persistable {
 							new SM_ITEM_USAGE_ANIMATION(responder.getObjectId(), item.getObjectId(), item.getItemId(), 0, 8), true);
 					}
 				};
-				
+
 				responder.getObserveController().attach(observer);
 
 				// item usage animation

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Equipment.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Equipment.java
@@ -8,8 +8,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.aionemu.gameserver.controllers.observer.ActionObserver;
-import com.aionemu.gameserver.controllers.observer.ObserverType;
+import com.aionemu.gameserver.controllers.observer.ItemUseObserver;
 import com.aionemu.gameserver.dao.InventoryDAO;
 import com.aionemu.gameserver.model.EmotionType;
 import com.aionemu.gameserver.model.Race;
@@ -731,26 +730,25 @@ public class Equipment implements Persistable {
 				PacketSendUtility.broadcastPacket(responder,
 					new SM_ITEM_USAGE_ANIMATION(responder.getObjectId(), item.getObjectId(), item.getItemId(), 5000, 4), true);
 
-				responder.getController().cancelTask(TaskId.ITEM_USE);
-
-				final ActionObserver moveObserver = new ActionObserver(ObserverType.MOVE) {
+				final ItemUseObserver observer = new ItemUseObserver() {
 
 					@Override
-					public void moved() {
-						responder.getController().cancelTask(TaskId.ITEM_USE);
+					public void abort() {
+						player.getController().cancelUseItem(false);
 						PacketSendUtility.sendPacket(responder, STR_SOUL_BOUND_ITEM_CANCELED(item.getL10n()));
 						PacketSendUtility.broadcastPacket(responder,
 							new SM_ITEM_USAGE_ANIMATION(responder.getObjectId(), item.getObjectId(), item.getItemId(), 0, 8), true);
 					}
 				};
-				responder.getObserveController().attach(moveObserver);
+				
+				responder.getObserveController().attach(observer);
 
 				// item usage animation
 				responder.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(new Runnable() {
 
 					@Override
 					public void run() {
-						responder.getObserveController().removeObserver(moveObserver);
+						responder.getObserveController().removeObserver(observer);
 
 						PacketSendUtility.broadcastPacket(responder,
 							new SM_ITEM_USAGE_ANIMATION(responder.getObjectId(), item.getObjectId(), item.getItemId(), 0, 6), true);

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Equipment.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Equipment.java
@@ -734,7 +734,7 @@ public class Equipment implements Persistable {
 
 					@Override
 					public void abort() {
-						player.getController().cancelUseItem(false);
+						responder.getController().cancelUseItem(false);
 						PacketSendUtility.sendPacket(responder, STR_SOUL_BOUND_ITEM_CANCELED(item.getL10n()));
 						PacketSendUtility.broadcastPacket(responder,
 							new SM_ITEM_USAGE_ANIMATION(responder.getObjectId(), item.getObjectId(), item.getItemId(), 0, 8), true);

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Player.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Player.java
@@ -1009,6 +1009,14 @@ public class Player extends Creature {
 		return true;
 	}
 
+	public void startCooldown(Item item) {
+		ItemUseLimits limits = item.getItemTemplate().getUseLimits();
+		if (limits == null || limits.getDelayTime() <= 0 || hasCooldown(item))
+			return;
+
+		addItemCoolDown(limits.getDelayId(), System.currentTimeMillis() + limits.getDelayTime(), limits.getDelayTime() / 1000);
+	}
+
 	public long getItemReuseTime(int delayId) {
 		ItemCooldown cd = itemCoolDowns.get(delayId);
 		return cd == null ? 0 : cd.getReuseTime();

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Player.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Player.java
@@ -1011,7 +1011,7 @@ public class Player extends Creature {
 
 	public void startCooldown(Item item) {
 		ItemUseLimits limits = item.getItemTemplate().getUseLimits();
-		if (limits == null || limits.getDelayTime() <= 0 || hasCooldown(item))
+		if (limits == null || limits.getDelayTime() <= 0)
 			return;
 
 		addItemCoolDown(limits.getDelayId(), System.currentTimeMillis() + limits.getDelayTime(), limits.getDelayTime() / 1000);

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Player.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Player.java
@@ -1575,7 +1575,7 @@ public class Player extends Creature {
 		this.isInSprintMode = isInSprintMode;
 	}
 
-	public void setRideObservers(ActionObserver observer) {
+	public void addRideObserver(ActionObserver observer) {
 		if (rideObservers == null)
 			rideObservers = new ArrayList<>();
 

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/player/PortalCooldown.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/player/PortalCooldown.java
@@ -19,8 +19,8 @@ public class PortalCooldown {
 		this.enterCount++;
 	}
 
-	public void decreaseEnterCount() {
-		this.enterCount--;
+	public void decreaseEnterCount(int count) {
+		this.enterCount -= count;
 	}
 
 	public int getWorldId() {

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/player/PortalCooldownList.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/player/PortalCooldownList.java
@@ -59,8 +59,10 @@ public class PortalCooldownList {
 	 */
 	public PortalCooldown getOrCreatePortalCooldown(int worldId) {
 		long reuseTime = DataManager.INSTANCE_COOLTIME_DATA.calculateInstanceEntranceCooltime(owner, worldId);
-		if (reuseTime == 0)
-			return null;
+		return reuseTime == 0 ? null : getOrCreatePortalCooldown(worldId, reuseTime);
+	}
+
+	private synchronized PortalCooldown getOrCreatePortalCooldown(int worldId, long reuseTime) {
 		if (portalCooldowns == null)
 			portalCooldowns = new HashMap<>();
 		return portalCooldowns.computeIfAbsent(worldId, id -> new PortalCooldown(id, reuseTime, 0));
@@ -75,15 +77,7 @@ public class PortalCooldownList {
 	}
 
 	public void addPortalCooldown(int worldId, long useDelay) {
-		if (portalCooldowns == null)
-			portalCooldowns = new HashMap<>();
-
-		PortalCooldown portalCooldown = portalCooldowns.get(worldId);
-		if (portalCooldown == null)
-			portalCooldown = new PortalCooldown(worldId, useDelay, 0);
-
-		portalCooldown.increaseEnterCount();
-		portalCooldowns.put(worldId, portalCooldown);
+		getOrCreatePortalCooldown(worldId, useDelay).increaseEnterCount();
 
 		PortalCooldownsDAO.storePortalCooldowns(owner);
 

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/player/PortalCooldownList.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/player/PortalCooldownList.java
@@ -53,6 +53,19 @@ public class PortalCooldownList {
 		return portalCooldowns == null ? null : portalCooldowns.get(worldId);
 	}
 
+	/**
+	 * @return The cooldown of the given world, creating it if absent, or null if the world has no entry limit (the client
+	 *         displays such instances as unlimited, as long as we don't send any entry info for them).
+	 */
+	public PortalCooldown getOrCreatePortalCooldown(int worldId) {
+		long reuseTime = DataManager.INSTANCE_COOLTIME_DATA.calculateInstanceEntranceCooltime(owner, worldId);
+		if (reuseTime == 0)
+			return null;
+		if (portalCooldowns == null)
+			portalCooldowns = new HashMap<>();
+		return portalCooldowns.computeIfAbsent(worldId, id -> new PortalCooldown(id, reuseTime, 0));
+	}
+
 	public Map<Integer, PortalCooldown> getPortalCoolDowns() {
 		return portalCooldowns;
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/ItemTemplate.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/ItemTemplate.java
@@ -80,8 +80,6 @@ public class ItemTemplate extends VisibleObjectTemplate {
 	private Stigma stigma;
 	@XmlAttribute(name = "name")
 	private String name;
-	@XmlAttribute(name = "cName")
-	private String clientName;
 	@XmlJavaTypeAdapter(SpaceSeparatedBytesAdapter.class)
 	@XmlAttribute(name = "restrict")
 	private byte[] levelRestrictions = DEFAULT_LEVEL_RESTRICTION;
@@ -314,13 +312,6 @@ public class ItemTemplate extends VisibleObjectTemplate {
 	@Override
 	public String getName() {
 		return name == null ? "" : name;
-	}
-
-	/**
-	 * @return the internal client name (e.g. "doc_quest_13520a"), never null
-	 */
-	public String getClientName() {
-		return clientName == null ? "" : clientName;
 	}
 
 	@Override

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/ItemTemplate.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/ItemTemplate.java
@@ -78,6 +78,8 @@ public class ItemTemplate extends VisibleObjectTemplate {
 	private Stigma stigma;
 	@XmlAttribute(name = "name")
 	private String name;
+	@XmlAttribute(name = "cName")
+	private String clientName;
 	@XmlJavaTypeAdapter(SpaceSeparatedBytesAdapter.class)
 	@XmlAttribute(name = "restrict")
 	private byte[] levelRestrictions;
@@ -310,6 +312,13 @@ public class ItemTemplate extends VisibleObjectTemplate {
 	@Override
 	public String getName() {
 		return name == null ? "" : name;
+	}
+
+	/**
+	 * @return the internal client name (e.g. "doc_quest_13520a"), never null
+	 */
+	public String getClientName() {
+		return clientName == null ? "" : clientName;
 	}
 
 	@Override

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/ItemTemplate.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/ItemTemplate.java
@@ -96,6 +96,8 @@ public class ItemTemplate extends VisibleObjectTemplate {
 	private int enchantType;
 	@XmlAttribute(name = "max_tampering")
 	private int maxTampering;
+	@XmlAttribute(name = "casting_delay")
+	private int castingDelay;
 	@XmlAttribute(name = "temp_exchange_time")
 	private int temExchangeTime;
 	@XmlAttribute(name = "expire_time")
@@ -281,6 +283,10 @@ public class ItemTemplate extends VisibleObjectTemplate {
 
 	public boolean isStigma() {
 		return stigma != null;
+	}
+
+	public int getCastingDelay() {
+		return castingDelay;
 	}
 
 	/**

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/ItemTemplate.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/ItemTemplate.java
@@ -31,6 +31,8 @@ import com.aionemu.gameserver.world.zone.ZoneName;
 @XmlType(namespace = "", name = "ItemTemplate")
 public class ItemTemplate extends VisibleObjectTemplate {
 
+	private static final byte[] DEFAULT_LEVEL_RESTRICTION = new byte[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+
 	private int itemId;
 	@XmlElement(name = "modifiers")
 	private ModifiersTemplate modifiers;
@@ -53,7 +55,7 @@ public class ItemTemplate extends VisibleObjectTemplate {
 	@XmlAttribute(name = "quality")
 	private ItemQuality itemQuality;
 	@XmlAttribute(name = "item_type")
-	private ItemType itemType;
+	private ItemType itemType = ItemType.NORMAL;
 	@XmlAttribute(name = "attack_type")
 	private ItemAttackType attackType;
 	@XmlAttribute(name = "attack_gap")
@@ -82,7 +84,7 @@ public class ItemTemplate extends VisibleObjectTemplate {
 	private String clientName;
 	@XmlJavaTypeAdapter(SpaceSeparatedBytesAdapter.class)
 	@XmlAttribute(name = "restrict")
-	private byte[] levelRestrictions;
+	private byte[] levelRestrictions = DEFAULT_LEVEL_RESTRICTION;
 	@XmlJavaTypeAdapter(SpaceSeparatedBytesAdapter.class)
 	@XmlAttribute(name = "restrict_max")
 	private byte[] maxLevelRestrictions;

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AnimationAddAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AnimationAddAction.java
@@ -65,6 +65,7 @@ public class AnimationAddAction extends AbstractItemAction {
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), castingDelay, 0, 0));
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
+			player.startCooldown(parentItem);
 			finishUse(player, parentItem);
 		}, castingDelay));
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AnimationAddAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AnimationAddAction.java
@@ -5,6 +5,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 
+import com.aionemu.gameserver.controllers.observer.ItemUseObserver;
 import com.aionemu.gameserver.model.TaskId;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
@@ -38,41 +39,57 @@ public class AnimationAddAction extends AbstractItemAction {
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_COLOR_ERROR());
 			return false;
 		}
-
 		return true;
 	}
 
 	@Override
 	public void act(final Player player, final Item parentItem, Item targetItem, Object... params) {
-		player.getController().cancelUseItem();
-		PacketSendUtility.sendPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate()
-			.getTemplateId(), 1000, 0, 0));
-		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(new Runnable() {
+		int castingDelay = parentItem.getItemTemplate().getCastingDelay();
+		if (castingDelay <= 0) {
+			finishUse(player, parentItem);
+			return;
+		}
+		final ItemUseObserver observer = new ItemUseObserver() {
 
 			@Override
-			public void run() {
-				if (player.getInventory().decreaseItemCount(parentItem, 1) != 0)
-					return;
-				if (idle != null) {
-					addMotion(player, idle);
-				}
-				if (run != null) {
-					addMotion(player, run);
-				}
-				if (jump != null) {
-					addMotion(player, jump);
-				}
-				if (rest != null) {
-					addMotion(player, rest);
-				}
-				if (shop != null) {
-					addMotion(player, shop);
-				}
-				PacketSendUtility.broadcastPacketAndReceive(player,
-					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 0));
-				PacketSendUtility.broadcastPacket(player, new SM_MOTION(player.getObjectId(), player.getMotions().getActiveMotions()), false);
+			public void abort() {
+				player.getController().cancelUseItem();
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
+				player.getObserveController().removeObserver(this);
 			}
-		}, 1000));
+
+		};
+
+		player.getObserveController().attach(observer);
+		PacketSendUtility.sendPacket(player,
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), castingDelay, 0, 0));
+		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
+			player.getObserveController().removeObserver(observer);
+			finishUse(player, parentItem);
+		}, castingDelay));
+	}
+
+	private void finishUse(Player player, Item parentItem) {
+		if (player.getInventory().decreaseItemCount(parentItem, 1) != 0)
+			return;
+		if (idle != null) {
+			addMotion(player, idle);
+		}
+		if (run != null) {
+			addMotion(player, run);
+		}
+		if (jump != null) {
+			addMotion(player, jump);
+		}
+		if (rest != null) {
+			addMotion(player, rest);
+		}
+		if (shop != null) {
+			addMotion(player, shop);
+		}
+		PacketSendUtility.broadcastPacketAndReceive(player,
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 0));
+		PacketSendUtility.broadcastPacket(player, new SM_MOTION(player.getObjectId(), player.getMotions().getActiveMotions()), false);
 	}
 
 	private void addMotion(Player player, int motionId) {

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AnimationAddAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AnimationAddAction.java
@@ -65,7 +65,6 @@ public class AnimationAddAction extends AbstractItemAction {
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), castingDelay, 0, 0));
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			player.startCooldown(parentItem);
 			finishUse(player, parentItem);
 		}, castingDelay));
 	}
@@ -73,6 +72,7 @@ public class AnimationAddAction extends AbstractItemAction {
 	private void finishUse(Player player, Item parentItem) {
 		if (player.getInventory().decreaseItemCount(parentItem, 1) != 0)
 			return;
+		player.startCooldown(parentItem);
 		if (idle != null) {
 			addMotion(player, idle);
 		}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AnimationAddAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AnimationAddAction.java
@@ -87,6 +87,7 @@ public class AnimationAddAction extends AbstractItemAction {
 		if (shop != null) {
 			addMotion(player, shop);
 		}
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		PacketSendUtility.broadcastPacketAndReceive(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 0));
 		PacketSendUtility.broadcastPacket(player, new SM_MOTION(player.getObjectId(), player.getMotions().getActiveMotions()), false);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
@@ -144,13 +144,14 @@ public class ApExtractAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			player.startCooldown(parentItem);
 			finishUse(player, parentItem, targetItem);
 		}, CASTING_DELAY));
 	}
 
 	private void finishUse(Player player, Item parentItem, Item targetItem) {
 		boolean success = extractAp(player, parentItem, targetItem);
+		if (success)
+			player.startCooldown(parentItem);
 		PacketSendUtility.broadcastPacket(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, success ? 1 : 2, 0), true);
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
@@ -48,7 +48,7 @@ public class ApExtractAction extends AbstractItemAction {
 			return false;
 		}
 
-		UseTarget type = null;
+		UseTarget type;
 		switch (targetItem.getItemTemplate().getItemGroup()) {
 			case SWORD:
 			case DAGGER:

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
@@ -7,7 +7,9 @@ import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.model.items.storage.Storage;
 import com.aionemu.gameserver.model.templates.item.Acquisition;
 import com.aionemu.gameserver.model.templates.item.enums.ItemGroup;
+import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.services.abyss.AbyssPointsService;
+import com.aionemu.gameserver.utils.PacketSendUtility;
 import com.aionemu.gameserver.utils.audit.AuditLogger;
 
 /**
@@ -22,12 +24,21 @@ public class ApExtractAction extends AbstractItemAction {
 
 	@Override
 	public boolean canAct(Player player, Item parentItem, Item targetItem, Object... params) {
-		if (targetItem == null || !targetItem.canApExtract())
+		if (targetItem == null || !targetItem.canApExtract()) {
+			if (targetItem != null)
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_CANNOT(targetItem.getL10n()));
 			return false;
-		if (parentItem.getItemTemplate().getLevel() < targetItem.getItemTemplate().getLevel())
+		}
+		if (parentItem.getItemTemplate().getLevel() < targetItem.getItemTemplate().getLevel()) {
+			PacketSendUtility.sendPacket(player,
+				SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_LEVEL(targetItem.getL10n(), targetItem.getItemTemplate().getLevel()));
 			return false;
-		if (parentItem.getItemTemplate().getItemQuality() != targetItem.getItemTemplate().getItemQuality())
+		}
+		if (parentItem.getItemTemplate().getItemQuality() != targetItem.getItemTemplate().getItemQuality()) {
+			PacketSendUtility.sendPacket(player,
+				SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_QUALITY(parentItem.getL10n(), targetItem.getL10n()));
 			return false;
+		}
 
 		// TODO: ApExtractTarget.OTHER, ApExtractTarget.ALL. Find out what should go there
 
@@ -88,11 +99,19 @@ public class ApExtractAction extends AbstractItemAction {
 					type = UseTarget.WING;
 					break;
 				}
+				PacketSendUtility.sendPacket(player,
+					SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_TARGET_ITEM_CATEGORY(parentItem.getL10n(), targetItem.getL10n()));
 				return false;
 			default:
+				PacketSendUtility.sendPacket(player,
+					SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_TARGET_ITEM_CATEGORY(parentItem.getL10n(), targetItem.getL10n()));
 				return false;
 		}
-		return (target == UseTarget.EQUIPMENT || target == type);
+		if (target == UseTarget.EQUIPMENT || target == type)
+			return true;
+		PacketSendUtility.sendPacket(player,
+			SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_TARGET_ITEM_CATEGORY(parentItem.getL10n(), targetItem.getL10n()));
+		return false;
 	}
 
 	@Override
@@ -104,8 +123,10 @@ public class ApExtractAction extends AbstractItemAction {
 		Storage inventory = player.getInventory();
 
 		if (inventory.delete(targetItem) != null) {
-			if (inventory.decreaseByObjectId(parentItem.getObjectId(), 1))
-				AbyssPointsService.addAp(player, ap);
+			if (inventory.decreaseByObjectId(parentItem.getObjectId(), 1)) {
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_ITEM_SUCCEED(targetItem.getL10n()));
+				AbyssPointsService.addAp(player, ap, SM_SYSTEM_MESSAGE::STR_MSG_AP_DECOMPOSE_ITEM_SUCCEED_AP);
+			}
 		} else
 			AuditLogger.log(player, "possibly using item AP extraction hack");
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
@@ -118,11 +118,12 @@ public class ApExtractAction extends AbstractItemAction {
 				return false;
 		}
 		// EQUIPMENT is a shorthand for "any of WEAPON/ARMOR/ACCESSORY/WING", confirmed on retail it does NOT also match OTHER
-		if (target == UseTarget.ALL || target == type || (target == UseTarget.EQUIPMENT && type != UseTarget.OTHER))
-			return true;
-		PacketSendUtility.sendPacket(player,
-			SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_TARGET_ITEM_CATEGORY(parentItem.getL10n(), targetItem.getL10n()));
-		return false;
+		if (target != UseTarget.ALL && target != type && !(target == UseTarget.EQUIPMENT && type != UseTarget.OTHER)) {
+			PacketSendUtility.sendPacket(player,
+				SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_TARGET_ITEM_CATEGORY(parentItem.getL10n(), targetItem.getL10n()));
+			return false;
+		}
+		return true;
 	}
 
 	@Override
@@ -163,13 +164,11 @@ public class ApExtractAction extends AbstractItemAction {
 		if (acquisition == null || acquisition.getRequiredAp() == 0)
 			return false;
 		Storage inventory = player.getInventory();
-		if (inventory.getItemByObjId(parentItem.getObjectId()) == null || inventory.getItemByObjId(targetItem.getObjectId()) == null) {
+		if (!inventory.decreaseByObjectId(parentItem.getObjectId(), 1) || inventory.delete(targetItem) == null) {
 			AuditLogger.log(player, "possibly using item AP extraction hack");
 			return false;
 		}
 		int ap = (int) (acquisition.getRequiredAp() * rate);
-		inventory.decreaseByObjectId(parentItem.getObjectId(), 1);
-		inventory.delete(targetItem);
 		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_ITEM_SUCCEED(targetItem.getL10n()));
 		AbyssPointsService.addAp(player, ap, SM_SYSTEM_MESSAGE::STR_MSG_AP_DECOMPOSE_ITEM_SUCCEED_AP);
 		return true;

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
@@ -134,7 +134,6 @@ public class ApExtractAction extends AbstractItemAction {
 			@Override
 			public void abort() {
 				player.getController().cancelUseItem(false);
-				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_ITEM_CANCELED(targetItem.getL10n()));
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 2, 0), true);
@@ -145,6 +144,7 @@ public class ApExtractAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
+			player.startCooldown(parentItem);
 			finishUse(player, parentItem, targetItem);
 		}, CASTING_DELAY));
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
@@ -2,20 +2,25 @@ package com.aionemu.gameserver.model.templates.item.actions;
 
 import javax.xml.bind.annotation.XmlAttribute;
 
+import com.aionemu.gameserver.controllers.observer.ItemUseObserver;
+import com.aionemu.gameserver.model.TaskId;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.model.items.storage.Storage;
 import com.aionemu.gameserver.model.templates.item.Acquisition;
-import com.aionemu.gameserver.model.templates.item.enums.ItemGroup;
+import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.services.abyss.AbyssPointsService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
+import com.aionemu.gameserver.utils.ThreadPoolManager;
 import com.aionemu.gameserver.utils.audit.AuditLogger;
 
 /**
  * @author Rolandas, Luzien
  */
 public class ApExtractAction extends AbstractItemAction {
+
+	private static final int CASTING_DELAY = 3000;
 
 	@XmlAttribute
 	protected UseTarget target;
@@ -29,9 +34,12 @@ public class ApExtractAction extends AbstractItemAction {
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_CANNOT(targetItem.getL10n()));
 			return false;
 		}
+		if (targetItem.isEquipped()) {
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_EQUIPED());
+			return false;
+		}
 		if (parentItem.getItemTemplate().getLevel() < targetItem.getItemTemplate().getLevel()) {
-			PacketSendUtility.sendPacket(player,
-				SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_LEVEL(targetItem.getL10n(), targetItem.getItemTemplate().getLevel()));
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_LEVEL(parentItem.getL10n(), targetItem.getL10n()));
 			return false;
 		}
 		if (parentItem.getItemTemplate().getItemQuality() != targetItem.getItemTemplate().getItemQuality()) {
@@ -39,8 +47,6 @@ public class ApExtractAction extends AbstractItemAction {
 				SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_QUALITY(parentItem.getL10n(), targetItem.getL10n()));
 			return false;
 		}
-
-		// TODO: ApExtractTarget.OTHER, ApExtractTarget.ALL. Find out what should go there
 
 		UseTarget type = null;
 		switch (targetItem.getItemTemplate().getItemGroup()) {
@@ -59,6 +65,11 @@ public class ApExtractAction extends AbstractItemAction {
 			case CANNON:
 				type = UseTarget.WEAPON;
 				break;
+			case TORSO:
+			case PANTS:
+			case SHOULDER:
+			case GLOVE:
+			case SHOES:
 			case RB_TORSO:
 			case RB_PANTS:
 			case RB_SHOULDER:
@@ -94,20 +105,20 @@ public class ApExtractAction extends AbstractItemAction {
 			case HEAD:
 				type = UseTarget.ACCESSORY;
 				break;
+			case WING:
+				type = UseTarget.WING;
+				break;
 			case NONE:
-				if (targetItem.getItemTemplate().getItemGroup() == ItemGroup.WING) {
-					type = UseTarget.WING;
-					break;
-				}
-				PacketSendUtility.sendPacket(player,
-					SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_TARGET_ITEM_CATEGORY(parentItem.getL10n(), targetItem.getL10n()));
-				return false;
+				// e.g. non-equipment "junk" items retail still allows AP extraction on (confirmed only matched by the OTHER/ALL target types)
+				type = UseTarget.OTHER;
+				break;
 			default:
 				PacketSendUtility.sendPacket(player,
 					SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_TARGET_ITEM_CATEGORY(parentItem.getL10n(), targetItem.getL10n()));
 				return false;
 		}
-		if (target == UseTarget.EQUIPMENT || target == type)
+		// EQUIPMENT is a shorthand for "any of WEAPON/ARMOR/ACCESSORY/WING", confirmed on retail it does NOT also match OTHER
+		if (target == UseTarget.ALL || target == type || (target == UseTarget.EQUIPMENT && type != UseTarget.OTHER))
 			return true;
 		PacketSendUtility.sendPacket(player,
 			SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_TARGET_ITEM_CATEGORY(parentItem.getL10n(), targetItem.getL10n()));
@@ -116,19 +127,45 @@ public class ApExtractAction extends AbstractItemAction {
 
 	@Override
 	public void act(Player player, Item parentItem, Item targetItem, Object... params) {
+		PacketSendUtility.broadcastPacket(player,
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), CASTING_DELAY, 0, 0), true);
+
+		ItemUseObserver observer = new ItemUseObserver() {
+
+			@Override
+			public void abort() {
+				player.getController().cancelUseItem(false);
+				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_ITEM_CANCELED(targetItem.getL10n()));
+				PacketSendUtility.broadcastPacket(player,
+					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 2, 0), true);
+				player.getObserveController().removeObserver(this);
+			}
+
+		};
+		player.getObserveController().attach(observer);
+		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
+			player.getObserveController().removeObserver(observer);
+			finishUse(player, parentItem, targetItem);
+		}, CASTING_DELAY));
+	}
+
+	private void finishUse(Player player, Item parentItem, Item targetItem) {
+		if (!canAct(player, parentItem, targetItem))
+			return;
 		Acquisition acquisition = targetItem.getItemTemplate().getAcquisition();
 		if (acquisition == null || acquisition.getRequiredAp() == 0)
 			return;
-		int ap = (int) (acquisition.getRequiredAp() * rate);
 		Storage inventory = player.getInventory();
-
-		if (inventory.delete(targetItem) != null) {
-			if (inventory.decreaseByObjectId(parentItem.getObjectId(), 1)) {
-				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_ITEM_SUCCEED(targetItem.getL10n()));
-				AbyssPointsService.addAp(player, ap, SM_SYSTEM_MESSAGE::STR_MSG_AP_DECOMPOSE_ITEM_SUCCEED_AP);
-			}
-		} else
+		if (inventory.getItemByObjId(parentItem.getObjectId()) == null || inventory.getItemByObjId(targetItem.getObjectId()) == null) {
 			AuditLogger.log(player, "possibly using item AP extraction hack");
+			return;
+		}
+		int ap = (int) (acquisition.getRequiredAp() * rate);
+		inventory.decreaseByObjectId(parentItem.getObjectId(), 1);
+		inventory.delete(targetItem);
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_ITEM_SUCCEED(targetItem.getL10n()));
+		AbyssPointsService.addAp(player, ap, SM_SYSTEM_MESSAGE::STR_MSG_AP_DECOMPOSE_ITEM_SUCCEED_AP);
 	}
 
 	public UseTarget getTarget() {

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
@@ -42,7 +42,7 @@ public class ApExtractAction extends AbstractItemAction {
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_LEVEL(parentItem.getL10n(), targetItem.getL10n()));
 			return false;
 		}
-		if (parentItem.getItemTemplate().getItemQuality() != targetItem.getItemTemplate().getItemQuality()) {
+		if (parentItem.getItemTemplate().getItemQuality().getQualityId() < targetItem.getItemTemplate().getItemQuality().getQualityId()) {
 			PacketSendUtility.sendPacket(player,
 				SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_QUALITY(parentItem.getL10n(), targetItem.getL10n()));
 			return false;
@@ -113,14 +113,12 @@ public class ApExtractAction extends AbstractItemAction {
 				type = UseTarget.OTHER;
 				break;
 			default:
-				PacketSendUtility.sendPacket(player,
-					SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_TARGET_ITEM_CATEGORY(parentItem.getL10n(), targetItem.getL10n()));
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_CANNOT(targetItem.getL10n()));
 				return false;
 		}
 		// EQUIPMENT is a shorthand for "any of WEAPON/ARMOR/ACCESSORY/WING", confirmed on retail it does NOT also match OTHER
 		if (target != UseTarget.ALL && target != type && !(target == UseTarget.EQUIPMENT && type != UseTarget.OTHER)) {
-			PacketSendUtility.sendPacket(player,
-				SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_WRONG_TARGET_ITEM_CATEGORY(parentItem.getL10n(), targetItem.getL10n()));
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_CANNOT(targetItem.getL10n()));
 			return false;
 		}
 		return true;

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
@@ -151,21 +151,28 @@ public class ApExtractAction extends AbstractItemAction {
 	}
 
 	private void finishUse(Player player, Item parentItem, Item targetItem) {
+		boolean success = extractAp(player, parentItem, targetItem);
+		PacketSendUtility.broadcastPacket(player,
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, success ? 1 : 2, 0), true);
+	}
+
+	private boolean extractAp(Player player, Item parentItem, Item targetItem) {
 		if (!canAct(player, parentItem, targetItem))
-			return;
+			return false;
 		Acquisition acquisition = targetItem.getItemTemplate().getAcquisition();
 		if (acquisition == null || acquisition.getRequiredAp() == 0)
-			return;
+			return false;
 		Storage inventory = player.getInventory();
 		if (inventory.getItemByObjId(parentItem.getObjectId()) == null || inventory.getItemByObjId(targetItem.getObjectId()) == null) {
 			AuditLogger.log(player, "possibly using item AP extraction hack");
-			return;
+			return false;
 		}
 		int ap = (int) (acquisition.getRequiredAp() * rate);
 		inventory.decreaseByObjectId(parentItem.getObjectId(), 1);
 		inventory.delete(targetItem);
 		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_ITEM_SUCCEED(targetItem.getL10n()));
 		AbyssPointsService.addAp(player, ap, SM_SYSTEM_MESSAGE::STR_MSG_AP_DECOMPOSE_ITEM_SUCCEED_AP);
+		return true;
 	}
 
 	public UseTarget getTarget() {

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AssemblyItemAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AssemblyItemAction.java
@@ -68,8 +68,11 @@ public class AssemblyItemAction extends AbstractItemAction {
 			AssemblyItem assemblyItem = getAssemblyItem();
 			Map<Integer, Long> requiredCounts = assemblyItem.getParts().stream().collect(Collectors.groupingBy(id -> id, Collectors.counting()));
 			for (Map.Entry<Integer, Long> requiredCount : requiredCounts.entrySet()) {
-				if (player.getInventory().getItemCountByItemId(requiredCount.getKey()) < requiredCount.getValue())
+				if (player.getInventory().getItemCountByItemId(requiredCount.getKey()) < requiredCount.getValue()) {
+					PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem
+						.getItemTemplate().getTemplateId(), 0, 2, 0), true);
 					return;
+				}
 			}
 			for (Integer itemId : assemblyItem.getParts()) {
 				player.getInventory().decreaseByItemId(itemId, 1);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AssemblyItemAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AssemblyItemAction.java
@@ -69,7 +69,6 @@ public class AssemblyItemAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			player.startCooldown(parentItem);
 			finishUse(player, parentItem);
 		}, castingDelay));
 	}
@@ -84,6 +83,7 @@ public class AssemblyItemAction extends AbstractItemAction {
 				return;
 			}
 		}
+		player.startCooldown(parentItem);
 		for (Integer itemId : assemblyItem.getParts()) {
 			player.getInventory().decreaseByItemId(itemId, 1);
 		}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AssemblyItemAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AssemblyItemAction.java
@@ -1,5 +1,8 @@
 package com.aionemu.gameserver.model.templates.item.actions;
 
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -63,10 +66,13 @@ public class AssemblyItemAction extends AbstractItemAction {
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
 			AssemblyItem assemblyItem = getAssemblyItem();
-			for (Integer itemId : assemblyItem.getParts()) {
-				if (!player.getInventory().decreaseByItemId(itemId, 1)) {
+			Map<Integer, Long> requiredCounts = assemblyItem.getParts().stream().collect(Collectors.groupingBy(id -> id, Collectors.counting()));
+			for (Map.Entry<Integer, Long> requiredCount : requiredCounts.entrySet()) {
+				if (player.getInventory().getItemCountByItemId(requiredCount.getKey()) < requiredCount.getValue())
 					return;
-				}
+			}
+			for (Integer itemId : assemblyItem.getParts()) {
+				player.getInventory().decreaseByItemId(itemId, 1);
 			}
 			PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem
 				.getItemTemplate().getTemplateId(), 0, 1, 0), true);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AssemblyItemAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AssemblyItemAction.java
@@ -49,7 +49,7 @@ public class AssemblyItemAction extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				player.getController().cancelTask(TaskId.ITEM_USE);
+				player.getController().cancelUseItem(false);
 				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem
@@ -60,25 +60,18 @@ public class AssemblyItemAction extends AbstractItemAction {
 		};
 
 		player.getObserveController().attach(observer);
-		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-
-				player.getObserveController().removeObserver(observer);
-				player.getController().cancelTask(TaskId.ITEM_USE);
-				AssemblyItem assemblyItem = getAssemblyItem();
-				for (Integer itemId : assemblyItem.getParts()) {
-					if (!player.getInventory().decreaseByItemId(itemId, 1)) {
-						return;
-					}
+		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
+			player.getObserveController().removeObserver(observer);
+			AssemblyItem assemblyItem = getAssemblyItem();
+			for (Integer itemId : assemblyItem.getParts()) {
+				if (!player.getInventory().decreaseByItemId(itemId, 1)) {
+					return;
 				}
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem
-					.getItemTemplate().getTemplateId(), 0, 1, 0), true);
-				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ASSEMBLY_ITEM_SUCCEEDED());
-				ItemService.addItem(player, assemblyItem.getId(), 1);
 			}
-
+			PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem
+				.getItemTemplate().getTemplateId(), 0, 1, 0), true);
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ASSEMBLY_ITEM_SUCCEEDED());
+			ItemService.addItem(player, assemblyItem.getId(), 1);
 		}, 1000));
 
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AssemblyItemAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AssemblyItemAction.java
@@ -46,14 +46,18 @@ public class AssemblyItemAction extends AbstractItemAction {
 
 	@Override
 	public void act(final Player player, final Item parentItem, Item targetItem, Object... params) {
+		int castingDelay = parentItem.getItemTemplate().getCastingDelay();
+		if (castingDelay <= 0) {
+			finishUse(player, parentItem);
+			return;
+		}
 		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(),
-			1000, 0, 0), true);
+			castingDelay, 0, 0), true);
 		final ItemUseObserver observer = new ItemUseObserver() {
 
 			@Override
 			public void abort() {
 				player.getController().cancelUseItem(false);
-				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ASSEMBLY_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem
 					.getItemTemplate().getTemplateId(), 0, 2, 0), true);
@@ -65,25 +69,29 @@ public class AssemblyItemAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			AssemblyItem assemblyItem = getAssemblyItem();
-			Map<Integer, Long> requiredCounts = assemblyItem.getParts().stream().collect(Collectors.groupingBy(id -> id, Collectors.counting()));
-			for (Map.Entry<Integer, Long> requiredCount : requiredCounts.entrySet()) {
-				if (player.getInventory().getItemCountByItemId(requiredCount.getKey()) < requiredCount.getValue()) {
-					PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem
-						.getItemTemplate().getTemplateId(), 0, 2, 0), true);
-					return;
-				}
-			}
-			for (Integer itemId : assemblyItem.getParts()) {
-				player.getInventory().decreaseByItemId(itemId, 1);
-			}
-			PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem
-				.getItemTemplate().getTemplateId(), 0, 1, 0), true);
-			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
-			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ASSEMBLY_ITEM_SUCCEEDED());
-			ItemService.addItem(player, assemblyItem.getId(), 1);
-		}, 1000));
+			player.startCooldown(parentItem);
+			finishUse(player, parentItem);
+		}, castingDelay));
+	}
 
+	private void finishUse(Player player, Item parentItem) {
+		AssemblyItem assemblyItem = getAssemblyItem();
+		Map<Integer, Long> requiredCounts = assemblyItem.getParts().stream().collect(Collectors.groupingBy(id -> id, Collectors.counting()));
+		for (Map.Entry<Integer, Long> requiredCount : requiredCounts.entrySet()) {
+			if (player.getInventory().getItemCountByItemId(requiredCount.getKey()) < requiredCount.getValue()) {
+				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem
+					.getItemTemplate().getTemplateId(), 0, 2, 0), true);
+				return;
+			}
+		}
+		for (Integer itemId : assemblyItem.getParts()) {
+			player.getInventory().decreaseByItemId(itemId, 1);
+		}
+		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem
+			.getItemTemplate().getTemplateId(), 0, 1, 0), true);
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ASSEMBLY_ITEM_SUCCEEDED());
+		ItemService.addItem(player, assemblyItem.getId(), 1);
 	}
 
 	public AssemblyItem getAssemblyItem() {

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AssemblyItemAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AssemblyItemAction.java
@@ -51,7 +51,7 @@ public class AssemblyItemAction extends AbstractItemAction {
 			public void abort() {
 				player.getController().cancelUseItem(false);
 				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
-				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ASSEMBLY_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem
 					.getItemTemplate().getTemplateId(), 0, 2, 0), true);
 				player.getObserveController().removeObserver(this);
@@ -70,6 +70,7 @@ public class AssemblyItemAction extends AbstractItemAction {
 			}
 			PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem
 				.getItemTemplate().getTemplateId(), 0, 1, 0), true);
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ASSEMBLY_ITEM_SUCCEEDED());
 			ItemService.addItem(player, assemblyItem.getId(), 1);
 		}, 1000));

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ChargeAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ChargeAction.java
@@ -29,7 +29,14 @@ public class ChargeAction extends AbstractItemAction {
 
 	@Override
 	public boolean canAct(Player player, Item parentItem, Item targetItem, Object... params) {
-		return !ItemChargeService.filterItemsToCondition(player, null, parentItem.getImprovement().getChargeWay()).isEmpty();
+		int chargeWay = parentItem.getImprovement().getChargeWay();
+		if (!ItemChargeService.filterItemsToCondition(player, null, chargeWay).isEmpty())
+			return true;
+		if (chargeWay == 1)
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_CHARGE_ALL_FAIL_NO_CHARGEABLE_EQUIPMENT());
+		else
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_CHARGE2_ALL_FAIL_NO_CHARGEABLE_EQUIPMENT());
+		return false;
 	}
 
 	@Override
@@ -71,6 +78,7 @@ public class ChargeAction extends AbstractItemAction {
 		if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1))
 			return;
 		ItemChargeService.chargeItems(player, conditioningItems, maxChargeLevel, false, false);
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 	}
 
 }

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ChargeAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ChargeAction.java
@@ -97,6 +97,12 @@ public class ChargeAction extends AbstractItemAction {
 	}
 
 	private void finishUse(Player player, Item parentItem, Item targetItem) {
+		if (targetItem != null && player.getInventory().getItemByObjId(targetItem.getObjectId()) == null && !targetItem.isEquipped()) {
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ENCHANT_ITEM_NO_TARGET_ITEM());
+			PacketSendUtility.broadcastPacket(player,
+				new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 2, 0), true);
+			return;
+		}
 		PacketSendUtility.broadcastPacket(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 0), true);
 		Collection<Item> conditioningItems = getConditioningItems(player, parentItem, targetItem);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ChargeAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ChargeAction.java
@@ -1,6 +1,7 @@
 package com.aionemu.gameserver.model.templates.item.actions;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -11,6 +12,7 @@ import com.aionemu.gameserver.controllers.observer.ItemUseObserver;
 import com.aionemu.gameserver.model.TaskId;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
+import com.aionemu.gameserver.model.items.ChargeInfo;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.services.item.ItemChargeService;
@@ -29,22 +31,45 @@ public class ChargeAction extends AbstractItemAction {
 
 	@Override
 	public boolean canAct(Player player, Item parentItem, Item targetItem, Object... params) {
+		return !getConditioningItems(player, parentItem, targetItem).isEmpty();
+	}
+
+	/**
+	 * @return The items to condition (just {@code targetItem} if one was selected), sending the appropriate "not chargeable" message if there are none.
+	 */
+	private Collection<Item> getConditioningItems(Player player, Item parentItem, Item targetItem) {
 		int chargeWay = parentItem.getImprovement().getChargeWay();
-		if (!ItemChargeService.filterItemsToCondition(player, null, chargeWay).isEmpty())
-			return true;
-		if (chargeWay == 1)
-			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_CHARGE_ALL_FAIL_NO_CHARGEABLE_EQUIPMENT());
-		else
-			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_CHARGE2_ALL_FAIL_NO_CHARGEABLE_EQUIPMENT());
-		return false;
+		if (targetItem != null) {
+			if (targetItem.getImprovement() == null || targetItem.getImprovement().getChargeWay() != chargeWay
+				|| targetItem.calculateAvailableChargeLevel(player) == 0) {
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_CHARGE_FAIL_NOT_CHARGEABLE(targetItem.getL10n()));
+				return Collections.emptyList();
+			}
+			int achievableLevel = ItemChargeService.calculateMaxChargeLevelBasedOnRank(player, targetItem, maxChargeLevel);
+			int achievableChargePoints = achievableLevel == 1 ? ChargeInfo.LEVEL1 : ChargeInfo.LEVEL2;
+			if (targetItem.getChargePoints() >= achievableChargePoints) {
+				PacketSendUtility.sendPacket(player,
+					SM_SYSTEM_MESSAGE.STR_MSG_ITEM_CHARGE_FAIL_ALREADY_CHARGED(targetItem.getL10n(), String.valueOf(achievableLevel)));
+				return Collections.emptyList();
+			}
+			return Collections.singletonList(targetItem);
+		}
+		Collection<Item> conditioningItems = ItemChargeService.filterItemsToCondition(player, null, chargeWay);
+		if (conditioningItems.isEmpty()) {
+			if (chargeWay == 1)
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_CHARGE_ALL_FAIL_NO_CHARGEABLE_EQUIPMENT());
+			else
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_CHARGE2_ALL_FAIL_NO_CHARGEABLE_EQUIPMENT());
+		}
+		return conditioningItems;
 	}
 
 	@Override
-	public void act(final Player player, Item parentItem, Item targetItem, Object... params) {
+	public void act(final Player player, Item parentItem, final Item targetItem, Object... params) {
 		int chargeWay = parentItem.getImprovement().getChargeWay();
 		int castingDelay = parentItem.getItemTemplate().getCastingDelay();
 		if (castingDelay <= 0) {
-			finishUse(player, parentItem, chargeWay);
+			finishUse(player, parentItem, targetItem);
 			return;
 		}
 		PacketSendUtility.broadcastPacket(player,
@@ -67,18 +92,22 @@ public class ChargeAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			finishUse(player, parentItem, chargeWay);
+			finishUse(player, parentItem, targetItem);
 		}, castingDelay));
 	}
 
-	private void finishUse(Player player, Item parentItem, int chargeWay) {
+	private void finishUse(Player player, Item parentItem, Item targetItem) {
 		PacketSendUtility.broadcastPacket(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 0), true);
+		Collection<Item> conditioningItems = getConditioningItems(player, parentItem, targetItem);
+		if (conditioningItems.isEmpty())
+			return;
 		if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1))
 			return;
-		// re-evaluate at finish time instead of reusing the collection from cast-start, in case equipment changed during the cast
-		Collection<Item> conditioningItems = ItemChargeService.filterItemsToCondition(player, null, chargeWay);
-		ItemChargeService.chargeItems(player, conditioningItems, maxChargeLevel, false, false);
+		if (targetItem != null) // avoid the "Successfully conditioned equipped item(s)" bulk summary for a single targeted item
+			ItemChargeService.chargeItem(player, targetItem, maxChargeLevel, false, false);
+		else
+			ItemChargeService.chargeItems(player, conditioningItems, maxChargeLevel, false, false);
 		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 	}
 

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ChargeAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ChargeAction.java
@@ -92,7 +92,6 @@ public class ChargeAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			player.startCooldown(parentItem);
 			finishUse(player, parentItem, targetItem);
 		}, castingDelay));
 	}
@@ -111,6 +110,7 @@ public class ChargeAction extends AbstractItemAction {
 			return;
 		if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1))
 			return;
+		player.startCooldown(parentItem);
 		if (targetItem != null) // avoid the "Successfully conditioned equipped item(s)" bulk summary for a single targeted item
 			ItemChargeService.chargeItem(player, targetItem, maxChargeLevel, false, false);
 		else

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ChargeAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ChargeAction.java
@@ -42,10 +42,9 @@ public class ChargeAction extends AbstractItemAction {
 	@Override
 	public void act(final Player player, Item parentItem, Item targetItem, Object... params) {
 		int chargeWay = parentItem.getImprovement().getChargeWay();
-		Collection<Item> conditioningItems = ItemChargeService.filterItemsToCondition(player, null, chargeWay);
 		int castingDelay = parentItem.getItemTemplate().getCastingDelay();
 		if (castingDelay <= 0) {
-			finishUse(player, parentItem, conditioningItems);
+			finishUse(player, parentItem, chargeWay);
 			return;
 		}
 		PacketSendUtility.broadcastPacket(player,
@@ -68,15 +67,17 @@ public class ChargeAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			finishUse(player, parentItem, conditioningItems);
+			finishUse(player, parentItem, chargeWay);
 		}, castingDelay));
 	}
-	
-	private void finishUse(Player player, Item parentItem, Collection<Item> conditioningItems) {
+
+	private void finishUse(Player player, Item parentItem, int chargeWay) {
 		PacketSendUtility.broadcastPacket(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 0), true);
 		if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1))
 			return;
+		// re-evaluate at finish time instead of reusing the collection from cast-start, in case equipment changed during the cast
+		Collection<Item> conditioningItems = ItemChargeService.filterItemsToCondition(player, null, chargeWay);
 		ItemChargeService.chargeItems(player, conditioningItems, maxChargeLevel, false, false);
 		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ChargeAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ChargeAction.java
@@ -92,6 +92,7 @@ public class ChargeAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
+			player.startCooldown(parentItem);
 			finishUse(player, parentItem, targetItem);
 		}, castingDelay));
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ChargeAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ChargeAction.java
@@ -36,14 +36,18 @@ public class ChargeAction extends AbstractItemAction {
 	public void act(final Player player, Item parentItem, Item targetItem, Object... params) {
 		int chargeWay = parentItem.getImprovement().getChargeWay();
 		Collection<Item> conditioningItems = ItemChargeService.filterItemsToCondition(player, null, chargeWay);
-
+		int castingDelay = parentItem.getItemTemplate().getCastingDelay();
+		if (castingDelay <= 0) {
+			finishUse(player, parentItem, conditioningItems);
+			return;
+		}
 		PacketSendUtility.broadcastPacket(player,
-			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 3000, 0, 0), true);
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), castingDelay, 0, 0), true);
 		ItemUseObserver observer = new ItemUseObserver() {
 
 			@Override
 			public void abort() {
-				player.getController().cancelTask(TaskId.ITEM_USE);
+				player.getController().cancelUseItem(false);
 				if (chargeWay == 1)
 					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_CHARGE_CANCELED());
 				else
@@ -57,12 +61,16 @@ public class ChargeAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			PacketSendUtility.broadcastPacket(player,
-				new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 0), true);
-			if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1))
-				return;
-			ItemChargeService.chargeItems(player, conditioningItems, maxChargeLevel, false, false);
-		}, 3000));
+			finishUse(player, parentItem, conditioningItems);
+		}, castingDelay));
+	}
+	
+	private void finishUse(Player player, Item parentItem, Collection<Item> conditioningItems) {
+		PacketSendUtility.broadcastPacket(player,
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 0), true);
+		if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1))
+			return;
+		ItemChargeService.chargeItems(player, conditioningItems, maxChargeLevel, false, false);
 	}
 
 }

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/CompositionAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/CompositionAction.java
@@ -7,7 +7,9 @@ import javax.xml.bind.annotation.XmlType;
 import com.aionemu.commons.utils.Rnd;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
+import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.services.item.ItemService;
+import com.aionemu.gameserver.utils.PacketSendUtility;
 
 /**
  * Created with IntelliJ IDEA. User: pixfid Date: 7/14/13 Time: 5:18 PM
@@ -48,6 +50,7 @@ public class CompositionAction extends AbstractItemAction {
 		boolean result1 = player.getInventory().decreaseByItemId(first.getItemId(), 1);
 		boolean result2 = player.getInventory().decreaseByItemId(second.getItemId(), 1);
 		if (result && result1 && result2) {
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_COMPOUND_SUCCESS(second.getL10n(), first.getL10n()));
 			ItemService.addItem(player, getItemId(calcLevel(first.getItemTemplate().getLevel(), second.getItemTemplate().getLevel())), 1);
 		}
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/CompositionAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/CompositionAction.java
@@ -5,14 +5,9 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
 
 import com.aionemu.commons.utils.Rnd;
-import com.aionemu.gameserver.controllers.observer.ItemUseObserver;
-import com.aionemu.gameserver.model.TaskId;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.services.item.ItemService;
-import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * Created with IntelliJ IDEA. User: pixfid Date: 7/14/13 Time: 5:18 PM
@@ -45,45 +40,16 @@ public class CompositionAction extends AbstractItemAction {
 		if (first.getItemCount() < 1 || second.getItemCount() < 1)
 			return false;
 
-		if (first.getItemTemplate().getLevel() > 95 || second.getItemTemplate().getLevel() > 95)
-			return false;
-
-		return true;
+		return first.getItemTemplate().getLevel() <= 95 && second.getItemTemplate().getLevel() <= 95;
 	}
 
 	public void act(final Player player, final Item tools, final Item first, final Item second) {
-
-		PacketSendUtility.sendPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), tools.getObjectId(), tools.getItemTemplate()
-			.getTemplateId(), 5000, 0, 0));
-		player.getController().cancelTask(TaskId.ITEM_USE);
-
-		final ItemUseObserver observer = new ItemUseObserver() {
-
-			@Override
-			public void abort() {
-				player.getController().cancelTask(TaskId.ITEM_USE);
-				PacketSendUtility.sendPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), tools.getObjectId(), tools.getItemTemplate()
-					.getTemplateId(), 0, 2, 0));
-				player.getObserveController().removeObserver(this);
-			}
-		};
-		player.getObserveController().attach(observer);
-		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				player.getObserveController().removeObserver(observer);
-				boolean result = player.getInventory().decreaseByItemId(tools.getItemId(), 1);
-				boolean result1 = player.getInventory().decreaseByItemId(first.getItemId(), 1);
-				boolean result2 = player.getInventory().decreaseByItemId(second.getItemId(), 1);
-				if (result && result1 && result2) {
-					ItemService.addItem(player, getItemId(calcLevel(first.getItemTemplate().getLevel(), second.getItemTemplate().getLevel())), 1);
-				}
-				PacketSendUtility.sendPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), tools.getObjectId(), tools.getItemTemplate()
-					.getTemplateId(), 0, 1, 0));
-			}
-		}, 5000));
-
+		boolean result = player.getInventory().decreaseByItemId(tools.getItemId(), 1);
+		boolean result1 = player.getInventory().decreaseByItemId(first.getItemId(), 1);
+		boolean result2 = player.getInventory().decreaseByItemId(second.getItemId(), 1);
+		if (result && result1 && result2) {
+			ItemService.addItem(player, getItemId(calcLevel(first.getItemTemplate().getLevel(), second.getItemTemplate().getLevel())), 1);
+		}
 	}
 
 	private int calcLevel(int first, int second) {

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/CompositionAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/CompositionAction.java
@@ -1,9 +1,5 @@
 package com.aionemu.gameserver.model.templates.item.actions;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-
 import com.aionemu.commons.utils.Rnd;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
@@ -12,21 +8,12 @@ import com.aionemu.gameserver.services.item.ItemService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
 
 /**
- * Created with IntelliJ IDEA. User: pixfid Date: 7/14/13 Time: 5:18 PM
+ * Handles combining two enchantment stones into one via {@code CM_COMPOSITE_STONES}. Not part of the regular
+ * item-use flow (retail has no server-side marker for this on the combination tool item, the client alone knows to
+ * send this packet for it), so unlike other item actions this isn't XML-bound and isn't invoked through
+ * {@link AbstractItemAction}.
  */
-@XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "CompositionAction")
-public class CompositionAction extends AbstractItemAction {
-
-	@Override
-	public boolean canAct(Player player, Item parentItem, Item targetItem, Object... params) {
-		return false;
-	}
-
-	@Override
-	public void act(Player player, Item parentItem, Item targetItem, Object... params) {
-
-	}
+public class CompositionAction {
 
 	public boolean canAct(Player player, Item tools, Item first, Item second) {
 

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/CraftLearnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/CraftLearnAction.java
@@ -8,6 +8,7 @@ import javax.xml.bind.annotation.XmlType;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
+import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.services.RecipeService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
 
@@ -25,6 +26,7 @@ public class CraftLearnAction extends AbstractItemAction {
 	public void act(Player player, Item parentItem, Item targetItem, Object... params) {
 		if (player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1)) {
 			if (RecipeService.addRecipe(player, recipeid, false)) {
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 				PacketSendUtility.sendPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate()
 					.getTemplateId()));
 			}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/CraftLearnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/CraftLearnAction.java
@@ -24,12 +24,13 @@ public class CraftLearnAction extends AbstractItemAction {
 
 	@Override
 	public void act(Player player, Item parentItem, Item targetItem, Object... params) {
-		if (player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1)) {
-			if (RecipeService.addRecipe(player, recipeid, false)) {
-				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
-				PacketSendUtility.sendPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate()
-					.getTemplateId()));
-			}
+		if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1))
+			return;
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
+		// client shows the "you learned" toast from this
+		if (RecipeService.addRecipe(player, recipeid, false)) {
+			PacketSendUtility.sendPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate()
+				.getTemplateId()));
 		}
 	}
 

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/CraftLearnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/CraftLearnAction.java
@@ -23,7 +23,6 @@ public class CraftLearnAction extends AbstractItemAction {
 
 	@Override
 	public void act(Player player, Item parentItem, Item targetItem, Object... params) {
-		player.getController().cancelUseItem();
 		if (player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1)) {
 			if (RecipeService.addRecipe(player, recipeid, false)) {
 				PacketSendUtility.sendPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate()

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/DecomposeAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/DecomposeAction.java
@@ -173,7 +173,7 @@ public class DecomposeAction extends AbstractItemAction {
 	private void finishUse(final Player player, Item parentItem, Item targetItem, ExtractedItemsCollection selectedCollection) {
 		boolean validAction = postValidate(player, parentItem, targetItem);
 		if (validAction) {
-			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_SUCCEED(parentItem.getL10n()));
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_UNCOMPRESS_COMPRESSED_ITEM_SUCCEEDED(parentItem.getL10n()));
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 			for (ResultedItem resultItem : selectedCollection.getItems()) {
 				if (resultItem.isObtainableFor(player)) {

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/DecomposeAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/DecomposeAction.java
@@ -37,7 +37,6 @@ import com.aionemu.gameserver.utils.ThreadPoolManager;
 public class DecomposeAction extends AbstractItemAction {
 
 	private static final Logger log = LoggerFactory.getLogger(DecomposeAction.class);
-	public static final int USAGE_DELAY = 3000;
 	private static Map<Race, int[]> chunkEarth = new HashMap<>();
 	private static Map<Race, int[]> chunkSand = new HashMap<>();
 	private static Map<Race, int[]> premiumOphidanRecipe = new HashMap<>();
@@ -101,8 +100,7 @@ public class DecomposeAction extends AbstractItemAction {
 	public boolean canAct(Player player, Item parentItem, Item targetItem, Object... params) {
 		if (player.isDead() || !player.isSpawned())
 			return false;
-		List<ExtractedItemsCollection> itemsCollections = null;
-		itemsCollections = DataManager.DECOMPOSABLE_ITEMS_DATA.getInfoByItemId(parentItem.getItemId());
+		List<ExtractedItemsCollection> itemsCollections = DataManager.DECOMPOSABLE_ITEMS_DATA.getInfoByItemId(parentItem.getItemId());
 		if (itemsCollections == null || itemsCollections.isEmpty()) {
 			if (DataManager.DECOMPOSABLE_ITEMS_DATA.getSelectableItems(parentItem.getItemId()) != null) // selectable decomposable
 				return true;
@@ -118,7 +116,6 @@ public class DecomposeAction extends AbstractItemAction {
 
 	@Override
 	public void act(final Player player, final Item parentItem, final Item targetItem, Object... params) {
-		player.getController().cancelUseItem();
 		Collection<ResultedItem> selectable = DataManager.DECOMPOSABLE_ITEMS_DATA.getSelectableItems(parentItem.getItemId());
 		if (selectable != null) {
 			selectable.removeIf(item -> !item.isObtainableFor(player));
@@ -129,20 +126,23 @@ public class DecomposeAction extends AbstractItemAction {
 		Collection<ExtractedItemsCollection> levelSuitableItems = filterItemsByLevel(player, itemsCollections);
 		final ExtractedItemsCollection selectedCollection = Chance.selectElement(levelSuitableItems);
 		if (selectedCollection.getRandomItems().isEmpty() && selectedCollection.getItems().stream().noneMatch(i -> i.isObtainableFor(player))) {
-			log.warn(
-				"Empty decomposable " + parentItem.getItemId() + " for " + player + ", class: " + player.getPlayerClass() + ", level: " + player.getLevel());
+			log.warn("Empty decomposable {} for {}, class: {}, level: {}", parentItem.getItemId(), player, player.getPlayerClass(), player.getLevel());
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_FAILED(parentItem.getL10n()));
 			return;
 		}
-
+		int castingDelay = parentItem.getItemTemplate().getCastingDelay();
+		if (castingDelay <= 0) {
+			finishUse(player, parentItem, targetItem, selectedCollection);
+			return;
+		}
 		PacketSendUtility.broadcastPacket(player,
-			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), USAGE_DELAY, 0, 0), true);
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), castingDelay, 0, 0), true);
 
 		final ItemUseObserver observer = new ItemUseObserver() {
 
 			@Override
 			public void abort() {
-				player.getController().cancelTask(TaskId.ITEM_USE);
+				player.getController().cancelUseItem(false);
 				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_CANCELED(parentItem.getL10n()));
 				PacketSendUtility.broadcastPacket(player,
@@ -153,218 +153,216 @@ public class DecomposeAction extends AbstractItemAction {
 		};
 
 		player.getObserveController().attach(observer);
-		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(new Runnable() {
+		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
+			player.getObserveController().removeObserver(observer);
+			finishUse(player, parentItem, targetItem, selectedCollection);
+		}, castingDelay));
+	}
 
-			@Override
-			public void run() {
-				player.getObserveController().removeObserver(observer);
-				boolean validAction = postValidate(player, parentItem);
-				if (validAction) {
-					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_SUCCEED(parentItem.getL10n()));
-					for (ResultedItem resultItem : selectedCollection.getItems()) {
-						if (resultItem.isObtainableFor(player)) {
-							int count = Rnd.get(resultItem.getMinCount(), resultItem.getMaxCount());
-							ItemService.addItem(player, resultItem.getItemId(), count, true,
-								new ItemUpdatePredicate(ItemAddType.DECOMPOSABLE, ItemUpdateType.INC_ITEM_COLLECT));
-						}
-					}
-					for (RandomItem randomItem : selectedCollection.getRandomItems()) {
-						RandomType randomType = randomItem.getType();
-						if (randomType != null) {
-							int randomId = 0;
-							int i = 0;
-							int itemLvl = parentItem.getItemTemplate().getLevel();
-							switch (randomItem.getType()) {
-								case ENCHANTMENT:
-									do {
-										randomId = 166000191 + Math.round(itemLvl / 100f) + Rnd.nextInt(4);
-										i++;
-										if (i > 50) {
-											randomId = 0;
-											break;
-										}
-									} while (!isValidItemId(randomId));
-									break;
-								case MANASTONE:
-								case MANASTONE_COMMON_GRADE_10:
-								case MANASTONE_COMMON_GRADE_20:
-								case MANASTONE_COMMON_GRADE_30:
-								case MANASTONE_COMMON_GRADE_40:
-								case MANASTONE_COMMON_GRADE_50:
-								case MANASTONE_COMMON_GRADE_60:
-								case MANASTONE_COMMON_GRADE_70:
-								case MANASTONE_RARE_GRADE_10:
-								case MANASTONE_RARE_GRADE_20:
-								case MANASTONE_RARE_GRADE_30:
-								case MANASTONE_RARE_GRADE_40:
-								case MANASTONE_RARE_GRADE_50:
-								case MANASTONE_RARE_GRADE_60:
-								case MANASTONE_RARE_GRADE_70:
-								case MANASTONE_LEGEND_GRADE_10:
-								case MANASTONE_LEGEND_GRADE_20:
-								case MANASTONE_LEGEND_GRADE_30:
-								case MANASTONE_LEGEND_GRADE_40:
-								case MANASTONE_LEGEND_GRADE_50:
-								case MANASTONE_LEGEND_GRADE_60:
-								case MANASTONE_LEGEND_GRADE_70:
-									if (randomType == RandomType.MANASTONE) // stone level near or equal to item level (if 1, near player level)
-										itemLvl = itemLvl % 10 == 0 ? itemLvl : ((int) Math.ceil((itemLvl == 1 ? player.getLevel() : itemLvl) / 10f) * 10);
-									else
-										itemLvl = randomType.getLevel();
-									List<ItemTemplate> stones = DataManager.ITEM_DATA.getManastones(itemLvl);
-									if (stones == null) {
-										log.warn("No lv" + itemLvl + " manastones found for decomposable random type " + randomItem.getType());
-										break;
-									}
-									if (randomType != RandomType.MANASTONE) {
-										final ItemQuality itemQuality;
-										if (randomType.name().contains("RARE"))
-											itemQuality = ItemQuality.RARE;
-										else if (randomType.name().contains("LEGEND"))
-											itemQuality = ItemQuality.LEGEND;
-										else
-											itemQuality = ItemQuality.COMMON;
-										List<ItemTemplate> selectedStones = stones.stream()
-											.filter(t -> t.getItemQuality() == itemQuality && !t.getName().contains(" MP ")).collect(Collectors.toList());
-										randomId = Rnd.get(selectedStones).getTemplateId();
-									} else {
-										List<ItemTemplate> selectedStones = stones.stream()
-											.filter(t -> t.getItemQuality() != ItemQuality.LEGEND && !t.getName().contains(" MP ")).collect(Collectors.toList());
-										randomId = Rnd.get(selectedStones).getTemplateId();
-									}
-									break;
-								case SPECIAL_MANASTONE_RARE_GRADE:
-								case SPECIAL_MANASTONE_LEGEND_GRADE:
-								case SPECIAL_MANASTONE_UNIQUE_GRADE:
-								case SPECIAL_MANASTONE_EPIC_GRADE:
-									List<ItemTemplate> ancientStones = DataManager.ITEM_DATA.getAncientManastones(randomType.getLevel());
-									if (ancientStones == null) {
-										log.warn("No ancient manastones found for decomposable random type " + randomItem.getType());
-										break;
-									}
-									final ItemQuality itemQuality;
-									if (randomType.name().contains("RARE"))
-										itemQuality = ItemQuality.RARE;
-									else if (randomType.name().contains("LEGEND"))
-										itemQuality = ItemQuality.LEGEND;
-									else if (randomType.name().contains("UNIQUE"))
-										itemQuality = ItemQuality.UNIQUE;
-									else if (randomType.name().contains("EPIC"))
-										itemQuality = ItemQuality.EPIC;
-									else
-										itemQuality = ItemQuality.COMMON;
-									List<ItemTemplate> selectedStones = ancientStones.stream()
-										.filter(t -> t.getItemQuality() == itemQuality && !t.getName().contains(" MP ")).collect(Collectors.toList());
-									randomId = Rnd.get(selectedStones).getTemplateId();
-									break;
-								case CHUNK_EARTH:
-									int[] earth = chunkEarth.get(player.getRace());
-									randomId = Rnd.get(earth);
-									break;
-								case CHUNK_SAND:
-									int[] sand = chunkSand.get(player.getRace());
-									randomId = Rnd.get(sand);
-									break;
-								case PREMIUM_OPHIDAN_RECIPE:
-									int[] recipe = premiumOphidanRecipe.get(player.getRace());
-									randomId = Rnd.get(recipe);
-									break;
-								case CHUNK_ROCK:
-									randomId = Rnd.get(chunkRock);
-									break;
-								case CHUNK_GEMSTONE:
-									randomId = Rnd.get(chunkGemstone);
-									break;
-								case SCROLLS:
-									randomId = Rnd.get(scrolls);
-									break;
-								case POTION:
-									randomId = Rnd.get(potion);
-									break;
-								case LESSER_POTIONS:
-									randomId = Rnd.get(lesser_potions);
-									break;
-								case POTION_50:
-									randomId = Rnd.get(potion_50);
-									break;
-								case ILLUSION_GODSTONE:
-									randomId = Rnd.get(illusion_godstones);
-									break;
-								case ANCIENTITEMS:
-									do {
-										randomId = Rnd.get(186000051, 186000066);
-										i++;
-										if (i > 50) {
-											randomId = 0;
-											break;
-										}
-									} while (!isValidItemId(randomId));
-									break;
-								case ANCIENT_CROWN:
-									do {
-										randomId = Rnd.get(186000051, 186000054);
-										i++;
-										if (i > 50) {
-											randomId = 0;
-											break;
-										}
-									} while (!isValidItemId(randomId));
-									break;
-								case ANCIENT_GOBLET:
-									do {
-										randomId = Rnd.get(186000055, 186000058);
-										i++;
-										if (i > 50) {
-											randomId = 0;
-											break;
-										}
-									} while (!isValidItemId(randomId));
-									break;
-								case ANCIENT_SEAL:
-									do {
-										randomId = Rnd.get(186000059, 186000062);
-										i++;
-										if (i > 50) {
-											randomId = 0;
-											break;
-										}
-									} while (!isValidItemId(randomId));
-									break;
-								case ANCIENT_ICON:
-									do {
-										randomId = Rnd.get(186000063, 186000066);
-										i++;
-										if (i > 50) {
-											randomId = 0;
-											break;
-										}
-									} while (!isValidItemId(randomId));
-									break;
-							}
-							if (randomId != 0) {
-								int count = Rnd.get(randomItem.getMinCount(), randomItem.getMaxCount());
-								ItemService.addItem(player, randomId, count, true,
-									new ItemUpdatePredicate(ItemAddType.DECOMPOSABLE, ItemUpdateType.INC_ITEM_COLLECT));
-							}
-						}
-					}
+	private boolean postValidate(Player player, Item parentItem, Item targetItem) {
+		if (!canAct(player, parentItem, targetItem)) {
+			return false;
+		}
+		if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1)) {
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_NO_TARGET_ITEM());
+			return false;
+		}
+		return true;
+	}
+
+	private void finishUse(final Player player, Item parentItem, Item targetItem, ExtractedItemsCollection selectedCollection) {
+		boolean validAction = postValidate(player, parentItem, targetItem);
+		if (validAction) {
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_SUCCEED(parentItem.getL10n()));
+			for (ResultedItem resultItem : selectedCollection.getItems()) {
+				if (resultItem.isObtainableFor(player)) {
+					int count = Rnd.get(resultItem.getMinCount(), resultItem.getMaxCount());
+					ItemService.addItem(player, resultItem.getItemId(), count, true,
+						new ItemUpdatePredicate(ItemAddType.DECOMPOSABLE, ItemUpdateType.INC_ITEM_COLLECT));
 				}
-				PacketSendUtility.broadcastPacket(player,
-					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, validAction ? 1 : 2, 0), true);
 			}
-
-			boolean postValidate(Player player, Item parentItem) {
-				if (!canAct(player, parentItem, targetItem)) {
-					return false;
+			for (RandomItem randomItem : selectedCollection.getRandomItems()) {
+				RandomType randomType = randomItem.getType();
+				if (randomType != null) {
+					int randomId = 0;
+					int i = 0;
+					int itemLvl = parentItem.getItemTemplate().getLevel();
+					switch (randomItem.getType()) {
+						case ENCHANTMENT:
+							do {
+								randomId = 166000191 + Math.round(itemLvl / 100f) + Rnd.nextInt(4);
+								i++;
+								if (i > 50) {
+									randomId = 0;
+									break;
+								}
+							} while (!isValidItemId(randomId));
+							break;
+						case MANASTONE:
+						case MANASTONE_COMMON_GRADE_10:
+						case MANASTONE_COMMON_GRADE_20:
+						case MANASTONE_COMMON_GRADE_30:
+						case MANASTONE_COMMON_GRADE_40:
+						case MANASTONE_COMMON_GRADE_50:
+						case MANASTONE_COMMON_GRADE_60:
+						case MANASTONE_COMMON_GRADE_70:
+						case MANASTONE_RARE_GRADE_10:
+						case MANASTONE_RARE_GRADE_20:
+						case MANASTONE_RARE_GRADE_30:
+						case MANASTONE_RARE_GRADE_40:
+						case MANASTONE_RARE_GRADE_50:
+						case MANASTONE_RARE_GRADE_60:
+						case MANASTONE_RARE_GRADE_70:
+						case MANASTONE_LEGEND_GRADE_10:
+						case MANASTONE_LEGEND_GRADE_20:
+						case MANASTONE_LEGEND_GRADE_30:
+						case MANASTONE_LEGEND_GRADE_40:
+						case MANASTONE_LEGEND_GRADE_50:
+						case MANASTONE_LEGEND_GRADE_60:
+						case MANASTONE_LEGEND_GRADE_70:
+							if (randomType == RandomType.MANASTONE) // stone level near or equal to item level (if 1, near player level)
+								itemLvl = itemLvl % 10 == 0 ? itemLvl : ((int) Math.ceil((itemLvl == 1 ? player.getLevel() : itemLvl) / 10f) * 10);
+							else
+								itemLvl = randomType.getLevel();
+							List<ItemTemplate> stones = DataManager.ITEM_DATA.getManastones(itemLvl);
+							if (stones == null) {
+								log.warn("No lv" + itemLvl + " manastones found for decomposable random type " + randomItem.getType());
+								break;
+							}
+							if (randomType != RandomType.MANASTONE) {
+								final ItemQuality itemQuality;
+								if (randomType.name().contains("RARE"))
+									itemQuality = ItemQuality.RARE;
+								else if (randomType.name().contains("LEGEND"))
+									itemQuality = ItemQuality.LEGEND;
+								else
+									itemQuality = ItemQuality.COMMON;
+								List<ItemTemplate> selectedStones = stones.stream().filter(t -> t.getItemQuality() == itemQuality && !t.getName().contains(" MP "))
+									.collect(Collectors.toList());
+								randomId = Rnd.get(selectedStones).getTemplateId();
+							} else {
+								List<ItemTemplate> selectedStones = stones.stream().filter(
+									t -> t.getItemQuality() != ItemQuality.LEGEND && !t.getName().contains(" MP ")).collect(Collectors.toList());
+								randomId = Rnd.get(selectedStones).getTemplateId();
+							}
+							break;
+						case SPECIAL_MANASTONE_RARE_GRADE:
+						case SPECIAL_MANASTONE_LEGEND_GRADE:
+						case SPECIAL_MANASTONE_UNIQUE_GRADE:
+						case SPECIAL_MANASTONE_EPIC_GRADE:
+							List<ItemTemplate> ancientStones = DataManager.ITEM_DATA.getAncientManastones(randomType.getLevel());
+							if (ancientStones == null) {
+								log.warn("No ancient manastones found for decomposable random type " + randomItem.getType());
+								break;
+							}
+							final ItemQuality itemQuality;
+							if (randomType.name().contains("RARE"))
+								itemQuality = ItemQuality.RARE;
+							else if (randomType.name().contains("LEGEND"))
+								itemQuality = ItemQuality.LEGEND;
+							else if (randomType.name().contains("UNIQUE"))
+								itemQuality = ItemQuality.UNIQUE;
+							else if (randomType.name().contains("EPIC"))
+								itemQuality = ItemQuality.EPIC;
+							else
+								itemQuality = ItemQuality.COMMON;
+							List<ItemTemplate> selectedStones = ancientStones.stream().filter(
+								t -> t.getItemQuality() == itemQuality && !t.getName().contains(" MP ")).collect(Collectors.toList());
+							randomId = Rnd.get(selectedStones).getTemplateId();
+							break;
+						case CHUNK_EARTH:
+							int[] earth = chunkEarth.get(player.getRace());
+							randomId = Rnd.get(earth);
+							break;
+						case CHUNK_SAND:
+							int[] sand = chunkSand.get(player.getRace());
+							randomId = Rnd.get(sand);
+							break;
+						case PREMIUM_OPHIDAN_RECIPE:
+							int[] recipe = premiumOphidanRecipe.get(player.getRace());
+							randomId = Rnd.get(recipe);
+							break;
+						case CHUNK_ROCK:
+							randomId = Rnd.get(chunkRock);
+							break;
+						case CHUNK_GEMSTONE:
+							randomId = Rnd.get(chunkGemstone);
+							break;
+						case SCROLLS:
+							randomId = Rnd.get(scrolls);
+							break;
+						case POTION:
+							randomId = Rnd.get(potion);
+							break;
+						case LESSER_POTIONS:
+							randomId = Rnd.get(lesser_potions);
+							break;
+						case POTION_50:
+							randomId = Rnd.get(potion_50);
+							break;
+						case ILLUSION_GODSTONE:
+							randomId = Rnd.get(illusion_godstones);
+							break;
+						case ANCIENTITEMS:
+							do {
+								randomId = Rnd.get(186000051, 186000066);
+								i++;
+								if (i > 50) {
+									randomId = 0;
+									break;
+								}
+							} while (!isValidItemId(randomId));
+							break;
+						case ANCIENT_CROWN:
+							do {
+								randomId = Rnd.get(186000051, 186000054);
+								i++;
+								if (i > 50) {
+									randomId = 0;
+									break;
+								}
+							} while (!isValidItemId(randomId));
+							break;
+						case ANCIENT_GOBLET:
+							do {
+								randomId = Rnd.get(186000055, 186000058);
+								i++;
+								if (i > 50) {
+									randomId = 0;
+									break;
+								}
+							} while (!isValidItemId(randomId));
+							break;
+						case ANCIENT_SEAL:
+							do {
+								randomId = Rnd.get(186000059, 186000062);
+								i++;
+								if (i > 50) {
+									randomId = 0;
+									break;
+								}
+							} while (!isValidItemId(randomId));
+							break;
+						case ANCIENT_ICON:
+							do {
+								randomId = Rnd.get(186000063, 186000066);
+								i++;
+								if (i > 50) {
+									randomId = 0;
+									break;
+								}
+							} while (!isValidItemId(randomId));
+							break;
+					}
+					if (randomId != 0) {
+						int count = Rnd.get(randomItem.getMinCount(), randomItem.getMaxCount());
+						ItemService.addItem(player, randomId, count, true, new ItemUpdatePredicate(ItemAddType.DECOMPOSABLE, ItemUpdateType.INC_ITEM_COLLECT));
+					}
 				}
-				if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1)) {
-					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_NO_TARGET_ITEM());
-					return false;
-				}
-				return true;
 			}
-
-		}, USAGE_DELAY));
+		}
+		PacketSendUtility.broadcastPacket(player,
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, validAction ? 1 : 2, 0), true);
 	}
 
 	/**

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/DecomposeAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/DecomposeAction.java
@@ -144,7 +144,7 @@ public class DecomposeAction extends AbstractItemAction {
 			public void abort() {
 				player.getController().cancelUseItem(false);
 				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
-				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_CANCELED(parentItem.getL10n()));
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_UNCOMPRESS_COMPRESSED_ITEM_CANCELED(parentItem.getL10n()));
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0), true);
 				player.getObserveController().removeObserver(this);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/DecomposeAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/DecomposeAction.java
@@ -154,7 +154,6 @@ public class DecomposeAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			player.startCooldown(parentItem);
 			finishUse(player, parentItem, targetItem, selectedCollection);
 		}, castingDelay));
 	}
@@ -173,6 +172,7 @@ public class DecomposeAction extends AbstractItemAction {
 	private void finishUse(final Player player, Item parentItem, Item targetItem, ExtractedItemsCollection selectedCollection) {
 		boolean validAction = postValidate(player, parentItem, targetItem);
 		if (validAction) {
+			player.startCooldown(parentItem);
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_UNCOMPRESS_COMPRESSED_ITEM_SUCCEEDED(parentItem.getL10n()));
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 			for (ResultedItem resultItem : selectedCollection.getItems()) {

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/DecomposeAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/DecomposeAction.java
@@ -174,6 +174,7 @@ public class DecomposeAction extends AbstractItemAction {
 		boolean validAction = postValidate(player, parentItem, targetItem);
 		if (validAction) {
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_SUCCEED(parentItem.getL10n()));
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 			for (ResultedItem resultItem : selectedCollection.getItems()) {
 				if (resultItem.isObtainableFor(player)) {
 					int count = Rnd.get(resultItem.getMinCount(), resultItem.getMaxCount());

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/DecomposeAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/DecomposeAction.java
@@ -143,7 +143,6 @@ public class DecomposeAction extends AbstractItemAction {
 			@Override
 			public void abort() {
 				player.getController().cancelUseItem(false);
-				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_UNCOMPRESS_COMPRESSED_ITEM_CANCELED(parentItem.getL10n()));
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0), true);
@@ -155,6 +154,7 @@ public class DecomposeAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
+			player.startCooldown(parentItem);
 			finishUse(player, parentItem, targetItem, selectedCollection);
 		}, castingDelay));
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/EmotionLearnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/EmotionLearnAction.java
@@ -55,6 +55,7 @@ public class EmotionLearnAction extends AbstractItemAction {
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), itemTemplate.getTemplateId()), true);
 
 		player.getEmotions().add(emotionId, minutes == 0 ? 0 : (int) (System.currentTimeMillis() / 1000) + minutes * 60, true);
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		player.getInventory().delete(parentItem);
 
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/EnchantItemAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/EnchantItemAction.java
@@ -111,8 +111,6 @@ public class EnchantItemAction extends AbstractItemAction {
 
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			player.startCooldown(parentItem);
-
 			if (player.getInventory().getItemByObjId(targetItem.getObjectId()) == null && !targetItem.isEquipped()) {
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ENCHANT_ITEM_NO_TARGET_ITEM());
 				PacketSendUtility.broadcastPacketAndReceive(player,
@@ -120,6 +118,7 @@ public class EnchantItemAction extends AbstractItemAction {
 				return;
 			}
 
+			player.startCooldown(parentItem);
 			if (isEnchantmentStone)
 				EnchantService.enchantItemAct(player, parentItem, targetItem, supplementItem, currentEnchant, isSuccess);
 			else // Manastone

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/EnchantItemAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/EnchantItemAction.java
@@ -6,7 +6,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 
 import com.aionemu.gameserver.configs.main.CustomConfig;
-import com.aionemu.gameserver.controllers.observer.StartMovingListener;
+import com.aionemu.gameserver.controllers.observer.ItemUseObserver;
 import com.aionemu.gameserver.model.TaskId;
 import com.aionemu.gameserver.model.enchants.EnchantmentStone;
 import com.aionemu.gameserver.model.gameobjects.Item;
@@ -89,21 +89,18 @@ public class EnchantItemAction extends AbstractItemAction {
 
 		boolean isEnchantmentStone = parentItem.getItemTemplate().getItemGroup() == ItemGroup.ENCHANTMENT;
 		int enchantDurationMillis = isEnchantmentStone ? 4000 : 2000;
-
-		StartMovingListener move = new StartMovingListener() {
-
+		
+		final ItemUseObserver observer = new ItemUseObserver() {
 			@Override
-			public void moved() {
-				super.moved();
-				player.getObserveController().removeObserver(this);
+			public void abort() {
 				player.getController().cancelUseItem();
 				PacketSendUtility.sendPacket(player, isEnchantmentStone ? SM_SYSTEM_MESSAGE.STR_ENCHANT_ITEM_CANCELED(targetItem.getL10n())
 					: SM_SYSTEM_MESSAGE.STR_GIVE_ITEM_OPTION_CANCELED(targetItem.getL10n()));
+				player.getObserveController().removeObserver(this);
 			}
-
 		};
 
-		player.getObserveController().attach(move);
+		player.getObserveController().attach(observer);
 
 		// Current enchant level
 		int currentEnchant = targetItem.getEnchantLevel();
@@ -112,38 +109,33 @@ public class EnchantItemAction extends AbstractItemAction {
 		PacketSendUtility.broadcastPacketAndReceive(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), targetItem.getObjectId(),
 			parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), enchantDurationMillis, 0, 0, 1, 0, 0));
 
-		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(new Runnable() {
+		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
+			player.getObserveController().removeObserver(observer);
 
-			@Override
-			public void run() {
-				player.getObserveController().removeObserver(move);
-
-				if (player.getInventory().getItemByObjId(targetItem.getObjectId()) == null && !targetItem.isEquipped()) {
-					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ENCHANT_ITEM_NO_TARGET_ITEM());
-					PacketSendUtility.broadcastPacketAndReceive(player,
-						new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0));
-					return;
-				}
-
-				if (isEnchantmentStone)
-					EnchantService.enchantItemAct(player, parentItem, targetItem, supplementItem, currentEnchant, isSuccess);
-				else // Manastone
-					EnchantService.socketManastoneAct(player, parentItem, targetItem, supplementItem, targetWeapon, isSuccess);
-
-				PacketSendUtility.broadcastPacketAndReceive(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(),
-					parentItem.getItemTemplate().getTemplateId(), 0, isSuccess ? 1 : 2, 0));
-				if (CustomConfig.ENABLE_ENCHANT_ANNOUNCE) {
-					if (isEnchantmentStone && isSuccess && (targetItem.getEnchantLevel() == 15 || targetItem.getEnchantLevel() == 20)) {
-						SM_SYSTEM_MESSAGE packet;
-						if (targetItem.getEnchantLevel() == 15)
-							packet = SM_SYSTEM_MESSAGE.STR_MSG_ENCHANT_ITEM_SUCCEEDED_15(player.getName(), targetItem.getItemTemplate().getL10n());
-						else
-							packet = SM_SYSTEM_MESSAGE.STR_MSG_ENCHANT_ITEM_SUCCEEDED_20(player.getName(), targetItem.getItemTemplate().getL10n());
-						PacketSendUtility.broadcastToWorld(packet, Predicates.Players.sameRace(player));
-					}
-				}
+			if (player.getInventory().getItemByObjId(targetItem.getObjectId()) == null && !targetItem.isEquipped()) {
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ENCHANT_ITEM_NO_TARGET_ITEM());
+				PacketSendUtility.broadcastPacketAndReceive(player,
+					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0));
+				return;
 			}
 
+			if (isEnchantmentStone)
+				EnchantService.enchantItemAct(player, parentItem, targetItem, supplementItem, currentEnchant, isSuccess);
+			else // Manastone
+				EnchantService.socketManastoneAct(player, parentItem, targetItem, supplementItem, targetWeapon, isSuccess);
+
+			PacketSendUtility.broadcastPacketAndReceive(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(),
+				parentItem.getItemTemplate().getTemplateId(), 0, isSuccess ? 1 : 2, 0));
+			if (CustomConfig.ENABLE_ENCHANT_ANNOUNCE) {
+				if (isEnchantmentStone && isSuccess && (targetItem.getEnchantLevel() == 15 || targetItem.getEnchantLevel() == 20)) {
+					SM_SYSTEM_MESSAGE packet;
+					if (targetItem.getEnchantLevel() == 15)
+						packet = SM_SYSTEM_MESSAGE.STR_MSG_ENCHANT_ITEM_SUCCEEDED_15(player.getName(), targetItem.getItemTemplate().getL10n());
+					else
+						packet = SM_SYSTEM_MESSAGE.STR_MSG_ENCHANT_ITEM_SUCCEEDED_20(player.getName(), targetItem.getItemTemplate().getL10n());
+					PacketSendUtility.broadcastToWorld(packet, Predicates.Players.sameRace(player));
+				}
+			}
 		}, enchantDurationMillis));
 	}
 

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/EnchantItemAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/EnchantItemAction.java
@@ -111,6 +111,7 @@ public class EnchantItemAction extends AbstractItemAction {
 
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
+			player.startCooldown(parentItem);
 
 			if (player.getInventory().getItemByObjId(targetItem.getObjectId()) == null && !targetItem.isEquipped()) {
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ENCHANT_ITEM_NO_TARGET_ITEM());

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/EnchantItemAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/EnchantItemAction.java
@@ -89,7 +89,7 @@ public class EnchantItemAction extends AbstractItemAction {
 
 		boolean isEnchantmentStone = parentItem.getItemTemplate().getItemGroup() == ItemGroup.ENCHANTMENT;
 		int enchantDurationMillis = isEnchantmentStone ? 4000 : 2000;
-		
+
 		final ItemUseObserver observer = new ItemUseObserver() {
 			@Override
 			public void abort() {

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpExtractAction.java
@@ -71,13 +71,11 @@ public class ExpExtractAction extends AbstractItemAction {
 
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			player.startCooldown(parentItem);
 			finishUse(player, parentItem);
 		}, castingDelay));
 	}
 
 	private void finishUse(Player player, Item parentItem) {
-
 		PlayerCommonData cd = player.getCommonData();
 		long requiredExp = getRequiredExp(cd);
 		long newExp = cd.getExp() - requiredExp;
@@ -88,6 +86,7 @@ public class ExpExtractAction extends AbstractItemAction {
 			return;
 		}
 
+		player.startCooldown(parentItem);
 		cd.setExp(newExp);
 		ItemService.addItem(player, itemId, 1);
 		String rewardItem = DataManager.ITEM_DATA.getItemTemplate(itemId).getL10n();

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpExtractAction.java
@@ -47,15 +47,19 @@ public class ExpExtractAction extends AbstractItemAction {
 
 	@Override
 	public void act(final Player player, final Item parentItem, Item targetItem, Object... params) {
-		PacketSendUtility.sendPacket(player,
-			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 5000, 0, 0));
+		int castingDelay = parentItem.getItemTemplate().getCastingDelay();
+		if (castingDelay <= 0) {
+			finishUse(player, parentItem);
+			return;
+		}
 
-		player.getController().cancelTask(TaskId.ITEM_USE);
+		PacketSendUtility.sendPacket(player,
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), castingDelay, 0, 0));
 
 		final ItemUseObserver observer = new ItemUseObserver() {
 			@Override
 			public void abort() {
-				player.getController().cancelTask(TaskId.ITEM_USE);
+				player.getController().cancelUseItem(false);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_CANCELED(parentItem.getL10n()));
 				PacketSendUtility.sendPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0));
@@ -65,31 +69,30 @@ public class ExpExtractAction extends AbstractItemAction {
 
 		player.getObserveController().attach(observer);
 
-		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(new Runnable() {
+		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
+			player.getObserveController().removeObserver(observer);
+			finishUse(player, parentItem);
+		}, castingDelay));
+	}
 
-			@Override
-			public void run() {
-				player.getObserveController().removeObserver(observer);
+	private void finishUse(Player player, Item parentItem) {
 
-				PlayerCommonData cd = player.getCommonData();
-				long requiredExp = getRequiredExp(cd);
-				long newExp = cd.getExp() - requiredExp;
-				if (!canExtractExp(player, newExp) || !player.getInventory().decreaseByItemId(parentItem.getItemId(), 1)) {
-					player.getController().cancelTask(TaskId.ITEM_USE);
-					PacketSendUtility.sendPacket(player,
-						new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(),
-							parentItem.getItemTemplate().getTemplateId(), 0, 2, 0));
-					return;
-				}
+		PlayerCommonData cd = player.getCommonData();
+		long requiredExp = getRequiredExp(cd);
+		long newExp = cd.getExp() - requiredExp;
+		if (!canExtractExp(player, newExp) || !player.getInventory().decreaseByItemId(parentItem.getItemId(), 1)) {
+			player.getController().cancelUseItem(false);
+			PacketSendUtility.sendPacket(player,
+				new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0));
+			return;
+		}
 
-				cd.setExp(newExp);
-				ItemService.addItem(player, itemId, 1);
-				String rewardItem = DataManager.ITEM_DATA.getItemTemplate(itemId).getL10n();
-				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_EXP_EXTRACTION_USE(parentItem.getL10n(), requiredExp, rewardItem));
-				PacketSendUtility.sendPacket(player,
-					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 1, 0));
-			}
-		}, 5000));
+		cd.setExp(newExp);
+		ItemService.addItem(player, itemId, 1);
+		String rewardItem = DataManager.ITEM_DATA.getItemTemplate(itemId).getL10n();
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_EXP_EXTRACTION_USE(parentItem.getL10n(), requiredExp, rewardItem));
+		PacketSendUtility.sendPacket(player,
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 1, 0));
 	}
 
 	private long getRequiredExp(PlayerCommonData cd) {

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpExtractAction.java
@@ -71,6 +71,7 @@ public class ExpExtractAction extends AbstractItemAction {
 
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
+			player.startCooldown(parentItem);
 			finishUse(player, parentItem);
 		}, castingDelay));
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpandInventoryAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpandInventoryAction.java
@@ -9,6 +9,7 @@ import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.model.templates.item.ItemTemplate;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
+import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.services.CubeExpandService;
 import com.aionemu.gameserver.services.WarehouseService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
@@ -38,6 +39,7 @@ public class ExpandInventoryAction extends AbstractItemAction {
 		if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1))
 			return;
 		ItemTemplate itemTemplate = parentItem.getItemTemplate();
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		PacketSendUtility.broadcastPacket(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), itemTemplate.getTemplateId()), true);
 

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpandInventoryAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpandInventoryAction.java
@@ -27,13 +27,10 @@ public class ExpandInventoryAction extends AbstractItemAction {
 
 	@Override
 	public boolean canAct(Player player, Item parentItem, Item targetItem, Object... params) {
-		switch (storage) {
-			case CUBE:
-				return CubeExpandService.canExpandByTicket(player, level);
-			case WAREHOUSE:
-				return WarehouseService.canExpandByTicket(player, level);
-		}
-		return false;
+		return switch (storage) {
+			case CUBE -> CubeExpandService.canExpandByTicket(player, level);
+			case WAREHOUSE -> WarehouseService.canExpandByTicket(player, level);
+		};
 	}
 
 	@Override

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExtractAction.java
@@ -58,6 +58,8 @@ public class ExtractAction extends AbstractItemAction {
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
 			boolean result = EnchantService.breakItem(player, targetItem, parentItem);
+			if (result)
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_SUCCEED(targetItem.getL10n()));
 			PacketSendUtility.sendPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate()
 				.getTemplateId(), 0, result ? 1 : 2, 0));
 		}, 5000));

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExtractAction.java
@@ -57,7 +57,7 @@ public class ExtractAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			boolean result = EnchantService.breakItem(player, targetItem, parentItem);
+			boolean result = canAct(player, parentItem, targetItem) && EnchantService.breakItem(player, targetItem, parentItem);
 			PacketSendUtility.sendPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate()
 				.getTemplateId(), 0, result ? 1 : 2, 0));
 		}, 5000));

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExtractAction.java
@@ -59,6 +59,8 @@ public class ExtractAction extends AbstractItemAction {
 			player.getObserveController().removeObserver(observer);
 			boolean result = canAct(player, parentItem, targetItem) && EnchantService.breakItem(player, targetItem, parentItem);
 			if (result)
+				// The only item with an extract action has no use delay, so this is effectively
+				// a no-op, but kept for consistency with the other actions.
 				player.startCooldown(parentItem);
 			PacketSendUtility.sendPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate()
 				.getTemplateId(), 0, result ? 1 : 2, 0));

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExtractAction.java
@@ -58,8 +58,6 @@ public class ExtractAction extends AbstractItemAction {
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
 			boolean result = EnchantService.breakItem(player, targetItem, parentItem);
-			if (result)
-				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_SUCCEED(targetItem.getL10n()));
 			PacketSendUtility.sendPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate()
 				.getTemplateId(), 0, result ? 1 : 2, 0));
 		}, 5000));

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExtractAction.java
@@ -57,6 +57,7 @@ public class ExtractAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
+			player.startCooldown(parentItem);
 			boolean result = canAct(player, parentItem, targetItem) && EnchantService.breakItem(player, targetItem, parentItem);
 			PacketSendUtility.sendPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate()
 				.getTemplateId(), 0, result ? 1 : 2, 0));

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExtractAction.java
@@ -57,8 +57,9 @@ public class ExtractAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			player.startCooldown(parentItem);
 			boolean result = canAct(player, parentItem, targetItem) && EnchantService.breakItem(player, targetItem, parentItem);
+			if (result)
+				player.startCooldown(parentItem);
 			PacketSendUtility.sendPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate()
 				.getTemplateId(), 0, result ? 1 : 2, 0));
 		}, 5000));

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExtractAction.java
@@ -43,12 +43,11 @@ public class ExtractAction extends AbstractItemAction {
 	public void act(Player player, Item parentItem, Item targetItem, Object... params) {
 		PacketSendUtility.sendPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate()
 			.getTemplateId(), 5000, 0, 0));
-		player.getController().cancelTask(TaskId.ITEM_USE);
 		ItemUseObserver observer = new ItemUseObserver() {
 
 			@Override
 			public void abort() {
-				player.getController().cancelTask(TaskId.ITEM_USE);
+				player.getController().cancelUseItem(false);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_CANCELED(targetItem.getL10n()));
 				PacketSendUtility.sendPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate()
 					.getTemplateId(), 0, 2, 0));

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/FireworksUseAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/FireworksUseAction.java
@@ -32,5 +32,6 @@ public class FireworksUseAction extends AbstractItemAction {
 		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem
 			.getItemTemplate().getTemplateId(), 0, 1, 0), true);
+		player.startCooldown(parentItem);
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/FireworksUseAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/FireworksUseAction.java
@@ -7,6 +7,7 @@ import javax.xml.bind.annotation.XmlType;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
+import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.utils.PacketSendUtility;
 
 /**
@@ -28,6 +29,7 @@ public class FireworksUseAction extends AbstractItemAction {
 		else
 			player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1);
 
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem
 			.getItemTemplate().getTemplateId(), 0, 1, 0), true);
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/InstanceTimeClear.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/InstanceTimeClear.java
@@ -44,16 +44,21 @@ public class InstanceTimeClear extends AbstractItemAction {
 
 	@Override
 	public void act(final Player player, final Item parentItem, Item targetItem, Object... params) {
+		int castingDelay = parentItem.getItemTemplate().getCastingDelay();
 		int syncId = (int) params[0];
+		if (castingDelay <= 0) {
+			finishUse(player, parentItem, syncId);
+			return;
+		}
 		PacketSendUtility.broadcastPacketAndReceive(player,
-			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 1000, 0, 0));
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), castingDelay, 0, 0));
 
 		final ItemUseObserver observer = new ItemUseObserver() {
 
 			@Override
 			public void abort() {
 				// TODO: abort is invalid. Should we abort all or only the last syncid?
-				player.getController().cancelTask(TaskId.ITEM_USE);
+				player.getController().cancelUseItem(false);
 				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player,
@@ -63,32 +68,30 @@ public class InstanceTimeClear extends AbstractItemAction {
 
 		};
 		player.getObserveController().attach(observer);
-		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				player.getObserveController().removeObserver(observer);
-				if (parentItem.getActivationCount() > 1) {
-					parentItem.setActivationCount(parentItem.getActivationCount() - 1);
-				} else {
-					player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1);
-				}
-
-				int worldId = DataManager.INSTANCE_COOLTIME_DATA.getWorldId(syncId);
-				PortalCooldown portalCD = player.getPortalCooldownList().getPortalCooldown(worldId);
-				if (portalCD == null || portalCD.getEnterCount() < 1)
-					return; // don't spam with not needed packets!
-
-				portalCD.decreaseEnterCount();
-				if (portalCD.getEnterCount() < 1)
-					player.getPortalCooldownList().removePortalCooldown(worldId);
-
-				player.getPortalCooldownList().sendEntryInfo(worldId);
-				PacketSendUtility.broadcastPacketAndReceive(player,
-					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 0));
-			}
-
-		}, 1000));
+		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
+			player.getObserveController().removeObserver(observer);
+			finishUse(player, parentItem, syncId);
+		}, castingDelay));
 	}
 
+	private void finishUse(Player player, Item parentItem, int syncId) {
+		if (parentItem.getActivationCount() > 1) {
+			parentItem.setActivationCount(parentItem.getActivationCount() - 1);
+		} else {
+			player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1);
+		}
+
+		int worldId = DataManager.INSTANCE_COOLTIME_DATA.getWorldId(syncId);
+		PortalCooldown portalCD = player.getPortalCooldownList().getPortalCooldown(worldId);
+		if (portalCD == null || portalCD.getEnterCount() < 1)
+			return; // don't spam with not needed packets!
+
+		portalCD.decreaseEnterCount();
+		if (portalCD.getEnterCount() < 1)
+			player.getPortalCooldownList().removePortalCooldown(worldId);
+
+		player.getPortalCooldownList().sendEntryInfo(worldId);
+		PacketSendUtility.broadcastPacketAndReceive(player,
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 0));
+	}
 }

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/InstanceTimeClear.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/InstanceTimeClear.java
@@ -66,7 +66,6 @@ public class InstanceTimeClear extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			player.startCooldown(parentItem);
 			finishUse(player, parentItem, syncId);
 		}, castingDelay));
 	}
@@ -80,6 +79,8 @@ public class InstanceTimeClear extends AbstractItemAction {
 			parentItem.setActivationCount(parentItem.getActivationCount() - 1);
 		} else if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1))
 			return;
+
+		player.startCooldown(parentItem);
 
 		PortalCooldown portalCD = player.getPortalCooldownList().getOrCreatePortalCooldown(worldId);
 		if (portalCD != null) {

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/InstanceTimeClear.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/InstanceTimeClear.java
@@ -77,8 +77,12 @@ public class InstanceTimeClear extends AbstractItemAction {
 	private void finishUse(Player player, Item parentItem, int syncId) {
 		int worldId = DataManager.INSTANCE_COOLTIME_DATA.getWorldId(syncId);
 		PortalCooldown portalCD = player.getPortalCooldownList().getPortalCooldown(worldId);
-		if (portalCD == null || portalCD.getEnterCount() < 1)
-			return; // cooldown state changed during the cast, or nothing to clear - don't consume the item for nothing
+		if (portalCD == null || portalCD.getEnterCount() < 1) {
+			// cooldown state changed during the cast, or nothing to clear - don't consume the item for nothing
+			PacketSendUtility.broadcastPacketAndReceive(player,
+				new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 2, 0));
+			return;
+		}
 
 		if (parentItem.getActivationCount() > 1) {
 			parentItem.setActivationCount(parentItem.getActivationCount() - 1);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/InstanceTimeClear.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/InstanceTimeClear.java
@@ -75,16 +75,16 @@ public class InstanceTimeClear extends AbstractItemAction {
 	}
 
 	private void finishUse(Player player, Item parentItem, int syncId) {
+		int worldId = DataManager.INSTANCE_COOLTIME_DATA.getWorldId(syncId);
+		PortalCooldown portalCD = player.getPortalCooldownList().getPortalCooldown(worldId);
+		if (portalCD == null || portalCD.getEnterCount() < 1)
+			return; // cooldown state changed during the cast, or nothing to clear - don't consume the item for nothing
+
 		if (parentItem.getActivationCount() > 1) {
 			parentItem.setActivationCount(parentItem.getActivationCount() - 1);
 		} else {
 			player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1);
 		}
-
-		int worldId = DataManager.INSTANCE_COOLTIME_DATA.getWorldId(syncId);
-		PortalCooldown portalCD = player.getPortalCooldownList().getPortalCooldown(worldId);
-		if (portalCD == null || portalCD.getEnterCount() < 1)
-			return; // don't spam with not needed packets!
 
 		portalCD.decreaseEnterCount();
 		if (portalCD.getEnterCount() < 1)

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/InstanceTimeClear.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/InstanceTimeClear.java
@@ -56,7 +56,6 @@ public class InstanceTimeClear extends AbstractItemAction {
 			@Override
 			public void abort() {
 				player.getController().cancelUseItem(false);
-				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0), true);
@@ -67,6 +66,7 @@ public class InstanceTimeClear extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
+			player.startCooldown(parentItem);
 			finishUse(player, parentItem, syncId);
 		}, castingDelay));
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/InstanceTimeClear.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/InstanceTimeClear.java
@@ -91,6 +91,7 @@ public class InstanceTimeClear extends AbstractItemAction {
 			player.getPortalCooldownList().removePortalCooldown(worldId);
 
 		player.getPortalCooldownList().sendEntryInfo(worldId);
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		PacketSendUtility.broadcastPacketAndReceive(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 0));
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/InstanceTimeClear.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/InstanceTimeClear.java
@@ -27,15 +27,13 @@ public class InstanceTimeClear extends AbstractItemAction {
 
 	@XmlAttribute(name = "sync_ids")
 	private List<Integer> syncIds;
+	@XmlAttribute(name = "recovery_instance_count")
+	private int recoveryInstanceCount = 1;
 
 	@Override
 	public boolean canAct(Player player, Item parentItem, Item targetItem, Object... params) {
 		int syncId = (int) params[0];
-		if (!syncIds.contains(syncId))
-			return false;
-		int worldId = DataManager.INSTANCE_COOLTIME_DATA.getWorldId(syncId);
-		PortalCooldown portalCooldown = player.getPortalCooldownList().getPortalCooldown(worldId);
-		if (portalCooldown == null || (portalCooldown.getReuseTime() < System.currentTimeMillis() && portalCooldown.getEnterCount() == 0)) {
+		if (!syncIds.contains(syncId)) {
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_CANT_INSTANCE_COOL_TIME_INIT());
 			return false;
 		}
@@ -57,7 +55,6 @@ public class InstanceTimeClear extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				// TODO: abort is invalid. Should we abort all or only the last syncid?
 				player.getController().cancelUseItem(false);
 				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
@@ -76,25 +73,19 @@ public class InstanceTimeClear extends AbstractItemAction {
 
 	private void finishUse(Player player, Item parentItem, int syncId) {
 		int worldId = DataManager.INSTANCE_COOLTIME_DATA.getWorldId(syncId);
-		PortalCooldown portalCD = player.getPortalCooldownList().getPortalCooldown(worldId);
-		if (portalCD == null || portalCD.getEnterCount() < 1) {
-			// cooldown state changed during the cast, or nothing to clear - don't consume the item for nothing
-			PacketSendUtility.broadcastPacketAndReceive(player,
-				new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 2, 0));
-			return;
-		}
 
 		if (parentItem.getActivationCount() > 1) {
+			if (player.getInventory().getItemByObjId(parentItem.getObjectId()) == null)
+				return; // item was traded or sold during the casting delay
 			parentItem.setActivationCount(parentItem.getActivationCount() - 1);
-		} else {
-			player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1);
+		} else if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1))
+			return;
+
+		PortalCooldown portalCD = player.getPortalCooldownList().getOrCreatePortalCooldown(worldId);
+		if (portalCD != null) {
+			portalCD.decreaseEnterCount(recoveryInstanceCount);
+			player.getPortalCooldownList().sendEntryInfo(worldId);
 		}
-
-		portalCD.decreaseEnterCount();
-		if (portalCD.getEnterCount() < 1)
-			player.getPortalCooldownList().removePortalCooldown(worldId);
-
-		player.getPortalCooldownList().sendEntryInfo(worldId);
 		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		PacketSendUtility.broadcastPacketAndReceive(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 0));

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ItemActions.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ItemActions.java
@@ -25,7 +25,7 @@ public class ItemActions {
 		@XmlElement(name = "housedeco", type = DecorateAction.class), @XmlElement(name = "assemble", type = AssemblyItemAction.class),
 		@XmlElement(name = "adoptpet", type = AdoptPetAction.class), @XmlElement(name = "apextract", type = ApExtractAction.class),
 		@XmlElement(name = "remodel", type = RemodelAction.class), @XmlElement(name = "expextract", type = ExpExtractAction.class),
-		@XmlElement(name = "polish", type = PolishAction.class), @XmlElement(name = "composition", type = CompositionAction.class),
+		@XmlElement(name = "polish", type = PolishAction.class),
 		@XmlElement(name = "tuning", type = TuningAction.class), @XmlElement(name = "megaphone", type = MegaphoneAction.class),
 		@XmlElement(name = "pack", type = PackAction.class), @XmlElement(name = "tampering", type = TamperingAction.class),
 		@XmlElement(name = "multireturn", type = MultiReturnAction.class) })

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/MultiReturnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/MultiReturnAction.java
@@ -44,7 +44,6 @@ public class MultiReturnAction extends AbstractItemAction {
 			@Override
 			public void abort() {
 				player.getController().cancelUseItem(false);
-				player.removeItemCoolDown(item.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), item.getObjectId(), item.getItemId(), 0, 2, 0),
 					true);
@@ -59,6 +58,7 @@ public class MultiReturnAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
+			player.startCooldown(item);
 			finishUse(player, item, observer, indexReturn);
 		}, castingDelay));
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/MultiReturnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/MultiReturnAction.java
@@ -1,6 +1,9 @@
 package com.aionemu.gameserver.model.templates.item.actions;
 
-import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
 
 import com.aionemu.gameserver.controllers.observer.ItemUseObserver;
 import com.aionemu.gameserver.dataholders.DataManager;
@@ -24,9 +27,6 @@ public class MultiReturnAction extends AbstractItemAction {
 	@XmlAttribute(name = "id")
 	protected int id;
 
-	@XmlTransient
-	private static final short USAGE_DELAY = 5000;
-
 	@Override
 	public boolean canAct(Player player, Item item, Item targetItem, Object... params) {
 		return true;
@@ -34,37 +34,44 @@ public class MultiReturnAction extends AbstractItemAction {
 
 	@Override
 	public void act(final Player player, final Item item, final Item targetItem, Object... params) {
+		int castingDelay = item.getItemTemplate().getCastingDelay();
 		int indexReturn = (int) params[0];
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), item.getObjectId(), item.getItemId(), USAGE_DELAY, 0, 0), true);
+		PacketSendUtility.broadcastPacket(player,
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), item.getObjectId(), item.getItemId(), castingDelay, 0, 0), true);
 
 		final ItemUseObserver observer = new ItemUseObserver() {
 
 			@Override
 			public void abort() {
-				player.getController().cancelTask(TaskId.ITEM_USE);
+				player.getController().cancelUseItem(false);
 				player.removeItemCoolDown(item.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), item.getObjectId(), item.getItemId(), 0, 2, 0), true);
+				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), item.getObjectId(), item.getItemId(), 0, 2, 0),
+					true);
 				player.getObserveController().removeObserver(this);
 			}
 		};
+		if (castingDelay <= 0) {
+			finishUse(player, item, observer, indexReturn);
+			return;
+		}
+
 		player.getObserveController().attach(observer);
-		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(new Runnable() {
+		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
+			player.getObserveController().removeObserver(observer);
+			finishUse(player, item, observer, indexReturn);
+		}, castingDelay));
+	}
 
-			@Override
-			public void run() {
-				ReturnLocList loc = DataManager.MULTIRETURN_DATA.getReturnLocListById(id).get(indexReturn);
-				if (loc != null && loc.getAlias() != null && loc.getWorldid() > 0) {
-					if (!player.getInventory().decreaseByObjectId(item.getObjectId(), 1)) {
-						observer.abort();
-						return;
-					}
-					player.getObserveController().removeObserver(observer);
-					TeleportService.useTeleportScroll(player, loc.getAlias().toUpperCase(), loc.getWorldid());
-					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(item.getL10n()));
-				}
+	private void finishUse(Player player, Item item, ItemUseObserver observer, int indexReturn) {
+		ReturnLocList loc = DataManager.MULTIRETURN_DATA.getReturnLocListById(id).get(indexReturn);
+		if (loc != null && loc.getAlias() != null && loc.getWorldid() > 0) {
+			if (!player.getInventory().decreaseByObjectId(item.getObjectId(), 1)) {
+				observer.abort();
+				return;
 			}
-
-		}, USAGE_DELAY));
+			TeleportService.useTeleportScroll(player, loc.getAlias().toUpperCase(), loc.getWorldid());
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(item.getL10n()));
+		}
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/MultiReturnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/MultiReturnAction.java
@@ -58,7 +58,6 @@ public class MultiReturnAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			player.startCooldown(item);
 			finishUse(player, item, observer, indexReturn);
 		}, castingDelay));
 	}
@@ -70,6 +69,7 @@ public class MultiReturnAction extends AbstractItemAction {
 				observer.abort();
 				return;
 			}
+			player.startCooldown(item);
 			TeleportService.useTeleportScroll(player, loc.getAlias().toUpperCase(), loc.getWorldid());
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(item.getL10n()));
 		}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/PolishAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/PolishAction.java
@@ -53,7 +53,7 @@ public class PolishAction extends AbstractItemAction {
 			public void abort() {
 				player.getController().cancelUseItem(false);
 				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
-				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_POLISH_CANCELED(targetItem.getL10n()));
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 2, 0), true);
 				player.getObserveController().removeObserver(this);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/PolishAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/PolishAction.java
@@ -51,7 +51,7 @@ public class PolishAction extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				player.getController().cancelTask(TaskId.ITEM_USE);
+				player.getController().cancelUseItem(false);
 				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player,

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/PolishAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/PolishAction.java
@@ -62,7 +62,6 @@ public class PolishAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			player.startCooldown(parentItem);
 
 			if (player.getInventory().getItemByObjId(targetItem.getObjectId()) == null && !targetItem.isEquipped()) {
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ENCHANT_ITEM_NO_TARGET_ITEM());
@@ -76,6 +75,7 @@ public class PolishAction extends AbstractItemAction {
 			if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1)) {
 				return;
 			}
+			player.startCooldown(parentItem);
 			int bonusNumber = DataManager.ITEM_RANDOM_BONUSES.selectRandomBonusNumber(StatBonusType.POLISH, polishSetId);
 			if (bonusNumber == 0) {
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ENCHANT_ITEM_FAILED(parentItem.getL10n()));

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/PolishAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/PolishAction.java
@@ -52,7 +52,6 @@ public class PolishAction extends AbstractItemAction {
 			@Override
 			public void abort() {
 				player.getController().cancelUseItem(false);
-				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_POLISH_CANCELED(targetItem.getL10n()));
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 2, 0), true);
@@ -63,6 +62,7 @@ public class PolishAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
+			player.startCooldown(parentItem);
 
 			if (player.getInventory().getItemByObjId(targetItem.getObjectId()) == null && !targetItem.isEquipped()) {
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ENCHANT_ITEM_NO_TARGET_ITEM());

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/PolishAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/PolishAction.java
@@ -64,6 +64,13 @@ public class PolishAction extends AbstractItemAction {
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
 
+			if (player.getInventory().getItemByObjId(targetItem.getObjectId()) == null && !targetItem.isEquipped()) {
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ENCHANT_ITEM_NO_TARGET_ITEM());
+				PacketSendUtility.broadcastPacket(player,
+					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 2, 0), true);
+				return;
+			}
+
 			PacketSendUtility.broadcastPacket(player,
 				new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 1), true);
 			if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1)) {

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/QuestStartAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/QuestStartAction.java
@@ -6,7 +6,6 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 
 import com.aionemu.gameserver.controllers.observer.ItemUseObserver;
-import com.aionemu.gameserver.dataholders.DataManager;
 import com.aionemu.gameserver.model.DialogAction;
 import com.aionemu.gameserver.model.TaskId;
 import com.aionemu.gameserver.model.gameobjects.Item;
@@ -14,9 +13,11 @@ import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.questEngine.QuestEngine;
+import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
 import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
+import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
 import com.aionemu.gameserver.utils.ThreadPoolManager;
 
@@ -33,16 +34,8 @@ public class QuestStartAction extends AbstractItemAction {
 
 	@Override
 	public boolean canAct(Player player, Item parentItem, Item targetItem, Object... params) {
-		QuestState qs = player.getQuestStateList().getQuestState(questid);
-		if (qs == null || qs.isStartable())
-			return true;
-		else if (qs.getStatus() != QuestStatus.COMPLETE)
-			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_WORKING_QUEST());
-		else if (!qs.canRepeat())
-			PacketSendUtility.sendPacket(player,
-				SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_NONE_REPEATABLE(DataManager.QUEST_DATA.getQuestById(questid).getName()));
-
-		return false;
+		// Retail always plays the cast; eligibility is only checked afterwards, in finishUse()
+		return true;
 	}
 
 	@Override
@@ -71,11 +64,30 @@ public class QuestStartAction extends AbstractItemAction {
 			player.getObserveController().removeObserver(observer);
 			finishUse(player, parentItem);
 		}, castingDelay));
-		
+
 	}
 
 	private void finishUse(Player player, Item item) {
 		PacketSendUtility.broadcastPacketAndReceive(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), item.getObjectId(), item.getItemId()));
-		QuestEngine.getInstance().onDialog(new QuestEnv(null, player, questid, DialogAction.ASK_QUEST_ACCEPT));
+
+		QuestState qs = player.getQuestStateList().getQuestState(questid);
+		boolean alreadyActive = qs != null && (qs.getStatus() == QuestStatus.START || qs.getStatus() == QuestStatus.REWARD);
+
+		// Retail only gates "doc_"-named quest items on race/level/etc.; plain quest items skip this check
+		// entirely and always reach the accept dialog (confirmed on retail 5.8)
+		boolean isDocument = item.getItemTemplate().getClientName().toLowerCase().startsWith("doc_");
+		boolean canStart = !alreadyActive && (!isDocument || QuestService.checkStartConditions(player, questid, true, 0, true, false, false));
+
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(item.getL10n()));
+
+		if (!canStart)
+			return; // quest already active, or race/level/etc. requirements not met (checkStartConditions already sent the message)
+
+		// CM_USE_ITEM skips onItemUseEvent for QuestStartAction items so it doesn't fire before the cast; call it
+		// here instead, falling back to the generic dialog routing if the item isn't a registered quest item
+		QuestEnv env = new QuestEnv(null, player, questid, DialogAction.ASK_QUEST_ACCEPT);
+		HandlerResult result = QuestEngine.getInstance().onItemUseEvent(env, item);
+		if (result != HandlerResult.SUCCESS)
+			QuestEngine.getInstance().onDialog(new QuestEnv(null, player, questid, DialogAction.ASK_QUEST_ACCEPT));
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/QuestStartAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/QuestStartAction.java
@@ -5,8 +5,10 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 
+import com.aionemu.gameserver.controllers.observer.ItemUseObserver;
 import com.aionemu.gameserver.dataholders.DataManager;
 import com.aionemu.gameserver.model.DialogAction;
+import com.aionemu.gameserver.model.TaskId;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
@@ -16,6 +18,7 @@ import com.aionemu.gameserver.questEngine.model.QuestEnv;
 import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.utils.PacketSendUtility;
+import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author Nemiroff Date: 17.12.2009
@@ -44,7 +47,35 @@ public class QuestStartAction extends AbstractItemAction {
 
 	@Override
 	public void act(Player player, Item parentItem, Item targetItem, Object... params) {
-		PacketSendUtility.broadcastPacketAndReceive(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId()));
+		int castingDelay = parentItem.getItemTemplate().getCastingDelay();
+		if (castingDelay <= 0) {
+			finishUse(player, parentItem);
+			return;
+		}
+		PacketSendUtility.broadcastPacket(player,
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), castingDelay, 0, 1), true);
+		final ItemUseObserver observer = new ItemUseObserver() {
+
+			@Override
+			public void abort() {
+				player.getController().cancelUseItem(false);
+				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
+				PacketSendUtility.broadcastPacket(player,
+					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0), true);
+			}
+		};
+
+		player.getObserveController().attach(observer);
+		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
+			player.getObserveController().removeObserver(observer);
+			finishUse(player, parentItem);
+		}, castingDelay));
+		
+	}
+
+	private void finishUse(Player player, Item item) {
+		PacketSendUtility.broadcastPacketAndReceive(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), item.getObjectId(), item.getItemId()));
 		QuestEngine.getInstance().onDialog(new QuestEnv(null, player, questid, DialogAction.ASK_QUEST_ACCEPT));
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/QuestStartAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/QuestStartAction.java
@@ -71,12 +71,10 @@ public class QuestStartAction extends AbstractItemAction {
 		PacketSendUtility.broadcastPacketAndReceive(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), item.getObjectId(), item.getItemId()));
 
 		QuestState qs = player.getQuestStateList().getQuestState(questid);
+		// retail stays silent when the quest is already active, but warns about race/level/etc. before sending the use
+		// message (confirmed on retail 5.8, for plain quest items as well as for documents)
 		boolean alreadyActive = qs != null && (qs.getStatus() == QuestStatus.START || qs.getStatus() == QuestStatus.REWARD);
-
-		// Retail only gates "doc_"-named quest items on race/level/etc.; plain quest items skip this check
-		// entirely and always reach the accept dialog (confirmed on retail 5.8)
-		boolean isDocument = item.getItemTemplate().getClientName().toLowerCase().startsWith("doc_");
-		boolean canStart = !alreadyActive && (!isDocument || QuestService.checkStartConditions(player, questid, true, 0, true, false, false));
+		boolean canStart = !alreadyActive && QuestService.checkStartConditions(player, questid, true, 0, true, false, false);
 
 		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(item.getL10n()));
 

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/QuestStartAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/QuestStartAction.java
@@ -60,13 +60,13 @@ public class QuestStartAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			player.startCooldown(parentItem);
 			finishUse(player, parentItem);
 		}, castingDelay));
 
 	}
 
 	private void finishUse(Player player, Item item) {
+		player.startCooldown(item);
 		PacketSendUtility.broadcastPacketAndReceive(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), item.getObjectId(), item.getItemId()));
 
 		// retail stays silent when the quest is already active or cannot be repeated (anymore), but warns about

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/QuestStartAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/QuestStartAction.java
@@ -51,7 +51,6 @@ public class QuestStartAction extends AbstractItemAction {
 			@Override
 			public void abort() {
 				player.getController().cancelUseItem(false);
-				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0), true);
@@ -61,6 +60,7 @@ public class QuestStartAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
+			player.startCooldown(parentItem);
 			finishUse(player, parentItem);
 		}, castingDelay));
 

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/QuestStartAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/QuestStartAction.java
@@ -16,7 +16,6 @@ import com.aionemu.gameserver.questEngine.QuestEngine;
 import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
 import com.aionemu.gameserver.questEngine.model.QuestState;
-import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
 import com.aionemu.gameserver.utils.ThreadPoolManager;
@@ -70,16 +69,15 @@ public class QuestStartAction extends AbstractItemAction {
 	private void finishUse(Player player, Item item) {
 		PacketSendUtility.broadcastPacketAndReceive(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), item.getObjectId(), item.getItemId()));
 
+		// retail stays silent when the quest is already active or cannot be repeated (anymore), but warns about
+		// race/level/etc. restrictions before sending the use message (confirmed on retail 5.8)
 		QuestState qs = player.getQuestStateList().getQuestState(questid);
-		// retail stays silent when the quest is already active, but warns about race/level/etc. before sending the use
-		// message (confirmed on retail 5.8, for plain quest items as well as for documents)
-		boolean alreadyActive = qs != null && (qs.getStatus() == QuestStatus.START || qs.getStatus() == QuestStatus.REWARD);
-		boolean canStart = !alreadyActive && QuestService.checkStartConditions(player, questid, true, 0, true, false, false);
+		boolean canStart = (qs == null || qs.isStartable()) && QuestService.checkStartConditions(player, questid, true, 0, true, true, false);
 
 		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(item.getL10n()));
 
 		if (!canStart)
-			return; // quest already active, or race/level/etc. requirements not met (checkStartConditions already sent the message)
+			return; // quest not startable, or requirements not met (checkStartConditions already sent the message)
 
 		// CM_USE_ITEM skips onItemUseEvent for QuestStartAction items so it doesn't fire before the cast; call it
 		// here instead, falling back to the generic dialog routing if the item isn't a registered quest item

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ReadAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ReadAction.java
@@ -52,12 +52,12 @@ public class ReadAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			player.startCooldown(parentItem);
 			finishUse(player, parentItem);
 		}, castingDelay));
 	}
 
 	private void finishUse(Player player, Item parentItem) {
+		player.startCooldown(parentItem);
 		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		PacketSendUtility.broadcastPacket(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 1, 0), true);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ReadAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ReadAction.java
@@ -4,11 +4,14 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
 
+import com.aionemu.gameserver.controllers.observer.ItemUseObserver;
+import com.aionemu.gameserver.model.TaskId;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.utils.PacketSendUtility;
+import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "ReadAction")
@@ -21,6 +24,40 @@ public class ReadAction extends AbstractItemAction {
 
 	@Override
 	public void act(Player player, Item parentItem, Item targetItem, Object... params) {
+		// items combining <queststart> with <read> get their "used" message and usage animation from QuestStartAction already
+		if (parentItem.getItemTemplate().getActions().getItemActions().stream().anyMatch(a -> a instanceof QuestStartAction))
+			return;
+
+		int castingDelay = parentItem.getItemTemplate().getCastingDelay();
+		if (castingDelay <= 0) {
+			finishUse(player, parentItem);
+			return;
+		}
+
+		PacketSendUtility.broadcastPacket(player,
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), castingDelay, 0, 0),
+			true);
+		ItemUseObserver observer = new ItemUseObserver() {
+
+			@Override
+			public void abort() {
+				player.getController().cancelUseItem(false);
+				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
+				PacketSendUtility.broadcastPacket(player,
+					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0),
+					true);
+				player.getObserveController().removeObserver(this);
+			}
+		};
+		player.getObserveController().attach(observer);
+		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
+			player.getObserveController().removeObserver(observer);
+			finishUse(player, parentItem);
+		}, castingDelay));
+	}
+
+	private void finishUse(Player player, Item parentItem) {
 		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		PacketSendUtility.broadcastPacket(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 1, 0), true);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ReadAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ReadAction.java
@@ -7,6 +7,7 @@ import javax.xml.bind.annotation.XmlType;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
+import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.utils.PacketSendUtility;
 
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -20,7 +21,7 @@ public class ReadAction extends AbstractItemAction {
 
 	@Override
 	public void act(Player player, Item parentItem, Item targetItem, Object... params) {
-		// The item's description window is shown by the client itself; retail has no casting animation for this
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		PacketSendUtility.broadcastPacket(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 1, 0), true);
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ReadAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ReadAction.java
@@ -42,7 +42,6 @@ public class ReadAction extends AbstractItemAction {
 			@Override
 			public void abort() {
 				player.getController().cancelUseItem(false);
-				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0),
@@ -53,6 +52,7 @@ public class ReadAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
+			player.startCooldown(parentItem);
 			finishUse(player, parentItem);
 		}, castingDelay));
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ReadAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ReadAction.java
@@ -8,7 +8,6 @@ import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.utils.PacketSendUtility;
-import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "ReadAction")
@@ -16,23 +15,14 @@ public class ReadAction extends AbstractItemAction {
 
 	@Override
 	public boolean canAct(Player player, Item parentItem, Item targetItem, Object... params) {
-		// TODO: get quest
 		return true;
 	}
 
 	@Override
-	public void act(final Player player, Item parentItem, Item targetItem, Object... params) {
-		final int itemObjId = parentItem.getObjectId();
-		final int id = parentItem.getItemTemplate().getTemplateId();
-
-		PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 50, 0, 0), true);
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), itemObjId, id, 0, 1, 0), true);
-			}
-		}, 50);
+	public void act(Player player, Item parentItem, Item targetItem, Object... params) {
+		// The item's description window is shown by the client itself; retail has no casting animation for this
+		PacketSendUtility.broadcastPacket(player,
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 1, 0), true);
 	}
 
 }

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
@@ -70,49 +70,33 @@ public class RideAction extends AbstractItemAction {
 
 	@Override
 	public void act(final Player player, final Item parentItem, Item targetItem, Object... params) {
-		player.getController().cancelUseItem();
 		if (player.isInPlayerMode(PlayerMode.RIDE)) {
 			player.unsetPlayerMode(PlayerMode.RIDE);
 			return;
 		}
-
-		PacketSendUtility.broadcastPacket(player,
-			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 3000, 0, 0), true);
-		final ItemUseObserver observer = new ItemUseObserver() {
-
-			@Override
-			public void abort() {
-				player.getController().cancelTask(TaskId.ITEM_USE);
-				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
-				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
-				PacketSendUtility.broadcastPacket(player,
-					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 3, 0), true);
-				player.getObserveController().removeObserver(this);
-			}
-
-		};
-
-		player.getObserveController().attach(observer);
-		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				player.unsetState(CreatureState.ACTIVE);
-				player.setState(CreatureState.RESTING);
-				if (player.isInFlyingState())
-					player.setState(CreatureState.FLOATING_CORPSE);
+		int castingDelay = parentItem.getItemTemplate().getCastingDelay();
+		if (castingDelay <= 0) {
+			finishUse(player, parentItem);
+		} else {
+			PacketSendUtility.broadcastPacket(player,
+				new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), castingDelay, 0, 0), true);
+			final ItemUseObserver observer = new ItemUseObserver() {
+				@Override
+				public void abort() {
+					player.getController().cancelUseItem();
+					player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
+					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
+					PacketSendUtility.broadcastPacket(player,
+						new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 3, 0), true);
+					player.getObserveController().removeObserver(this);
+				}
+			};
+			player.getObserveController().attach(observer);
+			player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 				player.getObserveController().removeObserver(observer);
-				ItemTemplate itemTemplate = parentItem.getItemTemplate();
-				player.setPlayerMode(PlayerMode.RIDE, getRideInfo());
-				PacketSendUtility.broadcastPacket(player, new SM_EMOTION(player, EmotionType.CHANGE_SPEED, 0, 0), true);
-				PacketSendUtility.broadcastPacket(player, new SM_EMOTION(player, EmotionType.RIDE, 0, getRideInfo().getNpcId()), true);
-				PacketSendUtility.broadcastPacket(player,
-					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 1), true);
-				player.getController().cancelTask(TaskId.ITEM_USE);
-				QuestEngine.getInstance().rideAction(new QuestEnv(null, player, 0), itemTemplate.getTemplateId());
-			}
-
-		}, 3000));
+				finishUse(player, parentItem);
+			}, castingDelay));
+		}
 
 		ActionObserver rideObserver = new ActionObserver(ObserverType.ABNORMALSETTED) {
 
@@ -125,7 +109,7 @@ public class RideAction extends AbstractItemAction {
 			}
 		};
 		player.getObserveController().addObserver(rideObserver);
-		player.setRideObservers(rideObserver);
+		player.addRideObserver(rideObserver);
 
 		// TODO some mounts have lower chance of dismounting
 		ActionObserver attackedObserver = new ActionObserver(ObserverType.ATTACKED) {
@@ -137,7 +121,7 @@ public class RideAction extends AbstractItemAction {
 			}
 		};
 		player.getObserveController().addObserver(attackedObserver);
-		player.setRideObservers(attackedObserver);
+		player.addRideObserver(attackedObserver);
 
 		ActionObserver dotAttackedObserver = new ActionObserver(ObserverType.DOT_ATTACKED) {
 
@@ -148,7 +132,21 @@ public class RideAction extends AbstractItemAction {
 			}
 		};
 		player.getObserveController().addObserver(dotAttackedObserver);
-		player.setRideObservers(dotAttackedObserver);
+		player.addRideObserver(dotAttackedObserver);
+	}
+
+	private void finishUse(Player player, Item parentItem) {
+		player.unsetState(CreatureState.ACTIVE);
+		player.setState(CreatureState.RESTING);
+		if (player.isInFlyingState())
+			player.setState(CreatureState.FLOATING_CORPSE);
+		ItemTemplate itemTemplate = parentItem.getItemTemplate();
+		player.setPlayerMode(PlayerMode.RIDE, getRideInfo());
+		PacketSendUtility.broadcastPacket(player, new SM_EMOTION(player, EmotionType.CHANGE_SPEED, 0, 0), true);
+		PacketSendUtility.broadcastPacket(player, new SM_EMOTION(player, EmotionType.RIDE, 0, getRideInfo().getNpcId()), true);
+		PacketSendUtility.broadcastPacket(player,
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 1), true);
+		QuestEngine.getInstance().rideAction(new QuestEnv(null, player, 0), itemTemplate.getTemplateId());
 	}
 
 	public RideInfo getRideInfo() {

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
@@ -136,6 +136,7 @@ public class RideAction extends AbstractItemAction {
 	}
 
 	private void finishUse(Player player, Item parentItem) {
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		player.unsetState(CreatureState.ACTIVE);
 		player.setState(CreatureState.RESTING);
 		if (player.isInFlyingState())

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
@@ -136,6 +136,11 @@ public class RideAction extends AbstractItemAction {
 	}
 
 	private void finishUse(Player player, Item parentItem) {
+		if (!canAct(player, parentItem, null)) {
+			PacketSendUtility.broadcastPacket(player,
+				new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 3, 0), true);
+			return;
+		}
 		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		player.unsetState(CreatureState.ACTIVE);
 		player.setState(CreatureState.RESTING);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
@@ -83,7 +83,7 @@ public class RideAction extends AbstractItemAction {
 			final ItemUseObserver observer = new ItemUseObserver() {
 				@Override
 				public void abort() {
-					player.getController().cancelUseItem();
+					player.getController().cancelUseItem(false);
 					player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 					PacketSendUtility.broadcastPacket(player,

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
@@ -84,7 +84,6 @@ public class RideAction extends AbstractItemAction {
 				@Override
 				public void abort() {
 					player.getController().cancelUseItem(false);
-					player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 					PacketSendUtility.broadcastPacket(player,
 						new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 3, 0), true);
@@ -94,6 +93,7 @@ public class RideAction extends AbstractItemAction {
 			player.getObserveController().attach(observer);
 			player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 				player.getObserveController().removeObserver(observer);
+				player.startCooldown(parentItem);
 				finishUse(player, parentItem);
 			}, castingDelay));
 		}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
@@ -96,6 +96,22 @@ public class RideAction extends AbstractItemAction {
 				finishUse(player, parentItem);
 			}, castingDelay));
 		}
+	}
+
+	private void finishUse(Player player, Item parentItem) {
+		if (!canAct(player, parentItem, null)) {
+			PacketSendUtility.broadcastPacket(player,
+				new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 3, 0), true);
+			return;
+		}
+		player.startCooldown(parentItem);
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
+		player.unsetState(CreatureState.ACTIVE);
+		player.setState(CreatureState.RESTING);
+		if (player.isInFlyingState())
+			player.setState(CreatureState.FLOATING_CORPSE);
+		ItemTemplate itemTemplate = parentItem.getItemTemplate();
+		player.setPlayerMode(PlayerMode.RIDE, getRideInfo());
 
 		ActionObserver rideObserver = new ActionObserver(ObserverType.ABNORMALSETTED) {
 
@@ -132,22 +148,7 @@ public class RideAction extends AbstractItemAction {
 		};
 		player.getObserveController().addObserver(dotAttackedObserver);
 		player.addRideObserver(dotAttackedObserver);
-	}
 
-	private void finishUse(Player player, Item parentItem) {
-		if (!canAct(player, parentItem, null)) {
-			PacketSendUtility.broadcastPacket(player,
-				new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 3, 0), true);
-			return;
-		}
-		player.startCooldown(parentItem);
-		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
-		player.unsetState(CreatureState.ACTIVE);
-		player.setState(CreatureState.RESTING);
-		if (player.isInFlyingState())
-			player.setState(CreatureState.FLOATING_CORPSE);
-		ItemTemplate itemTemplate = parentItem.getItemTemplate();
-		player.setPlayerMode(PlayerMode.RIDE, getRideInfo());
 		PacketSendUtility.broadcastPacket(player, new SM_EMOTION(player, EmotionType.CHANGE_SPEED, 0, 0), true);
 		PacketSendUtility.broadcastPacket(player, new SM_EMOTION(player, EmotionType.RIDE, 0, getRideInfo().getNpcId()), true);
 		PacketSendUtility.broadcastPacket(player,

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
@@ -93,7 +93,6 @@ public class RideAction extends AbstractItemAction {
 			player.getObserveController().attach(observer);
 			player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 				player.getObserveController().removeObserver(observer);
-				player.startCooldown(parentItem);
 				finishUse(player, parentItem);
 			}, castingDelay));
 		}
@@ -141,6 +140,7 @@ public class RideAction extends AbstractItemAction {
 				new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 3, 0), true);
 			return;
 		}
+		player.startCooldown(parentItem);
 		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		player.unsetState(CreatureState.ACTIVE);
 		player.setState(CreatureState.RESTING);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/SkillLearnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/SkillLearnAction.java
@@ -5,6 +5,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 
+import com.aionemu.gameserver.dataholders.DataManager;
 import com.aionemu.gameserver.model.PlayerClass;
 import com.aionemu.gameserver.model.Race;
 import com.aionemu.gameserver.model.gameobjects.Item;
@@ -12,6 +13,7 @@ import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.services.SkillLearnService;
+import com.aionemu.gameserver.skillengine.model.SkillTemplate;
 import com.aionemu.gameserver.utils.PacketSendUtility;
 
 /**
@@ -51,12 +53,17 @@ public class SkillLearnAction extends AbstractItemAction {
 
 	@Override
 	public void act(Player player, Item parentItem, Item targetItem, Object... params) {
-		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		PacketSendUtility.broadcastPacket(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId()), true);
 
-		// add skill
+		// add skill; SM_SKILL_LIST's embedded messageId alone doesn't show the "you learned" toast for these items, so send it explicitly
 		SkillLearnService.learnSkillBook(player, skillid);
+
+		SkillTemplate skillTemplate = DataManager.SKILL_DATA.getSkillTemplate(skillid);
+		PacketSendUtility.sendPacket(player,
+			SM_SYSTEM_MESSAGE.STR_SKILL_LEARNED_NEW_SKILL(skillTemplate.getL10n(), String.valueOf(skillTemplate.getLvl())));
+
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 
 		// remove book from inventory (assuming its not stackable)
 		Item item = player.getInventory().getItemByObjId(parentItem.getObjectId());

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/SkillLearnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/SkillLearnAction.java
@@ -9,7 +9,6 @@ import com.aionemu.gameserver.model.PlayerClass;
 import com.aionemu.gameserver.model.Race;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
-import com.aionemu.gameserver.model.templates.item.ItemTemplate;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.services.SkillLearnService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
@@ -52,11 +51,9 @@ public class SkillLearnAction extends AbstractItemAction {
 	@Override
 	public void act(Player player, Item parentItem, Item targetItem, Object... params) {
 		// item animation and message
-		ItemTemplate itemTemplate = parentItem.getItemTemplate();
 		// PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.USE_ITEM(itemTemplate.getDescription()));
-		player.getController().cancelUseItem();
 		PacketSendUtility.broadcastPacket(player,
-			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), itemTemplate.getTemplateId()), true);
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId()), true);
 
 		// add skill
 		SkillLearnService.learnSkillBook(player, skillid);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/SkillLearnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/SkillLearnAction.java
@@ -5,7 +5,6 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 
-import com.aionemu.gameserver.dataholders.DataManager;
 import com.aionemu.gameserver.model.PlayerClass;
 import com.aionemu.gameserver.model.Race;
 import com.aionemu.gameserver.model.gameobjects.Item;
@@ -13,7 +12,6 @@ import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.services.SkillLearnService;
-import com.aionemu.gameserver.skillengine.model.SkillTemplate;
 import com.aionemu.gameserver.utils.PacketSendUtility;
 
 /**
@@ -56,12 +54,8 @@ public class SkillLearnAction extends AbstractItemAction {
 		PacketSendUtility.broadcastPacket(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId()), true);
 
-		// add skill; SM_SKILL_LIST's embedded messageId alone doesn't show the "you learned" toast for these items, so send it explicitly
+		// add skill (the "you learned" message is embedded in SM_SKILL_LIST, sent by SkillLearnService)
 		SkillLearnService.learnSkillBook(player, skillid);
-
-		SkillTemplate skillTemplate = DataManager.SKILL_DATA.getSkillTemplate(skillid);
-		PacketSendUtility.sendPacket(player,
-			SM_SYSTEM_MESSAGE.STR_SKILL_LEARNED_NEW_SKILL(skillTemplate.getL10n(), String.valueOf(skillTemplate.getLvl())));
 
 		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/SkillLearnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/SkillLearnAction.java
@@ -10,6 +10,7 @@ import com.aionemu.gameserver.model.Race;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
+import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.services.SkillLearnService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
 
@@ -50,8 +51,7 @@ public class SkillLearnAction extends AbstractItemAction {
 
 	@Override
 	public void act(Player player, Item parentItem, Item targetItem, Object... params) {
-		// item animation and message
-		// PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.USE_ITEM(itemTemplate.getDescription()));
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		PacketSendUtility.broadcastPacket(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId()), true);
 

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/SkillUseAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/SkillUseAction.java
@@ -100,7 +100,6 @@ public class SkillUseAction extends AbstractItemAction {
 	public void act(Player player, Item parentItem, Item targetItem, Object... params) {
 		Skill skill = SkillEngine.getInstance().getSkill(player, skillid, level, player.getTarget(), parentItem.getItemTemplate());
 		if (skill != null) {
-			player.getController().cancelUseItem();
 			skill.setItemObjectId(parentItem.getObjectId());
 			skill.useSkill();
 		}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TamperingAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TamperingAction.java
@@ -59,7 +59,6 @@ public class TamperingAction extends AbstractItemAction {
 			@Override
 			public void run() {
 				player.getObserveController().removeObserver(observer);
-				player.startCooldown(parentItem);
 
 				if (player.getInventory().getItemByObjId(targetItem.getObjectId()) == null && !targetItem.isEquipped()) {
 					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ENCHANT_ITEM_NO_TARGET_ITEM());
@@ -80,6 +79,7 @@ public class TamperingAction extends AbstractItemAction {
 						new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parntObjectId, parentItemId, 0, 2, 0));
 					return;
 				}
+				player.startCooldown(parentItem);
 
 				float temperingChance = calculateChance(player, targetItem);
 				if (Rnd.chance() < temperingChance) {

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TamperingAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TamperingAction.java
@@ -48,10 +48,9 @@ public class TamperingAction extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				player.getController().cancelTask(TaskId.ITEM_USE);
+				player.getController().cancelUseItem();
 				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_AUTHORIZE_CANCEL(targetItem.getL10n()));
-				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parntObjectId, parentItemId, 0, 3, 0), true);
 				player.getObserveController().removeObserver(this);
 			}
 		};

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TamperingAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TamperingAction.java
@@ -68,51 +68,55 @@ public class TamperingAction extends AbstractItemAction {
 					return;
 				}
 
+				int maxTemp = targetItem.getItemTemplate().getMaxTampering();
+				if (targetItem.getTempering() >= maxTemp) {
+					PacketSendUtility.broadcastPacketAndReceive(player,
+						new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parntObjectId, parentItemId, 0, 2, 0));
+					return;
+				}
+
 				if (!player.getInventory().decreaseByObjectId(parntObjectId, 1)) {
 					PacketSendUtility.broadcastPacketAndReceive(player,
 						new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parntObjectId, parentItemId, 0, 2, 0));
 					return;
 				}
 
-				int maxTemp = targetItem.getItemTemplate().getMaxTampering();
-				if (targetItem.getTempering() < maxTemp) {
-					float temperingChance = calculateChance(player, targetItem);
-					if (Rnd.chance() < temperingChance) {
-						setTemperingLevel(targetItem, player, targetItem.getTempering() + 1);
-						PacketSendUtility.sendPacket(player,
-							SM_SYSTEM_MESSAGE.STR_MSG_ITEM_AUTHORIZE_SUCCEEDED(targetItem.getL10n(), targetItem.getTempering()));
-						PacketSendUtility.broadcastPacketAndReceive(player,
-							new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parntObjectId, parentItemId, 0, 1, 0));
+				float temperingChance = calculateChance(player, targetItem);
+				if (Rnd.chance() < temperingChance) {
+					setTemperingLevel(targetItem, player, targetItem.getTempering() + 1);
+					PacketSendUtility.sendPacket(player,
+						SM_SYSTEM_MESSAGE.STR_MSG_ITEM_AUTHORIZE_SUCCEEDED(targetItem.getL10n(), targetItem.getTempering()));
+					PacketSendUtility.broadcastPacketAndReceive(player,
+						new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parntObjectId, parentItemId, 0, 1, 0));
 
-						if (CustomConfig.ENABLE_ENCHANT_ANNOUNCE && targetItem.getTempering() == 10) {
-							PacketSendUtility.broadcastToWorld(
-								SM_SYSTEM_MESSAGE.STR_MSG_ITEM_AUTHORIZE_SUCCEEDED_MAX(player.getName(), targetItem.getItemTemplate().getL10n(),
-									targetItem.getTempering()),
-								Predicates.Players.sameRace(player));
-						}
-
-						if (LoggingConfig.LOG_TAMPERING)
-							log.info("Player " + player.getName() + " successfully tampered item " + targetItem.getItemId() + "(" + targetItem.getObjectId()
-								+ ") to level " + targetItem.getTempering());
-					} else {
-						setTemperingLevel(targetItem, player, 0);
-						if (targetItem.getItemTemplate().getItemGroup() == ItemGroup.PLUME) {
-							PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_AUTHORIZE_FAILED_TSHIRT(targetItem.getL10n()));
-							PacketSendUtility.broadcastPacketAndReceive(player,
-								new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parntObjectId, parentItemId, 0, 2, 0));
-							if (targetItem.isEquipped())
-								player.getEquipment().decreaseEquippedItemCount(targetItem.getObjectId(), 1);
-							else
-								player.getInventory().decreaseByObjectId(targetItem.getObjectId(), 1);
-						} else {
-							PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_AUTHORIZE_FAILED(targetItem.getL10n()));
-							PacketSendUtility.broadcastPacketAndReceive(player,
-								new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parntObjectId, parentItemId, 0, 2, 0));
-						}
-
-						if (LoggingConfig.LOG_TAMPERING)
-							log.info("Player " + player.getName() + " failed to tamper item " + targetItem.getItemId() + "(" + targetItem.getObjectId() + ").");
+					if (CustomConfig.ENABLE_ENCHANT_ANNOUNCE && targetItem.getTempering() == 10) {
+						PacketSendUtility.broadcastToWorld(
+							SM_SYSTEM_MESSAGE.STR_MSG_ITEM_AUTHORIZE_SUCCEEDED_MAX(player.getName(), targetItem.getItemTemplate().getL10n(),
+								targetItem.getTempering()),
+							Predicates.Players.sameRace(player));
 					}
+
+					if (LoggingConfig.LOG_TAMPERING)
+						log.info("Player {} successfully tampered item {}({}) to level {}", player.getName(), targetItem.getItemId(), targetItem.getObjectId(),
+							targetItem.getTempering());
+				} else {
+					setTemperingLevel(targetItem, player, 0);
+					if (targetItem.getItemTemplate().getItemGroup() == ItemGroup.PLUME) {
+						PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_AUTHORIZE_FAILED_TSHIRT(targetItem.getL10n()));
+						PacketSendUtility.broadcastPacketAndReceive(player,
+							new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parntObjectId, parentItemId, 0, 2, 0));
+						if (targetItem.isEquipped())
+							player.getEquipment().decreaseEquippedItemCount(targetItem.getObjectId(), 1);
+						else
+							player.getInventory().decreaseByObjectId(targetItem.getObjectId(), 1);
+					} else {
+						PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_AUTHORIZE_FAILED(targetItem.getL10n()));
+						PacketSendUtility.broadcastPacketAndReceive(player,
+							new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parntObjectId, parentItemId, 0, 2, 0));
+					}
+
+					if (LoggingConfig.LOG_TAMPERING)
+						log.info("Player {} failed to tamper item {}({}).", player.getName(), targetItem.getItemId(), targetItem.getObjectId());
 				}
 			}
 

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TamperingAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TamperingAction.java
@@ -49,7 +49,6 @@ public class TamperingAction extends AbstractItemAction {
 			@Override
 			public void abort() {
 				player.getController().cancelUseItem();
-				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_AUTHORIZE_CANCEL(targetItem.getL10n()));
 				player.getObserveController().removeObserver(this);
 			}
@@ -60,6 +59,7 @@ public class TamperingAction extends AbstractItemAction {
 			@Override
 			public void run() {
 				player.getObserveController().removeObserver(observer);
+				player.startCooldown(parentItem);
 
 				if (player.getInventory().getItemByObjId(targetItem.getObjectId()) == null && !targetItem.isEquipped()) {
 					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ENCHANT_ITEM_NO_TARGET_ITEM());

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TitleAddAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TitleAddAction.java
@@ -44,6 +44,7 @@ public class TitleAddAction extends AbstractItemAction {
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), itemTemplate.getTemplateId()), true);
 
 		if (player.getTitleList().addTitle(titleid, false, minutes == null ? 0 : ((int) (System.currentTimeMillis() / 1000)) + minutes * 60)) {
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 			Item item = player.getInventory().getItemByObjId(parentItem.getObjectId());
 			player.getInventory().delete(item);
 		}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ToyPetSpawnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ToyPetSpawnAction.java
@@ -96,6 +96,7 @@ public class ToyPetSpawnAction extends AbstractItemAction {
 	}
 
 	private void finishUse(Player player, Item parentItem) {
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		PacketSendUtility.broadcastPacket(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 1), true);
 		// RemoveKisk

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ToyPetSpawnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ToyPetSpawnAction.java
@@ -90,7 +90,6 @@ public class ToyPetSpawnAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			player.startCooldown(parentItem);
 			finishUse(player, parentItem);
 		}, castingDelay));
 	}
@@ -107,6 +106,7 @@ public class ToyPetSpawnAction extends AbstractItemAction {
 		// RemoveKisk
 		if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1))
 			return;
+		player.startCooldown(parentItem);
 		float x = player.getX();
 		float y = player.getY();
 		float z = player.getZ();

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ToyPetSpawnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ToyPetSpawnAction.java
@@ -69,14 +69,18 @@ public class ToyPetSpawnAction extends AbstractItemAction {
 	@Override
 	public void act(final Player player, final Item parentItem, Item targetItem, Object... params) {
 		// ShowAction
-		player.getController().cancelUseItem();
+		int castingDelay = parentItem.getItemTemplate().getCastingDelay();
+		if (castingDelay <= 0) {
+			finishUse(player, parentItem);
+			return;
+		}
 		PacketSendUtility.broadcastPacket(player,
-			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 10000, 0, 0), true);
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), castingDelay, 0, 0), true);
 		final ItemUseObserver observer = new ItemUseObserver() {
 
 			@Override
 			public void abort() {
-				player.getController().cancelTask(TaskId.ITEM_USE);
+				player.getController().cancelUseItem(false);
 				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player,
@@ -86,35 +90,38 @@ public class ToyPetSpawnAction extends AbstractItemAction {
 
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
-			PacketSendUtility.broadcastPacket(player,
-				new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 1), true);
 			player.getObserveController().removeObserver(observer);
-			// RemoveKisk
-			if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1))
-				return;
-			float x = player.getX();
-			float y = player.getY();
-			float z = player.getZ();
-			byte heading = (byte) ((player.getHeading() + 60) % 120);
-			int worldId = player.getWorldId();
-			int instanceId = player.getInstanceId();
-			SpawnTemplate spawn = SpawnEngine.newSingleTimeSpawn(worldId, npcid, x, y, z, heading);
+			finishUse(player, parentItem);
+		}, castingDelay));
+	}
 
-			final Kisk kisk = VisibleObjectSpawner.spawnKisk(spawn, instanceId, player);
-			final int objOwnerId = player.getObjectId();
-			// Schedule Despawn Action
-			Future<?> task = ThreadPoolManager.getInstance().schedule(() -> kisk.getController().delete(), kisk.getRemainingLifetime(), TimeUnit.SECONDS);
-			kisk.getController().addTask(TaskId.DESPAWN, task);
+	private void finishUse(Player player, Item parentItem) {
+		PacketSendUtility.broadcastPacket(player,
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 1), true);
+		// RemoveKisk
+		if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1))
+			return;
+		float x = player.getX();
+		float y = player.getY();
+		float z = player.getZ();
+		byte heading = (byte) ((player.getHeading() + 60) % 120);
+		int worldId = player.getWorldId();
+		int instanceId = player.getInstanceId();
+		SpawnTemplate spawn = SpawnEngine.newSingleTimeSpawn(worldId, npcid, x, y, z, heading);
 
-			// ShowFinalAction
-			player.getController().cancelTask(TaskId.ITEM_USE);
-			KiskService.getInstance().regKisk(kisk, objOwnerId);
+		final Kisk kisk = VisibleObjectSpawner.spawnKisk(spawn, instanceId, player);
+		final int objOwnerId = player.getObjectId();
+		// Schedule Despawn Action
+		Future<?> task = ThreadPoolManager.getInstance().schedule(() -> kisk.getController().delete(), kisk.getRemainingLifetime(), TimeUnit.SECONDS);
+		kisk.getController().addTask(TaskId.DESPAWN, task);
 
-			if (kisk.getMaxMembers() > 1)
-				kisk.getController().onDialogRequest(player);
-			else
-				KiskService.getInstance().onBind(kisk, player);
-		}, 10000));
+		// ShowFinalAction
+		KiskService.getInstance().regKisk(kisk, objOwnerId);
+
+		if (kisk.getMaxMembers() > 1)
+			kisk.getController().onDialogRequest(player);
+		else
+			KiskService.getInstance().onBind(kisk, player);
 	}
 
 	private boolean isPutKiskZone(Player player) {

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ToyPetSpawnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ToyPetSpawnAction.java
@@ -96,6 +96,8 @@ public class ToyPetSpawnAction extends AbstractItemAction {
 	}
 
 	private void finishUse(Player player, Item parentItem) {
+		if (!canAct(player, parentItem, null))
+			return;
 		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		PacketSendUtility.broadcastPacket(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 1), true);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ToyPetSpawnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ToyPetSpawnAction.java
@@ -81,7 +81,6 @@ public class ToyPetSpawnAction extends AbstractItemAction {
 			@Override
 			public void abort() {
 				player.getController().cancelUseItem(false);
-				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0), true);
@@ -91,6 +90,7 @@ public class ToyPetSpawnAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
+			player.startCooldown(parentItem);
 			finishUse(player, parentItem);
 		}, castingDelay));
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ToyPetSpawnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ToyPetSpawnAction.java
@@ -96,8 +96,11 @@ public class ToyPetSpawnAction extends AbstractItemAction {
 	}
 
 	private void finishUse(Player player, Item parentItem) {
-		if (!canAct(player, parentItem, null))
+		if (!canAct(player, parentItem, null)) {
+			PacketSendUtility.broadcastPacket(player,
+				new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 2, 0), true);
 			return;
+		}
 		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(parentItem.getL10n()));
 		PacketSendUtility.broadcastPacket(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 1, 1), true);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TuningAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TuningAction.java
@@ -63,12 +63,12 @@ public class TuningAction extends AbstractItemAction {
 		int tuningScrollItemId = parentItem.getItemId();
 		int tuningScrollObjectId = parentItem.getObjectId();
 		PacketSendUtility.broadcastPacket(player,
-			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), tuningScrollItemId, 5000, 12, 0), true);
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), tuningScrollObjectId, tuningScrollItemId, 5000, 12, 0), true);
 		ItemUseObserver observer = new ItemUseObserver() {
 
 			@Override
 			public void abort() {
-				player.getController().cancelTask(TaskId.ITEM_USE);
+				player.getController().cancelUseItem(false);
 				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_REIDENTIFY_CANCELED(targetItem.getL10n()));
 				PacketSendUtility.broadcastPacket(player,

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TuningAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TuningAction.java
@@ -69,7 +69,6 @@ public class TuningAction extends AbstractItemAction {
 			@Override
 			public void abort() {
 				player.getController().cancelUseItem(false);
-				player.removeItemCoolDown(parentItem.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_REIDENTIFY_CANCELED(targetItem.getL10n()));
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), tuningScrollObjectId, tuningScrollItemId, 0, 14, 0), true);
@@ -80,6 +79,7 @@ public class TuningAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
+			player.startCooldown(parentItem);
 			if (player.getInventory().getItemByObjId(targetItem.getObjectId()) == null || !canAct(player, parentItem, targetItem)) {
 				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), tuningScrollObjectId, tuningScrollItemId, 0, 14, 0),
 					true);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TuningAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TuningAction.java
@@ -80,6 +80,11 @@ public class TuningAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
+			if (player.getInventory().getItemByObjId(targetItem.getObjectId()) == null || !canAct(player, parentItem, targetItem)) {
+				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), tuningScrollObjectId, tuningScrollItemId, 0, 14, 0),
+					true);
+				return;
+			}
 			PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), tuningScrollObjectId, tuningScrollItemId, 0, 13, 0),
 				true);
 			if (!player.getInventory().decreaseByObjectId(tuningScrollObjectId, 1))

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TuningAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TuningAction.java
@@ -79,7 +79,6 @@ public class TuningAction extends AbstractItemAction {
 		player.getObserveController().attach(observer);
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
 			player.getObserveController().removeObserver(observer);
-			player.startCooldown(parentItem);
 			if (player.getInventory().getItemByObjId(targetItem.getObjectId()) == null || !canAct(player, parentItem, targetItem)) {
 				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), tuningScrollObjectId, tuningScrollItemId, 0, 14, 0),
 					true);
@@ -89,6 +88,7 @@ public class TuningAction extends AbstractItemAction {
 				true);
 			if (!player.getInventory().decreaseByObjectId(tuningScrollObjectId, 1))
 				return;
+			player.startCooldown(parentItem);
 
 			int newOptionalSockets, newEnchantBonus, newStatBonusId;
 			if (shouldNotReduceTuneCount) { // only tune attributes (bonus stats)

--- a/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_USE_ITEM.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_USE_ITEM.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import com.aionemu.gameserver.model.TaskId;
 import com.aionemu.gameserver.model.gameobjects.HouseObject;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
@@ -114,12 +115,6 @@ public class CM_USE_ITEM extends AionClientPacket {
 		if (actions.isEmpty())
 			return; // notification should be handled in canAct
 
-		int useDelay = item.getItemTemplate().getUseLimits().getDelayTime();
-		if (useDelay > 0)
-			player.addItemCoolDown(item.getItemTemplate().getUseLimits().getDelayId(), System.currentTimeMillis() + useDelay, useDelay / 1000);
-
-
-
 		for (AbstractItemAction itemAction : actions) {
 			switch (itemAction) {
 				case DyeAction _ -> itemAction.act(player, item, targetItem, targetHouseObject);
@@ -128,5 +123,10 @@ public class CM_USE_ITEM extends AionClientPacket {
 				default -> itemAction.act(player, item, targetItem);
 			}
 		}
+
+		// the use delay starts when the item use is over, so actions which cast start it themselves
+		if (!player.getController().hasScheduledTask(TaskId.ITEM_USE)
+			&& !(player.isCasting() && player.getCastingSkill().getItemTemplate() != null))
+			player.startCooldown(item);
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_USE_ITEM.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_USE_ITEM.java
@@ -12,6 +12,7 @@ import com.aionemu.gameserver.model.templates.item.actions.AbstractItemAction;
 import com.aionemu.gameserver.model.templates.item.actions.DyeAction;
 import com.aionemu.gameserver.model.templates.item.actions.InstanceTimeClear;
 import com.aionemu.gameserver.model.templates.item.actions.MultiReturnAction;
+import com.aionemu.gameserver.model.templates.item.actions.QuestStartAction;
 import com.aionemu.gameserver.network.aion.AionClientPacket;
 import com.aionemu.gameserver.network.aion.AionConnection.State;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
@@ -81,11 +82,13 @@ public class CM_USE_ITEM extends AionClientPacket {
 		if (!PlayerRestrictions.canUseItem(player, item))
 			return;
 
-		HandlerResult result = QuestEngine.getInstance().onItemUseEvent(new QuestEnv(null, player, 0), item);
-
 		List<AbstractItemAction> itemActions = item.getItemTemplate().getActions() == null ? Collections.emptyList()
 			: item.getItemTemplate().getActions().getItemActions();
-		
+
+		// QuestStartAction opens the quest dialog itself (after the casting delay), quest handlers must not open it a second time
+		HandlerResult result = itemActions.stream().anyMatch(a -> a instanceof QuestStartAction) ? HandlerResult.UNKNOWN
+			: QuestEngine.getInstance().onItemUseEvent(new QuestEnv(null, player, 0), item);
+
 		if (itemActions.isEmpty() && result != HandlerResult.SUCCESS) {
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_IS_NOT_USABLE());
 			return;
@@ -107,7 +110,7 @@ public class CM_USE_ITEM extends AionClientPacket {
 				actions.add(itemAction);
 			}
 		}
-		
+
 		if (actions.isEmpty())
 			return; // notification should be handled in canAct
 

--- a/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_USE_ITEM.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_USE_ITEM.java
@@ -75,6 +75,9 @@ public class CM_USE_ITEM extends AionClientPacket {
 		if (player.isCasting())
 			player.getController().cancelCurrentSkill(null);
 
+		// notify item use observer
+		player.getObserveController().notifyItemuseObservers(item);
+
 		if (!PlayerRestrictions.canUseItem(player, item))
 			return;
 
@@ -82,7 +85,7 @@ public class CM_USE_ITEM extends AionClientPacket {
 
 		List<AbstractItemAction> itemActions = item.getItemTemplate().getActions() == null ? Collections.emptyList()
 			: item.getItemTemplate().getActions().getItemActions();
-
+		
 		if (itemActions.isEmpty() && result != HandlerResult.SUCCESS) {
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_IS_NOT_USABLE());
 			return;
@@ -104,7 +107,7 @@ public class CM_USE_ITEM extends AionClientPacket {
 				actions.add(itemAction);
 			}
 		}
-
+		
 		if (actions.isEmpty())
 			return; // notification should be handled in canAct
 
@@ -112,18 +115,14 @@ public class CM_USE_ITEM extends AionClientPacket {
 		if (useDelay > 0)
 			player.addItemCoolDown(item.getItemTemplate().getUseLimits().getDelayId(), System.currentTimeMillis() + useDelay, useDelay / 1000);
 
-		// notify item use observer
-		player.getObserveController().notifyItemuseObservers(item);
+
 
 		for (AbstractItemAction itemAction : actions) {
-			if (itemAction instanceof DyeAction) {
-				itemAction.act(player, item, targetItem, targetHouseObject);
-			} else if (itemAction instanceof MultiReturnAction) {
-				itemAction.act(player, item, targetItem, indexReturn);
-			} else if (itemAction instanceof InstanceTimeClear) {
-				itemAction.act(player, item, targetItem, syncId);
-			} else {
-				itemAction.act(player, item, targetItem);
+			switch (itemAction) {
+				case DyeAction _ -> itemAction.act(player, item, targetItem, targetHouseObject);
+				case MultiReturnAction _ -> itemAction.act(player, item, targetItem, indexReturn);
+				case InstanceTimeClear _ -> itemAction.act(player, item, targetItem, syncId);
+				default -> itemAction.act(player, item, targetItem);
 			}
 		}
 	}

--- a/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_USE_ITEM.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_USE_ITEM.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import com.aionemu.gameserver.model.TaskId;
 import com.aionemu.gameserver.model.gameobjects.HouseObject;
 import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
@@ -123,10 +122,5 @@ public class CM_USE_ITEM extends AionClientPacket {
 				default -> itemAction.act(player, item, targetItem);
 			}
 		}
-
-		// the use delay starts when the item use is over, so actions which cast start it themselves
-		if (!player.getController().hasScheduledTask(TaskId.ITEM_USE)
-			&& !(player.isCasting() && player.getCastingSkill().getItemTemplate() != null))
-			player.startCooldown(item);
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_ITEM_USAGE_ANIMATION.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_ITEM_USAGE_ANIMATION.java
@@ -95,4 +95,9 @@ public class SM_ITEM_USAGE_ANIMATION extends AionServerPacket {
 		writeC(unk2);// unk
 		writeD(unk3);// mb cd?
 	}
+
+	@Override
+	public String toString() {
+		return String.format("//fsc 183 dddddccccd %s %s %s %s %s %s %s %s %s %s", playerObjId, targetObjId, itemObjId, itemId, time, end, unk, unk1, unk2, unk3);
+	}
 }

--- a/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_ITEM_USAGE_ANIMATION.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_ITEM_USAGE_ANIMATION.java
@@ -95,9 +95,4 @@ public class SM_ITEM_USAGE_ANIMATION extends AionServerPacket {
 		writeC(unk2);// unk
 		writeD(unk3);// mb cd?
 	}
-
-	@Override
-	public String toString() {
-		return String.format("//fsc 183 dddddccccd %s %s %s %s %s %s %s %s %s %s", playerObjId, targetObjId, itemObjId, itemId, time, end, unk, unk1, unk2, unk3);
-	}
 }

--- a/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_SYSTEM_MESSAGE.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_SYSTEM_MESSAGE.java
@@ -25172,6 +25172,13 @@ public final class SM_SYSTEM_MESSAGE extends AionServerPacket {
 	}
 
 	/**
+	 * Assembly canceled.
+	 */
+	public static SM_SYSTEM_MESSAGE STR_ASSEMBLY_ITEM_CANCELED() {
+		return new SM_SYSTEM_MESSAGE(1401123);
+	}
+
+	/**
 	 * This emblem is already registered.
 	 */
 	public static SM_SYSTEM_MESSAGE STR_GUILD_ALREADY_POSTED_THIS_EMBLEM() {
@@ -26136,6 +26143,69 @@ public final class SM_SYSTEM_MESSAGE extends AionServerPacket {
 	}
 
 	/**
+	 * No Abyss Points can be extracted from %0.
+	 */
+	public static SM_SYSTEM_MESSAGE STR_MSG_AP_DECOMPOSE_CANNOT(String itemL10n) {
+		return new SM_SYSTEM_MESSAGE(1401640, itemL10n);
+	}
+
+	/**
+	 * The level of %0 is below %1. No Abyss Points can be obtained.
+	 */
+	public static SM_SYSTEM_MESSAGE STR_MSG_AP_DECOMPOSE_WRONG_LEVEL(String itemL10n, int levelRequired) {
+		return new SM_SYSTEM_MESSAGE(1401641, itemL10n, levelRequired);
+	}
+
+	/**
+	 * The value of %0 is lower than %1, so no Abyss Points can be obtained.
+	 */
+	public static SM_SYSTEM_MESSAGE STR_MSG_AP_DECOMPOSE_WRONG_QUALITY(String extractItemL10n, String targetItemL10n) {
+		return new SM_SYSTEM_MESSAGE(1401642, extractItemL10n, targetItemL10n);
+	}
+
+	/**
+	 * No Abyss Points can be extracted from %1 with %0.
+	 */
+	public static SM_SYSTEM_MESSAGE STR_MSG_AP_DECOMPOSE_WRONG_TARGET_ITEM_CATEGORY(String extractItemL10n, String targetItemL10n) {
+		return new SM_SYSTEM_MESSAGE(1401643, extractItemL10n, targetItemL10n);
+	}
+
+	/**
+	 * The extraction of Abyss Points from %0 was interrupted.
+	 */
+	public static SM_SYSTEM_MESSAGE STR_MSG_AP_DECOMPOSE_ITEM_CANCELED(String itemL10n) {
+		return new SM_SYSTEM_MESSAGE(1401644, itemL10n);
+	}
+
+	/**
+	 * Abyss Points were extracted from %0.
+	 */
+	public static SM_SYSTEM_MESSAGE STR_MSG_AP_DECOMPOSE_ITEM_SUCCEED(String itemL10n) {
+		return new SM_SYSTEM_MESSAGE(1401645, itemL10n);
+	}
+
+	/**
+	 * Abyss Points cannot be extracted from an equipped object.
+	 */
+	public static SM_SYSTEM_MESSAGE STR_MSG_AP_DECOMPOSE_WRONG_EQUIPED() {
+		return new SM_SYSTEM_MESSAGE(1401646);
+	}
+
+	/**
+	 * You have reached the maximum number of Abyss Points for Level %0. The extraction of %0 has been cancelled.
+	 */
+	public static SM_SYSTEM_MESSAGE STR_MSG_AP_DECOMPOSE_ITEM_CANCELED_BAN(String itemL10n) {
+		return new SM_SYSTEM_MESSAGE(1401647, itemL10n);
+	}
+
+	/**
+	 * You have received %num0 Abyss Point(s).
+	 */
+	public static SM_SYSTEM_MESSAGE STR_MSG_AP_DECOMPOSE_ITEM_SUCCEED_AP(int num0) {
+		return new SM_SYSTEM_MESSAGE(1401656, num0);
+	}
+
+	/**
 	 * The Idian level is too high for the selected item.
 	 */
 	public static SM_SYSTEM_MESSAGE STR_MSG_POLISH_WRONG_LEVEL() {
@@ -26154,6 +26224,13 @@ public final class SM_SYSTEM_MESSAGE extends AionServerPacket {
 	 */
 	public static SM_SYSTEM_MESSAGE STR_MSG_POLISH_CHANGE_CONDITION_END(String weaponL10n) {
 		return new SM_SYSTEM_MESSAGE(1401652, weaponL10n);
+	}
+
+	/**
+	 * Idian socketing for %0 was cancelled.
+	 */
+	public static SM_SYSTEM_MESSAGE STR_MSG_POLISH_CANCELED(String weaponL10n) {
+		return new SM_SYSTEM_MESSAGE(1401653, weaponL10n);
 	}
 
 	/**

--- a/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_SYSTEM_MESSAGE.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_SYSTEM_MESSAGE.java
@@ -26152,8 +26152,8 @@ public final class SM_SYSTEM_MESSAGE extends AionServerPacket {
 	/**
 	 * The level of %0 is below %1. No Abyss Points can be obtained.
 	 */
-	public static SM_SYSTEM_MESSAGE STR_MSG_AP_DECOMPOSE_WRONG_LEVEL(String itemL10n, int levelRequired) {
-		return new SM_SYSTEM_MESSAGE(1401641, itemL10n, levelRequired);
+	public static SM_SYSTEM_MESSAGE STR_MSG_AP_DECOMPOSE_WRONG_LEVEL(String extractItemL10n, String targetItemL10n) {
+		return new SM_SYSTEM_MESSAGE(1401641, extractItemL10n, targetItemL10n);
 	}
 
 	/**

--- a/game-server/src/com/aionemu/gameserver/restrictions/PlayerRestrictions.java
+++ b/game-server/src/com/aionemu/gameserver/restrictions/PlayerRestrictions.java
@@ -65,8 +65,14 @@ public class PlayerRestrictions {
 		}
 		// check if is casting to avoid multicast exploit
 		// TODO cancel skill if other is used
-		if (player.isCasting())
-			return false;
+		if (player.isCasting()) {
+			if (player.getCastingSkill().getItemTemplate() == null) {
+				return false;
+			} else {
+				player.getController().cancelCurrentSkill(null);
+			}
+		}
+
 
 		if (!player.canAttack() && !template.hasEvadeEffect()) {
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_CAN_NOT_ATTACK_WHILE_IN_ABNORMAL_STATE());

--- a/game-server/src/com/aionemu/gameserver/restrictions/PlayerRestrictions.java
+++ b/game-server/src/com/aionemu/gameserver/restrictions/PlayerRestrictions.java
@@ -331,6 +331,12 @@ public class PlayerRestrictions {
 			return false;
 		}
 
+		// Checked before the "no actions" fallback below so a race mismatch reports correctly even without one
+		if (item.getItemTemplate().getRace() != Race.PC_ALL && item.getItemTemplate().getRace() != player.getRace()) {
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_CANNOT_USE_ITEM_INVALID_RACE());
+			return false;
+		}
+
 		ItemActions itemActions = item.getItemTemplate().getActions();
 		if (itemActions == null || itemActions.getItemActions().isEmpty()) {
 			if (!QuestEngine.getInstance().isRegisteredQuestItem(item.getItemId())) {
@@ -342,11 +348,6 @@ public class PlayerRestrictions {
 		ItemUseLimits limits = item.getItemTemplate().getUseLimits();
 		if (limits.getGenderPermitted() != null && limits.getGenderPermitted() != player.getGender()) {
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_CANNOT_USE_ITEM_INVALID_GENDER());
-			return false;
-		}
-
-		if (item.getItemTemplate().getRace() != Race.PC_ALL && item.getItemTemplate().getRace() != player.getRace()) {
-			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_CANNOT_USE_ITEM_INVALID_RACE());
 			return false;
 		}
 

--- a/game-server/src/com/aionemu/gameserver/restrictions/PlayerRestrictions.java
+++ b/game-server/src/com/aionemu/gameserver/restrictions/PlayerRestrictions.java
@@ -63,16 +63,9 @@ public class PlayerRestrictions {
 		if (!checkFly(player, target) || player.getLifeStats().isAboutToDie() || player.isDead()) {
 			return false;
 		}
-		// check if is casting to avoid multicast exploit
-		// TODO cancel skill if other is used
-		if (player.isCasting()) {
-			if (player.getCastingSkill().getItemTemplate() == null) {
-				return false;
-			} else {
-				player.getController().cancelCurrentSkill(null);
-			}
-		}
-
+		// item casts are interruptible (PlayerController cancels them), skill casts are not
+		if (player.isCasting() && player.getCastingSkill().getItemTemplate() == null)
+			return false;
 
 		if (!player.canAttack() && !template.hasEvadeEffect()) {
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_CAN_NOT_ATTACK_WHILE_IN_ABNORMAL_STATE());

--- a/game-server/src/com/aionemu/gameserver/services/EnchantService.java
+++ b/game-server/src/com/aionemu/gameserver/services/EnchantService.java
@@ -66,13 +66,12 @@ public class EnchantService {
 		else
 			stoneId = 166000191; // Alpha
 
-		if (inventory.decreaseByObjectId(parentItem.getObjectId(), 1)) {
-			if (inventory.delete(targetItem) != null) {
-				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_SUCCEED(targetItem.getL10n()));
-				ItemService.addItem(player, stoneId, itemTemplate.isWeapon() ? Rnd.get(2, 5) : Rnd.get(1, 3));
-			}
-		} else
+		if (!inventory.decreaseByObjectId(parentItem.getObjectId(), 1) || inventory.delete(targetItem) == null) {
 			AuditLogger.log(player, "possibly used break item hack");
+			return false;
+		}
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_SUCCEED(targetItem.getL10n()));
+		ItemService.addItem(player, stoneId, itemTemplate.isWeapon() ? Rnd.get(2, 5) : Rnd.get(1, 3));
 		return true;
 	}
 

--- a/game-server/src/com/aionemu/gameserver/services/EnchantService.java
+++ b/game-server/src/com/aionemu/gameserver/services/EnchantService.java
@@ -66,8 +66,8 @@ public class EnchantService {
 		else
 			stoneId = 166000191; // Alpha
 
-		if (inventory.delete(targetItem) != null) {
-			if (inventory.decreaseByObjectId(parentItem.getObjectId(), 1)) {
+		if (inventory.decreaseByObjectId(parentItem.getObjectId(), 1)) {
+			if (inventory.delete(targetItem) != null) {
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_SUCCEED(targetItem.getL10n()));
 				ItemService.addItem(player, stoneId, itemTemplate.isWeapon() ? Rnd.get(2, 5) : Rnd.get(1, 3));
 			}
@@ -396,10 +396,10 @@ public class EnchantService {
 	}
 
 	public static boolean socketManastoneAct(Player player, Item parentItem, Item targetItem, Item supplementItem, int targetWeapon, boolean result) {
-		// Decrease required supplements
-		player.updateSupplements();
 		if (!player.getInventory().decreaseByObjectId(parentItem.getObjectId(), 1))
 			return false;
+		// Decrease required supplements
+		player.updateSupplements();
 		if (result) {
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_GIVE_ITEM_OPTION_SUCCEED(targetItem.getL10n()));
 

--- a/game-server/src/com/aionemu/gameserver/services/EnchantService.java
+++ b/game-server/src/com/aionemu/gameserver/services/EnchantService.java
@@ -67,8 +67,10 @@ public class EnchantService {
 			stoneId = 166000191; // Alpha
 
 		if (inventory.delete(targetItem) != null) {
-			if (inventory.decreaseByObjectId(parentItem.getObjectId(), 1))
+			if (inventory.decreaseByObjectId(parentItem.getObjectId(), 1)) {
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_SUCCEED(targetItem.getL10n()));
 				ItemService.addItem(player, stoneId, itemTemplate.isWeapon() ? Rnd.get(2, 5) : Rnd.get(1, 3));
+			}
 		} else
 			AuditLogger.log(player, "possibly used break item hack");
 		return true;

--- a/game-server/src/com/aionemu/gameserver/services/QuestService.java
+++ b/game-server/src/com/aionemu/gameserver/services/QuestService.java
@@ -937,7 +937,8 @@ public final class QuestService {
 		if (qwi != null) {
 			for (QuestItems qi : qwi.getQuestWorkItem()) {
 				if (qi != null) {
-					long count = player.getInventory().getItemCountByItemId(qi.getItemId());
+					// Only remove the amount the quest actually needs, not the player's whole stack of that item
+					long count = Math.min(qi.getCount(), player.getInventory().getItemCountByItemId(qi.getItemId()));
 					if (count > 0)
 						player.getInventory().decreaseByItemId(qi.getItemId(), count, qs.getStatus());
 				}

--- a/game-server/src/com/aionemu/gameserver/services/StigmaService.java
+++ b/game-server/src/com/aionemu/gameserver/services/StigmaService.java
@@ -379,7 +379,6 @@ public class StigmaService {
 			@Override
 			public void abort() {
 				player.getController().cancelUseItem(false);
-				player.removeItemCoolDown(stigma.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentObjectId, chargeStone.getObjectId(), parentItemId, 0, 2, 0), true);

--- a/game-server/src/com/aionemu/gameserver/services/StigmaService.java
+++ b/game-server/src/com/aionemu/gameserver/services/StigmaService.java
@@ -378,7 +378,7 @@ public class StigmaService {
 
 			@Override
 			public void abort() {
-				player.getController().cancelTask(TaskId.ITEM_USE);
+				player.getController().cancelUseItem(false);
 				player.removeItemCoolDown(stigma.getItemTemplate().getUseLimits().getDelayId());
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player,

--- a/game-server/src/com/aionemu/gameserver/services/abyss/AbyssPointsService.java
+++ b/game-server/src/com/aionemu/gameserver/services/abyss/AbyssPointsService.java
@@ -1,5 +1,7 @@
 package com.aionemu.gameserver.services.abyss;
 
+import java.util.function.IntFunction;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,6 +31,10 @@ public class AbyssPointsService {
 	}
 
 	public static void addAp(Player player, int amount) {
+		addAp(player, amount, SM_SYSTEM_MESSAGE::STR_MSG_COMBAT_MY_ABYSS_POINT_GAIN);
+	}
+
+	public static void addAp(Player player, int amount, IntFunction<SM_SYSTEM_MESSAGE> gainMessage) {
 		if (player == null)
 			return;
 
@@ -37,7 +43,7 @@ public class AbyssPointsService {
 		player.getAbyssRank().addAp(amount);
 		int added = player.getAbyssRank().getAp() - oldAp;
 
-		SM_SYSTEM_MESSAGE msg = amount >= 0 ? SM_SYSTEM_MESSAGE.STR_MSG_COMBAT_MY_ABYSS_POINT_GAIN(added) : SM_SYSTEM_MESSAGE.STR_MSG_USE_ABYSSPOINT(-added);
+		SM_SYSTEM_MESSAGE msg = amount >= 0 ? gainMessage.apply(added) : SM_SYSTEM_MESSAGE.STR_MSG_USE_ABYSSPOINT(-added);
 		PacketSendUtility.sendPacket(player, msg);
 		onRankChanged(player, added != 0, oldAbyssRank != player.getAbyssRank().getRank(), null);
 		if (player.isLegionMember() && added > 0) {

--- a/game-server/src/com/aionemu/gameserver/services/item/ItemActionService.java
+++ b/game-server/src/com/aionemu/gameserver/services/item/ItemActionService.java
@@ -27,7 +27,7 @@ public class ItemActionService {
 
 			@Override
 			public void abort() {
-				player.getController().cancelTask(TaskId.ITEM_USE);
+				player.getController().cancelUseItem(false);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_IDENTIFY_CANCELED(item.getL10n()));
 				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), item.getObjectId(), itemId, 0, 11, 0), true);
 				player.getObserveController().removeObserver(this);

--- a/game-server/src/com/aionemu/gameserver/services/item/ItemSocketService.java
+++ b/game-server/src/com/aionemu/gameserver/services/item/ItemSocketService.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.aionemu.gameserver.controllers.observer.StartMovingListener;
+import com.aionemu.gameserver.controllers.observer.ItemUseObserver;
 import com.aionemu.gameserver.dao.ItemStoneListDAO;
 import com.aionemu.gameserver.dataholders.DataManager;
 import com.aionemu.gameserver.model.TaskId;
@@ -161,20 +161,17 @@ public class ItemSocketService {
 			AuditLogger.log(player, "tried to insert godstone in not compatible item " + weapon.getItemId());
 			return;
 		}
-
-		final StartMovingListener move = new StartMovingListener() {
-
+		
+		final ItemUseObserver observer = new ItemUseObserver() {
 			@Override
-			public void moved() {
-				super.moved();
+			public void abort() {
 				player.getObserveController().removeObserver(this);
 				player.getController().cancelUseItem();
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_GIVE_PROC_CANCEL(weapon.getL10n()));
-
 			}
 		};
 
-		player.getObserveController().attach(move);
+		player.getObserveController().attach(observer);
 
 		Item godstone = player.getInventory().getItemByObjId(stoneId);
 		if (godstone == null) {
@@ -192,7 +189,7 @@ public class ItemSocketService {
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), stoneId, itemTemplate.getTemplateId(), 2000, 0, 0));
 
 		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
-			player.getObserveController().removeObserver(move);
+			player.getObserveController().removeObserver(observer);
 
 			PacketSendUtility.broadcastPacketAndReceive(player,
 				new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), stoneId, itemTemplate.getTemplateId(), 0, 1, 0));

--- a/game-server/src/com/aionemu/gameserver/services/item/ItemSocketService.java
+++ b/game-server/src/com/aionemu/gameserver/services/item/ItemSocketService.java
@@ -161,7 +161,7 @@ public class ItemSocketService {
 			AuditLogger.log(player, "tried to insert godstone in not compatible item " + weapon.getItemId());
 			return;
 		}
-		
+
 		final ItemUseObserver observer = new ItemUseObserver() {
 			@Override
 			public void abort() {

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
@@ -353,8 +353,8 @@ public class Skill {
 	}
 
 	private int calculateCastDuration() {
-		if (this.getItemTemplate() != null)
-			return this.getItemTemplate().getCastingDelay();
+		if (getItemTemplate() != null)
+			return getItemTemplate().getCastingDelay();
 		//2nd+ time of multicast-skill activation
 		if (getMultiCastCount() > 0)
 			return 0;

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
@@ -549,17 +549,15 @@ public class Skill {
 		effector.setCasting(null);
 
 		// try removing item, if its not possible return to prevent exploits
-		if (effector instanceof Player && skillMethod == SkillMethod.ITEM) {
-			Item item = ((Player) effector).getInventory().getItemByObjId(itemObjectId);
+		if (skillMethod == SkillMethod.ITEM && effector instanceof Player itemUser) {
+			Item item = itemUser.getInventory().getItemByObjId(itemObjectId);
 			if (item == null)
 				return;
-			if (item.getActivationCount() > 1) {
+			if (item.getActivationCount() > 1)
 				item.setActivationCount(item.getActivationCount() - 1);
-			} else {
-				if (!((Player) effector).getInventory().decreaseByObjectId(item.getObjectId(), 1, ItemUpdateType.DEC_ITEM_USE))
-					return;
-			}
-			((Player) effector).startCooldown(item);
+			else if (!itemUser.getInventory().decreaseByObjectId(item.getObjectId(), 1, ItemUpdateType.DEC_ITEM_USE))
+				return;
+			itemUser.startCooldown(item);
 		}
 
 		endCondCheck();

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
@@ -353,8 +353,11 @@ public class Skill {
 	}
 
 	private int calculateCastDuration() {
-		// ap & cash revival stones, or 2nd+ time of multicast-skill activation
-		if (getSkillId() == 10802 || getMultiCastCount() > 0)
+		if (this.getItemTemplate() != null) {
+			return this.getItemTemplate().getCastingDelay();
+		}
+		//2nd+ time of multicast-skill activation
+		if (getMultiCastCount() > 0)
 			return 0;
 		if (skillTemplate.getType() != SkillType.MAGICAL || !isCastDurationAffectedByCastSpeed())
 			return baseCastDuration;

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
@@ -353,9 +353,8 @@ public class Skill {
 	}
 
 	private int calculateCastDuration() {
-		if (this.getItemTemplate() != null) {
+		if (this.getItemTemplate() != null)
 			return this.getItemTemplate().getCastingDelay();
-		}
 		//2nd+ time of multicast-skill activation
 		if (getMultiCastCount() > 0)
 			return 0;

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
@@ -559,6 +559,7 @@ public class Skill {
 				if (!((Player) effector).getInventory().decreaseByObjectId(item.getObjectId(), 1, ItemUpdateType.DEC_ITEM_USE))
 					return;
 			}
+			((Player) effector).startCooldown(item);
 		}
 
 		endCondCheck();


### PR DESCRIPTION
## Summary

This PR refactors item use flow to align it closer with retail behavior and removes a number of hardcoded casting delay values.

### Casting delays

- Added `casting_delay` to `item_templates.xml` using client 4.8 `client_items_etc.xml` and `client_items_misc.xml` data.
- Replaced hardcoded casting delays in multiple item actions with values from `item_templates.xml`.
- Added `casting_delay` support to `QuestStartAction` and `ReadAction` (8 items retail-confirmed to cast for 2s: 182207613, 182207865, 182213549, 182213550, 182215452, 182215453, 182215577, 182215578).
- Removed `casting_delay` support from `CompositionAction`, since retail ignores it even when present.
- The following actions technically support `casting_delay` on retail if defined in XML, but support was not added since no retail items currently use it: `CraftLearnAction`, `EmotionLearnAction`, `FireworksUseAction`, `TitleAddAction`, `SkillLearnAction`, `ExpandInventoryAction`.

### Cancel / interruption handling

- Added `ItemUseObserver` (or replaced `StartMovingListener`) for several actions to properly cancel ongoing item usage when another item is used. Previously this didn't always happen, which could delay execution (e.g. Soul Bind completing after its cast time) or leave items stuck unusable (e.g. enchant stones staying greyed out). Examples: `AnimationAddAction`, `EnchantItemAction`, `ItemSocketService`, `Equipment` (Soul Bind).
- Item actions that cast skills are now cancelled when another skill is used.
- Observer notification order changed to retail behavior: observers are notified before validating whether the item can actually be used (previously only before `act()`).
- Removed redundant `cancelUseItem()` calls from successful `act()` paths. Only observable difference found: `usingItem` stays set after successful completion until cleared elsewhere, which currently seems to affect only `CM_EMOTION`. Further verification welcome.

### Quest-start items

- Fixed quest dialog opening/closing immediately on use: the quest handler and `QuestStartAction` both tried to open it for the same use. Casting, message order, and race/level gating now match retail (checked against 4.6/5.8/4.8 client data).
- Dropped `queststart` from 4 items retail never actually wires to a quest (188100111, 188100112, 182212214, 182212215). Two are dead duplicates not in retail's item registry at all, and the other two are formally registered but have no activation and can't be used on retail either.

### System messages (retail wording/order)

- Corrected item-use system messages across most item actions to match retail wording/order: missing "You have used %0", wrong/reused message IDs, silent `canAct()` failures now notify the player, corrected cancel messages.
- Fixed message ordering for `ExtractAction`/`EnchantService.breakItem` (extract-success before acquired-item toast), `SkillLearnAction` (learned-skill toast before used-item, plus an explicit `STR_SKILL_LEARNED_NEW_SKILL` message the embedded `SM_SKILL_LIST` messageId doesn't actually trigger for these items), and `CraftLearnAction` (used-item before learned-recipe toast, confirmed the opposite order from `SkillLearnAction` on retail, not a universal rule).
- Fixed `DecomposeAction`'s regular (non-selectable) decompose path sending the wrong success message (`STR_DECOMPOSE_ITEM_SUCCEED`) instead of the retail-correct `STR_UNCOMPRESS_COMPRESSED_ITEM_SUCCEEDED`. `CM_SELECT_DECOMPOSABLE` (the selectable-decompose path) already used the right one.

### Multi-action item audit

Audited every item in the DB for co-occurring action tags. Only 3 combinations ever appear on the same item:

1. `queststart` + `read` (29 items): `ReadAction` was sending a redundant `STR_USE_ITEM`. It now no-ops if a sibling `QuestStartAction` exists on the item.
2. `charge` + `remodel` (1481 items): not a real conflict, `RemodelAction.canAct()` is hardcoded `return false`, so it's dead code that never runs.
3. `decompose` + `fireworkact` (4 event firecracker items): turned out to be a data bug, not a real combo. Cross-checked against the 5.8 server leak, all 4 items only have `<breakdown>1</breakdown>`, no firework field of any kind. Removed the erroneous `<fireworkact/>` tag from these 4 item templates (188051672, 188051711, 188052701, 188052702).

### ApExtractAction retail audit

tested every message and target-matching branch in `ApExtractAction` against 4.6 pts and fixed several bugs found in the process:

- `STR_MSG_AP_DECOMPOSE_WRONG_LEVEL` had the wrong parameters. Retail wording is "The level of %0 is below %1", where %0 is the extraction tool's name and %1 is the target item's name (both strings), but the code passed the target's name twice, once as a raw level number in place of %1.
- `UseTarget.ALL` was not handled at all and always failed with a wrong-category message. Confirmed on retail it acts as a universal target like `EQUIPMENT`.
- `UseTarget.WING` was never actually reachable due to dead code (a leftover check inside the `NONE` switch case that could never be true). AP extraction on wings was completely broken. Added a proper `WING` case.
- `UseTarget.OTHER` is used by retail for non-equipment ("junk") items with the `NONE` item group. Added handling for it, confirmed with a dedicated retail test item.
- Confirmed on retail that `EQUIPMENT` does not extend to `OTHER` category items, unlike `ALL`. Adjusted the code to match.
- Added the "bare" armor item groups (`TORSO`, `PANTS`, `SHOULDER`, `GLOVE`, `SHOES`, without a material prefix) to the armor category mapping. Confirmed on retail these are valid AP extraction targets that previously always failed with a wrong-category message.
- Added the missing casting delay (3 seconds, confirmed on retail, hardcoded like `PolishAction` since retail's own item data doesn't define it either) with proper cancel handling, reusing the `STR_MSG_AP_DECOMPOSE_ITEM_CANCELED` message that already existed in code but was never used.
- Added the missing check for extracting AP from an equipped item (`STR_MSG_AP_DECOMPOSE_WRONG_EQUIPED`, also previously defined but unused). Confirmed on retail this check takes priority over the other validation failures.

### Stale state during casting delays

While adding the `ApExtractAction` casting delay, found and fixed several other item actions that could apply a mutation based on state that changed during their own casting delay (target traded away, sold, re-equipped, or otherwise modified mid-cast), or that consumed items one by one and lost the earlier ones if a later one turned out to be missing:

- `AssemblyItemAction` now verifies all required parts are still present before consuming any of them, instead of consuming them one by one and losing the ones already consumed if a later part is missing.
- `EnchantService.breakItem` and `socketManastoneAct` now consume the cost item (the tool, or the manastone) before the item being acted on or before supplement materials, instead of the reverse order.
- `ChargeAction` now recomputes which equipped items to charge at the end of the cast instead of reusing a list captured at the start.
- `TuningAction` now re-validates the target item's presence and state before applying the tuning result.
- `InstanceTimeClear` now checks the cooldown is still there before consuming the item, instead of consuming it unconditionally.
- `ToyPetSpawnAction` now re-validates before spawning the kisk.

## Known issues (out of scope for this PR)

- ~30 quests have no handler implemented in this emulator at all (items behave correctly now, but there's nothing to accept/progress). Needs the quests themselves written from scratch.
- 188100111/112: shows a generic "can't use" message on use, where retail has zero reaction (verified on 4.6). This is a deliberate deviation, not an oversight: these items carry the same quest-activation scaffolding (`activate_target`, `use_delay`, quest-category flag) as real quest items from the same zone (Danuar Sanctuary), but aren't actually referenced as a work item by any quest in our data or in the retail quest.xml dump. They're orphaned, not wired to anything, likely just named or tagged from the same dev batch as quest 16982/26982's real quest items (182213547/182213548) without ever being hooked up. Silently swallowing the use attempt would make players wonder if the client lagged or the packet didn't go through. A clear "cannot be used" message is more helpful for genuinely dead items like these, and it costs nothing since there's no quest progress to preserve either way.
- Two of the 4 firecracker items above (188051672, 188051711) have no reward data in `decomposable_items.xml`, so `DecomposeAction.canAct()` fails outright ("cannot be decomposed") for them. Full decompose-item reward data reportedly wasn't present in the client before 4.9.
