### PR TITLE
FIX: correct attack display

### DIFF
--- a/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_GM_SHOW_PLAYER_STATUS.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_GM_SHOW_PLAYER_STATUS.java
@@ -89,14 +89,14 @@ public class SM_GM_SHOW_PLAYER_STATUS extends AionServerPacket {
 		writeC(player.getFlyState());// [fly state]
 		writeC(player.getMoveController().getMovementMask());// [movementMask]
 
-		writeH(pgs.getMainHandPAttack(CalculationType.DISPLAY).getCurrent());// [current main hand attack]
-		writeH(pgs.getOffHandPAttack(CalculationType.DISPLAY).getCurrent());// [off hand attack]
+		writeH(Math.max(0, pgs.getMainHandPAttack(CalculationType.DISPLAY).getCurrent()));// [current main hand attack]
+		writeH(Math.max(0, pgs.getOffHandPAttack(CalculationType.DISPLAY).getCurrent()));// [current off hand attack]
 
 		writeH(0);// unk 3.0
 
 		writeD(pgs.getPDef().getCurrent());// [current pdef]
-		writeH(pgs.getMainHandMAttack(CalculationType.DISPLAY).getCurrent());// [current magic attack]
-		writeH(pgs.getOffHandMAttack(CalculationType.DISPLAY).getCurrent());
+		writeH(Math.max(0, pgs.getMainHandMAttack(CalculationType.DISPLAY).getCurrent()));// [current magic attack]
+		writeH(Math.max(0, pgs.getOffHandMAttack(CalculationType.DISPLAY).getCurrent()));// [current off hand magic attack]
 		writeD(pgs.getMDef().getCurrent()); // [Current magic def]
 		writeH(pgs.getMResist().getCurrent());// [current mres]
 		writeH(0);// unk 3.0

--- a/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_STATS_INFO.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_STATS_INFO.java
@@ -76,14 +76,14 @@ public class SM_STATS_INFO extends AionServerPacket {
 		writeC(player.getFlyState());// [fly state]
 		writeC(player.getMoveController().getMovementMask());// [movementMask]
 
-		writeH(pgs.getMainHandPAttack(CalculationType.DISPLAY).getCurrent());// [current main hand attack]
-		writeH(pgs.getOffHandPAttack(CalculationType.DISPLAY).getCurrent());// [current off hand attack]
+		writeH(Math.max(0, pgs.getMainHandPAttack(CalculationType.DISPLAY).getCurrent()));// [current main hand attack]
+		writeH(Math.max(0, pgs.getOffHandPAttack(CalculationType.DISPLAY).getCurrent()));// [current off hand attack]
 
 		writeH(0);// unk 3.0
 
 		writeD(pgs.getPDef().getCurrent());// [current pdef]
-		writeH(pgs.getMainHandMAttack(CalculationType.DISPLAY).getCurrent());// [current magic attack]
-		writeH(pgs.getOffHandMAttack(CalculationType.DISPLAY).getCurrent());// [current off hand magic attack]
+		writeH(Math.max(0, pgs.getMainHandMAttack(CalculationType.DISPLAY).getCurrent()));// [current magic attack]
+		writeH(Math.max(0, pgs.getOffHandMAttack(CalculationType.DISPLAY).getCurrent()));// [current off hand magic attack]
 		writeD(pgs.getMDef().getCurrent()); // [Current magic def]
 		writeH(pgs.getMResist().getCurrent());// [current mres]
 		writeH(0);// unk 3.0


### PR DESCRIPTION
> Fixed an issue where attack values could underflow when a **StatDown** effect reduced a character's attack below zero.
>
> **Example:**
>
> * Current Physical Attack: `120`
> * Effect: `<change stat="PHYSICAL_ATTACK" func="ADD" value="-150"/>`
> * Result: `120 - 150 = -30`
>
> Instead of displaying the correct value, the character stats window would overflow and incorrectly show **+65390** attack for both physical and magical classes.