### PR TITLE
FIX: update NPC look state after dialog closes.

### DIFF
--- a/game-server/src/com/aionemu/gameserver/controllers/NpcController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/NpcController.java
@@ -80,19 +80,15 @@ public class NpcController extends CreatureController<Npc> {
 		getOwner().getGameStats().renewLastChangeTargetTime();
 		if (!getOwner().isDead()) {
 			if (newTarget == null && getOwner().getObjectTemplate().getTalkInfo() != null) {
-				//This packet must be sent after the dialog is closed; otherwise, other players will still see the player interacting with the NPC.
-				PacketSendUtility.broadcastPacket(getOwner(), new SM_LOOKATOBJECT(getOwner()));
 				ThreadPoolManager.getInstance().schedule(() -> {
-					if (getOwner().getTarget() == null) {
-						getOwner().getAi().think();
-					}
+					if (getOwner().getTarget() == null)
+						getOwner().getAi().think(); // resume walking or reset heading
 				}, 750);
-			} else {
-				if (newTarget != null && !getOwner().equals(newTarget)) {
-					getOwner().getPosition().setH(PositionUtil.getHeadingTowards(getOwner(), newTarget));
-				}
-				PacketSendUtility.broadcastPacket(getOwner(), new SM_LOOKATOBJECT(getOwner()));
+			} else if (newTarget != null && !getOwner().equals(newTarget)) {
+				getOwner().getPosition().setH(PositionUtil.getHeadingTowards(getOwner(), newTarget));
 			}
+			// broadcast NPC's current target and heading
+			PacketSendUtility.broadcastPacket(getOwner(), new SM_LOOKATOBJECT(getOwner()));
 		}
 	}
 

--- a/game-server/src/com/aionemu/gameserver/controllers/NpcController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/NpcController.java
@@ -80,13 +80,17 @@ public class NpcController extends CreatureController<Npc> {
 		getOwner().getGameStats().renewLastChangeTargetTime();
 		if (!getOwner().isDead()) {
 			if (newTarget == null && getOwner().getObjectTemplate().getTalkInfo() != null) {
+				//This packet must be sent after the dialog is closed; otherwise, other players will still see the player interacting with the NPC.
+				PacketSendUtility.broadcastPacket(getOwner(), new SM_LOOKATOBJECT(getOwner()));
 				ThreadPoolManager.getInstance().schedule(() -> {
-					if (getOwner().getTarget() == null)
-						getOwner().getAi().think(); // resume walking or reset heading
+					if (getOwner().getTarget() == null) {
+						getOwner().getAi().think();
+					}
 				}, 750);
 			} else {
-				if (newTarget != null && !getOwner().equals(newTarget))
+				if (newTarget != null && !getOwner().equals(newTarget)) {
 					getOwner().getPosition().setH(PositionUtil.getHeadingTowards(getOwner(), newTarget));
+				}
 				PacketSendUtility.broadcastPacket(getOwner(), new SM_LOOKATOBJECT(getOwner()));
 			}
 		}

--- a/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_CLOSE_DIALOG.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_CLOSE_DIALOG.java
@@ -6,6 +6,7 @@ import com.aionemu.gameserver.model.gameobjects.VisibleObject;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.AionClientPacket;
 import com.aionemu.gameserver.network.aion.AionConnection.State;
+import com.aionemu.gameserver.network.aion.serverpackets.SM_LOOKATOBJECT;
 import com.aionemu.gameserver.services.DialogService;
 
 public class CM_CLOSE_DIALOG extends AionClientPacket {
@@ -28,6 +29,9 @@ public class CM_CLOSE_DIALOG extends AionClientPacket {
 	protected void runImpl() {
 		Player player = getConnection().getActivePlayer();
 		VisibleObject target = player.getKnownList().getObject(targetObjectId);
+		if (target == null)
+			return;
 		DialogService.onCloseDialog(player, target);
+		sendPacket(new SM_LOOKATOBJECT(target));
 	}
 }


### PR DESCRIPTION
> Fixed an issue where:
>
> * After closing an NPC dialog or moving away from the NPC, other players would still see the player as interacting with the NPC.
> * The NPC would also incorrectly appear to still be engaged in a conversation with that player.