### PR TITLE
Fix OnFly condition to require flying state

### DIFF
--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Player.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Player.java
@@ -736,7 +736,7 @@ public class Player extends Creature {
 	 */
 	@Override
 	public boolean isFlying() {
-		return flyState >= 1;
+		return flyState != 0;
 	}
 
 	/**

--- a/game-server/src/com/aionemu/gameserver/skillengine/condition/OnFlyCondition.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/condition/OnFlyCondition.java
@@ -18,16 +18,16 @@ public class OnFlyCondition extends Condition {
 
 	@Override
 	public boolean validate(Skill env) {
-		return env.getEffector().isFlying();
+		return env.getEffector().isInFlyingState();
 	}
 
 	@Override
 	public boolean validate(Stat2 stat, IStatFunction statFunction) {
-		return stat.getOwner().isFlying();
+		return stat.getOwner().isInFlyingState();
 	}
 
 	@Override
 	public boolean validate(Effect effect) {
-		return effect.getEffected().isFlying();
+		return effect.getEffected().isInFlyingState();
 	}
 }


### PR DESCRIPTION
OnFlyCondition was using `Creature.isFlying()`, which returns true for any non-zero fly state, including gliding started from the ground.
This causes "while flying" conditions to be applied during regular gliding, which does not match retail behavior.