### PR TITLE
Rework summon release handling

### DIFF
--- a/game-server/data/handlers/instance/TalocsHollowInstance.java
+++ b/game-server/data/handlers/instance/TalocsHollowInstance.java
@@ -13,7 +13,6 @@ import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.Summon;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.model.geometry.Point3D;
-import com.aionemu.gameserver.model.summons.SummonMode;
 import com.aionemu.gameserver.model.summons.UnsummonType;
 import com.aionemu.gameserver.model.templates.flyring.FlyRingTemplate;
 import com.aionemu.gameserver.model.templates.spawns.SpawnTemplate;
@@ -111,7 +110,7 @@ public class TalocsHollowInstance extends GeneralInstanceHandler {
 						Summon summon = player.getSummon();
 						if (summon != null) {
 							if (summon.getNpcId() == 799500 || summon.getNpcId() == 799501) {
-								SummonsService.doMode(SummonMode.RELEASE, summon, UnsummonType.UNSPECIFIED);
+								SummonsService.release(summon, UnsummonType.UNSPECIFIED);
 								PacketSendUtility.sendPacket(player, new SM_PLAY_MOVIE(false, 0, 0, 435, true));
 							}
 						}

--- a/game-server/src/com/aionemu/gameserver/ai/follow/FollowSummonTaskAI.java
+++ b/game-server/src/com/aionemu/gameserver/ai/follow/FollowSummonTaskAI.java
@@ -4,7 +4,6 @@ import com.aionemu.gameserver.ai.event.AIEventType;
 import com.aionemu.gameserver.model.gameobjects.Creature;
 import com.aionemu.gameserver.model.gameobjects.Summon;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
-import com.aionemu.gameserver.model.summons.SummonMode;
 import com.aionemu.gameserver.model.summons.UnsummonType;
 import com.aionemu.gameserver.services.summons.SummonsService;
 import com.aionemu.gameserver.utils.PositionUtil;
@@ -37,7 +36,7 @@ public class FollowSummonTaskAI implements Runnable {
 	@Override
 	public void run() {
 		if (!isInMasterRange()) {
-			SummonsService.doMode(SummonMode.RELEASE, summon, UnsummonType.DISTANCE);
+			SummonsService.release(summon, UnsummonType.DISTANCE);
 			return;
 		}
 		if (!isInTargetRange()) {

--- a/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
@@ -33,7 +33,6 @@ import com.aionemu.gameserver.model.gameobjects.state.CreatureVisualState;
 import com.aionemu.gameserver.model.gameobjects.state.FlyState;
 import com.aionemu.gameserver.model.house.House;
 import com.aionemu.gameserver.model.stats.container.PlayerGameStats;
-import com.aionemu.gameserver.model.summons.SummonMode;
 import com.aionemu.gameserver.model.summons.UnsummonType;
 import com.aionemu.gameserver.model.templates.QuestTemplate;
 import com.aionemu.gameserver.model.templates.flypath.FlightPath;
@@ -290,7 +289,7 @@ public class PlayerController extends CreatureController<Player> {
 		// Release summon
 		Summon summon = player.getSummon();
 		if (summon != null)
-			SummonsService.doMode(SummonMode.RELEASE, summon, UnsummonType.UNSPECIFIED);
+			SummonsService.release(summon, UnsummonType.MASTER_DEATH);
 
 		// setIsFlyingBeforeDead for PlayerReviveService
 		if (player.isInState(CreatureState.FLYING))

--- a/game-server/src/com/aionemu/gameserver/controllers/SummonController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/SummonController.java
@@ -70,7 +70,7 @@ public class SummonController extends CreatureController<Summon> {
 	}
 
 	public boolean canAttack(int targetObjId) {
-		return getOwner().getKnownList().getObject(targetObjId) instanceof Creature;
+		return getOwner().getKnownList().getObject(targetObjId) instanceof Creature creature && getOwner().getMaster().isEnemy(creature);
 	}
 
 	@Override
@@ -132,7 +132,7 @@ public class SummonController extends CreatureController<Summon> {
 		Skill skill = SkillEngine.getInstance().getSkill(creature, order.getSkillId(), 1, order.getTarget());
 		skill.setHate(order.getHate());
 		if (skill.useSkill() && order.isRelease()) {
-			SummonsService.release(getOwner(), UnsummonType.UNSPECIFIED);
+			SummonsService.release(getOwner(), UnsummonType.SKILL_ORDER);
 		}
 	}
 

--- a/game-server/src/com/aionemu/gameserver/controllers/SummonController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/SummonController.java
@@ -70,7 +70,7 @@ public class SummonController extends CreatureController<Summon> {
 	}
 
 	public boolean canAttack(int targetObjId) {
-		return getOwner().getKnownList().getObject(targetObjId) instanceof Creature creature && getOwner().getMaster().isEnemy(creature);
+		return getOwner().getKnownList().getObject(targetObjId) instanceof Creature creature && getOwner().isEnemy(creature);
 	}
 
 	@Override

--- a/game-server/src/com/aionemu/gameserver/controllers/SummonController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/SummonController.java
@@ -65,10 +65,12 @@ public class SummonController extends CreatureController<Summon> {
 	 * Change to attackMode
 	 */
 	public void attackMode(int targetObjId) {
-		VisibleObject obj = getOwner().getKnownList().getObject(targetObjId);
-		if (obj instanceof Creature) {
+		if (canAttack(targetObjId))
 			SummonsService.attackMode(getOwner());
-		}
+	}
+
+	public boolean canAttack(int targetObjId) {
+		return getOwner().getKnownList().getObject(targetObjId) instanceof Creature;
 	}
 
 	@Override
@@ -95,8 +97,7 @@ public class SummonController extends CreatureController<Summon> {
 		if (getOwner().isDead())
 			return;
 
-		// temp
-		if (getOwner().getMode() == SummonMode.RELEASE)
+		if (getOwner().isReleaseUncancelable())
 			return;
 
 		super.onAttack(creature, effect, type, damage, notifyAttack, log, attackStatus, hopType);
@@ -119,7 +120,7 @@ public class SummonController extends CreatureController<Summon> {
 	@Override
 	public void onDie(Creature lastAttacker) {
 		super.onDie(lastAttacker);
-		SummonsService.release(getOwner(), UnsummonType.UNSPECIFIED);
+		SummonsService.release(getOwner(), UnsummonType.SUMMON_DEATH);
 	}
 
 	public void useSkill(SkillOrder order) {

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/Summon.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/Summon.java
@@ -19,7 +19,6 @@ import com.aionemu.gameserver.model.stats.container.SummonLifeStats;
 import com.aionemu.gameserver.model.summons.SkillOrder;
 import com.aionemu.gameserver.model.summons.SummonMode;
 import com.aionemu.gameserver.model.summons.SummonRelease;
-import com.aionemu.gameserver.model.summons.UnsummonType;
 import com.aionemu.gameserver.model.templates.npc.NpcTemplate;
 import com.aionemu.gameserver.model.templates.npc.NpcTemplateType;
 import com.aionemu.gameserver.model.templates.spawns.SpawnTemplate;
@@ -32,7 +31,7 @@ public class Summon extends Creature {
 
 	private final Player master;
 	private SummonMode mode = SummonMode.GUARD;
-	private SummonMode modeBeforeRelease;
+	private SummonMode modeBeforeRelease = mode;
 	private final Queue<SkillOrder> skillOrders = new ConcurrentLinkedQueue<>();
 	private SummonRelease pendingRelease;
 	private SkillElement alwaysResistElement = SkillElement.NONE;
@@ -126,7 +125,7 @@ public class Summon extends Creature {
 	public void setMode(SummonMode mode) {
 		if (mode != SummonMode.ATTACK)
 			clearSkillOrders();
-		if (mode == SummonMode.RELEASE && this.mode != SummonMode.RELEASE)
+		if (this.mode != SummonMode.RELEASE)
 			modeBeforeRelease = this.mode;
 		this.mode = mode;
 	}

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/Summon.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/Summon.java
@@ -2,7 +2,6 @@ package com.aionemu.gameserver.model.gameobjects;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.Future;
 
 import com.aionemu.gameserver.controllers.SiegeWeaponController;
 import com.aionemu.gameserver.controllers.SummonController;
@@ -19,6 +18,8 @@ import com.aionemu.gameserver.model.stats.container.SummonGameStats;
 import com.aionemu.gameserver.model.stats.container.SummonLifeStats;
 import com.aionemu.gameserver.model.summons.SkillOrder;
 import com.aionemu.gameserver.model.summons.SummonMode;
+import com.aionemu.gameserver.model.summons.SummonRelease;
+import com.aionemu.gameserver.model.summons.UnsummonType;
 import com.aionemu.gameserver.model.templates.npc.NpcTemplate;
 import com.aionemu.gameserver.model.templates.npc.NpcTemplateType;
 import com.aionemu.gameserver.model.templates.spawns.SpawnTemplate;
@@ -32,7 +33,7 @@ public class Summon extends Creature {
 	private final Player master;
 	private SummonMode mode = SummonMode.GUARD;
 	private final Queue<SkillOrder> skillOrders = new ConcurrentLinkedQueue<>();
-	private Future<?> releaseTask;
+	private SummonRelease pendingRelease;
 	private SkillElement alwaysResistElement = SkillElement.NONE;
 	private int summonedBySkillId, liveTime;
 
@@ -191,14 +192,43 @@ public class Summon extends Creature {
 		this.summonedBySkillId = summonedBySkillId;
 	}
 
-	public void setReleaseTask(Future<?> task) {
-		releaseTask = task;
+	/**
+	 * An instant release supersedes a scheduled one, a release which already started can never be superseded.
+	 *
+	 * @return True if the caller may go on releasing this summon.
+	 */
+	public boolean registerRelease(SummonRelease release) {
+		if (pendingRelease != null) {
+			if (pendingRelease.hasStarted() || !release.getUnsummonType().isInstant())
+				return false;
+			pendingRelease.cancel();
+		}
+		pendingRelease = release;
+		return true;
 	}
 
-	public void cancelReleaseTask() {
-		if (releaseTask != null && !releaseTask.isDone()) {
-			releaseTask.cancel(true);
-		}
+	/**
+	 * @return True if the given release is still the pending one, meaning the caller may go on despawning this summon.
+	 */
+	public boolean startRelease(SummonRelease release) {
+		if (pendingRelease != release)
+			return false;
+		release.markStarted();
+		return true;
+	}
+
+	public void cancelReleaseByMaster() {
+		if (pendingRelease != null && pendingRelease.isCancelableByMaster() && pendingRelease.cancel())
+			pendingRelease = null;
+	}
+
+	public boolean isReleaseUncancelable() {
+		SummonRelease release = pendingRelease;
+		return release != null && !release.isCancelableByMaster();
+	}
+
+	public boolean isBeingReleased() {
+		return pendingRelease != null;
 	}
 
 	public void addSkillOrder(int skillId, int skillLvl, Creature target, int hate, boolean release) {

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/Summon.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/Summon.java
@@ -32,6 +32,7 @@ public class Summon extends Creature {
 
 	private final Player master;
 	private SummonMode mode = SummonMode.GUARD;
+	private SummonMode modeBeforeRelease;
 	private final Queue<SkillOrder> skillOrders = new ConcurrentLinkedQueue<>();
 	private SummonRelease pendingRelease;
 	private SkillElement alwaysResistElement = SkillElement.NONE;
@@ -114,9 +115,19 @@ public class Summon extends Creature {
 		return mode;
 	}
 
+	/**
+	 * @return The mode to report to the master's client, hiding a pending release the master was never told about (see
+	 *         {@link com.aionemu.gameserver.services.summons.SummonsService SummonsService}'s handling of {@link com.aionemu.gameserver.model.summons.UnsummonType#isCancelableByMaster()}).
+	 */
+	public SummonMode getVisibleMode() {
+		return isReleaseUncancelable() ? modeBeforeRelease : mode;
+	}
+
 	public void setMode(SummonMode mode) {
 		if (mode != SummonMode.ATTACK)
 			clearSkillOrders();
+		if (mode == SummonMode.RELEASE && this.mode != SummonMode.RELEASE)
+			modeBeforeRelease = this.mode;
 		this.mode = mode;
 	}
 

--- a/game-server/src/com/aionemu/gameserver/model/summons/SummonRelease.java
+++ b/game-server/src/com/aionemu/gameserver/model/summons/SummonRelease.java
@@ -1,0 +1,43 @@
+package com.aionemu.gameserver.model.summons;
+
+import java.util.concurrent.Future;
+
+/**
+ * Scheduled or already running release of a summon, see {@link com.aionemu.gameserver.model.gameobjects.Summon#registerRelease(SummonRelease)}.
+ */
+public class SummonRelease {
+
+	private final UnsummonType unsummonType;
+	private Future<?> task;
+	private boolean started;
+
+	public SummonRelease(UnsummonType unsummonType) {
+		this.unsummonType = unsummonType;
+	}
+
+	public UnsummonType getUnsummonType() {
+		return unsummonType;
+	}
+
+	public void setTask(Future<?> task) {
+		this.task = task;
+	}
+
+	public void markStarted() {
+		started = true;
+	}
+
+	public boolean hasStarted() {
+		return started;
+	}
+
+	public boolean isCancelableByMaster() {
+		return !started && unsummonType.isCancelableByMaster();
+	}
+
+	public boolean cancel() {
+		if (started)
+			return false;
+		return task == null || task.cancel(false);
+	}
+}

--- a/game-server/src/com/aionemu/gameserver/model/summons/UnsummonType.java
+++ b/game-server/src/com/aionemu/gameserver/model/summons/UnsummonType.java
@@ -1,11 +1,38 @@
 package com.aionemu.gameserver.model.summons;
 
 /**
+ * Cause of a summon release, defining how long the summon stays alive and whether its master may take the order back.
+ *
  * @author xTz
  */
 public enum UnsummonType {
-	LOGOUT,
-	DISTANCE,
-	COMMAND,
-	UNSPECIFIED
+
+	LOGOUT(0, false),
+	DISTANCE(0, false),
+	COMMAND(3000, true),
+	SUMMON_DEATH(0, false),
+	MASTER_DEATH(0, false),
+	/** Live time ran out, skill order with release flag (summon casts and vanishes), instance script, ... */
+	UNSPECIFIED(3000, false),
+	PET_ORDER_UNSUMMON_EFFECT(0, false);
+
+	private final int delayMillis;
+	private final boolean cancelableByMaster;
+
+	UnsummonType(int delayMillis, boolean cancelableByMaster) {
+		this.delayMillis = delayMillis;
+		this.cancelableByMaster = cancelableByMaster;
+	}
+
+	public int getDelayMillis() {
+		return delayMillis;
+	}
+
+	public boolean isInstant() {
+		return delayMillis == 0;
+	}
+
+	public boolean isCancelableByMaster() {
+		return cancelableByMaster;
+	}
 }

--- a/game-server/src/com/aionemu/gameserver/model/summons/UnsummonType.java
+++ b/game-server/src/com/aionemu/gameserver/model/summons/UnsummonType.java
@@ -12,8 +12,10 @@ public enum UnsummonType {
 	COMMAND(3000, true),
 	SUMMON_DEATH(0, false),
 	MASTER_DEATH(0, false),
-	/** Live time ran out, skill order with release flag (summon casts and vanishes), instance script, ... */
-	UNSPECIFIED(3000, false),
+	/** Live time ran out, instance script, ... */
+	UNSPECIFIED(0, false),
+	/** The summon was ordered to cast a skill and vanish afterwards. */
+	SKILL_ORDER(3000, false),
 	PET_ORDER_UNSUMMON_EFFECT(0, false);
 
 	private final int delayMillis;

--- a/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_SUMMON_UPDATE.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_SUMMON_UPDATE.java
@@ -20,7 +20,7 @@ public class SM_SUMMON_UPDATE extends AionServerPacket {
 	@Override
 	protected void writeImpl(AionConnection con) {
 		writeC(summon.getLevel());
-		writeH(summon.getMode().getId());
+		writeH(summon.getVisibleMode().getId());
 		writeD(0);// unk
 		writeD(0);// unk
 		writeD(summon.getLifeStats().getCurrentHp());

--- a/game-server/src/com/aionemu/gameserver/services/player/PlayerLeaveWorldService.java
+++ b/game-server/src/com/aionemu/gameserver/services/player/PlayerLeaveWorldService.java
@@ -15,7 +15,6 @@ import com.aionemu.gameserver.model.gameobjects.Summon;
 import com.aionemu.gameserver.model.gameobjects.player.BindPointPosition;
 import com.aionemu.gameserver.model.gameobjects.player.FriendList;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
-import com.aionemu.gameserver.model.summons.SummonMode;
 import com.aionemu.gameserver.model.summons.UnsummonType;
 import com.aionemu.gameserver.model.team.alliance.PlayerAllianceService;
 import com.aionemu.gameserver.model.team.group.PlayerGroupService;
@@ -114,7 +113,7 @@ public class PlayerLeaveWorldService {
 
 		Summon summon = player.getSummon();
 		if (summon != null)
-			SummonsService.doMode(SummonMode.RELEASE, summon, UnsummonType.LOGOUT);
+			SummonsService.release(summon, UnsummonType.LOGOUT);
 		if (player.getPet() != null)
 			player.getPet().getController().delete();
 		if (player.getPostman() != null)

--- a/game-server/src/com/aionemu/gameserver/services/player/PlayerLeaveWorldService.java
+++ b/game-server/src/com/aionemu/gameserver/services/player/PlayerLeaveWorldService.java
@@ -100,7 +100,6 @@ public class PlayerLeaveWorldService {
 		}
 		player.getEffectController().removeNonStorableEffectsForLogout();
 		PlayerEffectsDAO.storePlayerEffects(player);
-		PlayerCooldownsDAO.storePlayerCooldowns(player);
 		ItemCooldownsDAO.storeItemCooldowns(player);
 		PlayerLifeStatsDAO.updatePlayerLifeStat(player);
 
@@ -113,7 +112,8 @@ public class PlayerLeaveWorldService {
 
 		Summon summon = player.getSummon();
 		if (summon != null)
-			SummonsService.release(summon, UnsummonType.LOGOUT);
+			SummonsService.release(summon, UnsummonType.LOGOUT); // puts the summoning skill on cooldown, so store cooldowns afterwards
+		PlayerCooldownsDAO.storePlayerCooldowns(player);
 		if (player.getPet() != null)
 			player.getPet().getController().delete();
 		if (player.getPostman() != null)

--- a/game-server/src/com/aionemu/gameserver/services/summons/SummonsService.java
+++ b/game-server/src/com/aionemu/gameserver/services/summons/SummonsService.java
@@ -87,16 +87,14 @@ public class SummonsService {
 			if (summoningSkill != null && summoningSkill.getCooldown() > 0)
 				master.setSkillCoolDown(summoningSkill.getCooldownId(), summoningSkill.getCooldown() * 100 + System.currentTimeMillis());
 
-			if (unsummonType != UnsummonType.LOGOUT) { // the master is leaving the world, updating his client is pointless
-				if (unsummonType == UnsummonType.DISTANCE)
-					PacketSendUtility.sendPacket(master, SM_SYSTEM_MESSAGE.STR_SKILL_SUMMON_UNSUMMON_BY_TOO_DISTANCE());
-				else
-					PacketSendUtility.sendPacket(master, SM_SYSTEM_MESSAGE.STR_SKILL_SUMMON_UNSUMMONED(summon.getL10n()));
-				PacketSendUtility.sendPacket(master, new SM_SUMMON_PANEL_REMOVE(summon.getSummonedBySkillId()));
-				PacketSendUtility.sendPacket(master, new SM_SUMMON_OWNER_REMOVE(summon.getObjectId()));
-				if (!addedMasterHate)
-					scheduleAddMasterHate(summon);
-			}
+			if (unsummonType == UnsummonType.DISTANCE)
+				PacketSendUtility.sendPacket(master, SM_SYSTEM_MESSAGE.STR_SKILL_SUMMON_UNSUMMON_BY_TOO_DISTANCE());
+			else
+				PacketSendUtility.sendPacket(master, SM_SYSTEM_MESSAGE.STR_SKILL_SUMMON_UNSUMMONED(summon.getL10n()));
+			PacketSendUtility.sendPacket(master, new SM_SUMMON_PANEL_REMOVE(summon.getSummonedBySkillId()));
+			PacketSendUtility.sendPacket(master, new SM_SUMMON_OWNER_REMOVE(summon.getObjectId()));
+			if (!addedMasterHate)
+				scheduleAddMasterHate(summon);
 		}
 
 		public void scheduleOrRun() {

--- a/game-server/src/com/aionemu/gameserver/services/summons/SummonsService.java
+++ b/game-server/src/com/aionemu/gameserver/services/summons/SummonsService.java
@@ -83,28 +83,19 @@ public class SummonsService {
 			if (summon.equals(master.getSummon()))
 				master.setSummon(null);
 
-			switch (unsummonType) {
-				case COMMAND:
-				case DISTANCE:
-				case SUMMON_DEATH:
-				case MASTER_DEATH:
-				case UNSPECIFIED:
-				case PET_ORDER_UNSUMMON_EFFECT:
-					SkillTemplate summoningSkill = DataManager.SKILL_DATA.getSkillTemplate(summon.getSummonedBySkillId());
-					if (summoningSkill != null && summoningSkill.getCooldown() > 0)
-						master.setSkillCoolDown(summoningSkill.getCooldownId(), summoningSkill.getCooldown() * 100 + System.currentTimeMillis());
+			SkillTemplate summoningSkill = DataManager.SKILL_DATA.getSkillTemplate(summon.getSummonedBySkillId());
+			if (summoningSkill != null && summoningSkill.getCooldown() > 0)
+				master.setSkillCoolDown(summoningSkill.getCooldownId(), summoningSkill.getCooldown() * 100 + System.currentTimeMillis());
 
-					if (unsummonType == UnsummonType.DISTANCE)
-						PacketSendUtility.sendPacket(master, SM_SYSTEM_MESSAGE.STR_SKILL_SUMMON_UNSUMMON_BY_TOO_DISTANCE());
-					else
-						PacketSendUtility.sendPacket(master, SM_SYSTEM_MESSAGE.STR_SKILL_SUMMON_UNSUMMONED(summon.getL10n()));
-					PacketSendUtility.sendPacket(master, new SM_SUMMON_PANEL_REMOVE(summon.getSummonedBySkillId()));
-					PacketSendUtility.sendPacket(master, new SM_SUMMON_OWNER_REMOVE(summon.getObjectId()));
-					if (!addedMasterHate)
-						scheduleAddMasterHate(summon);
-					break;
-				case LOGOUT:
-					break;
+			if (unsummonType != UnsummonType.LOGOUT) { // the master is leaving the world, updating his client is pointless
+				if (unsummonType == UnsummonType.DISTANCE)
+					PacketSendUtility.sendPacket(master, SM_SYSTEM_MESSAGE.STR_SKILL_SUMMON_UNSUMMON_BY_TOO_DISTANCE());
+				else
+					PacketSendUtility.sendPacket(master, SM_SYSTEM_MESSAGE.STR_SKILL_SUMMON_UNSUMMONED(summon.getL10n()));
+				PacketSendUtility.sendPacket(master, new SM_SUMMON_PANEL_REMOVE(summon.getSummonedBySkillId()));
+				PacketSendUtility.sendPacket(master, new SM_SUMMON_OWNER_REMOVE(summon.getObjectId()));
+				if (!addedMasterHate)
+					scheduleAddMasterHate(summon);
 			}
 		}
 
@@ -207,7 +198,8 @@ public class SummonsService {
 				return;
 			if (summonMode == SummonMode.ATTACK && !summon.getController().canAttack(targetObjId))
 				return; // don't cancel a pending release for an order that won't be carried out
-			if (summonMode != SummonMode.RELEASE)
+			// UNK leaves the summons mode untouched, so it must not take back a pending release either
+			if (summonMode == SummonMode.ATTACK || summonMode == SummonMode.GUARD || summonMode == SummonMode.REST)
 				summon.cancelReleaseByMaster();
 		}
 

--- a/game-server/src/com/aionemu/gameserver/services/summons/SummonsService.java
+++ b/game-server/src/com/aionemu/gameserver/services/summons/SummonsService.java
@@ -26,10 +26,7 @@ import com.aionemu.gameserver.world.World;
  */
 public class SummonsService {
 
-	/**
-	 * create summon
-	 */
-	public static final Summon createSummon(Player master, int npcId, int skillId, int skillLevel, int time) {
+	public static Summon createSummon(Player master, int npcId, int skillId, int skillLevel, int time) {
 		if (master.getSummon() != null) {
 			PacketSendUtility.sendPacket(master, SM_SYSTEM_MESSAGE.STR_SKILL_SUMMON_ALREADY_HAVE_A_FOLLOWER());
 			return null;
@@ -45,7 +42,7 @@ public class SummonsService {
 	/**
 	 * Releases the summon after {@link UnsummonType#getDelayMillis()}, see {@link Summon#registerRelease(SummonRelease)} for competing releases.
 	 */
-	public static final void release(Summon summon, UnsummonType unsummonType) {
+	public static void release(Summon summon, UnsummonType unsummonType) {
 		SummonRelease release = new SummonRelease(unsummonType);
 		if (!summon.registerRelease(release))
 			return;

--- a/game-server/src/com/aionemu/gameserver/services/summons/SummonsService.java
+++ b/game-server/src/com/aionemu/gameserver/services/summons/SummonsService.java
@@ -2,7 +2,6 @@ package com.aionemu.gameserver.services.summons;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Future;
 
 import com.aionemu.gameserver.controllers.attack.AggroList;
 import com.aionemu.gameserver.dataholders.DataManager;
@@ -13,6 +12,7 @@ import com.aionemu.gameserver.model.gameobjects.Summon;
 import com.aionemu.gameserver.model.gameobjects.VisibleObject;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.model.summons.SummonMode;
+import com.aionemu.gameserver.model.summons.SummonRelease;
 import com.aionemu.gameserver.model.summons.UnsummonType;
 import com.aionemu.gameserver.network.aion.serverpackets.*;
 import com.aionemu.gameserver.skillengine.model.SkillTemplate;
@@ -43,37 +43,42 @@ public class SummonsService {
 	}
 
 	/**
-	 * Release summon
+	 * Releases the summon after {@link UnsummonType#getDelayMillis()}, see {@link Summon#registerRelease(SummonRelease)} for competing releases.
 	 */
 	public static final void release(Summon summon, UnsummonType unsummonType) {
-		if (summon.getMode() == SummonMode.RELEASE)
+		SummonRelease release = new SummonRelease(unsummonType);
+		if (!summon.registerRelease(release))
 			return;
 		summon.getController().cancelCurrentSkill(null);
 		summon.setMode(SummonMode.RELEASE);
 		summon.getObserveController().notifySummonReleaseObservers();
-		new ReleaseSummonTask(summon, unsummonType).scheduleOrRun();
+		new ReleaseSummonTask(summon, release).scheduleOrRun();
 	}
 
 	private static class ReleaseSummonTask implements Runnable {
 
 		private final Summon summon;
+		private final SummonRelease release;
 		private final UnsummonType unsummonType;
 		private boolean addedMasterHate;
 
-		public ReleaseSummonTask(Summon owner, UnsummonType unsummonType) {
+		public ReleaseSummonTask(Summon owner, SummonRelease release) {
 			this.summon = owner;
-			this.unsummonType = unsummonType;
+			this.release = release;
+			this.unsummonType = release.getUnsummonType();
 		}
 
 		@Override
 		public void run() {
+			if (!summon.startRelease(release))
+				return;
 			Player master = summon.getMaster();
 			VisibleObject summonObj = World.getInstance().findVisibleObject(summon.getObjectId());
 			// transformed npc via SM_TRANSFORM_IN_SUMMON
-			if (summonObj != null && summonObj instanceof Npc npc)
+			if (summonObj instanceof Npc npc)
 				npc.getController().delete();
 			else
-				summon.getController().delete();
+				summon.getController().delete(); // triggers SummonController.notKnow(master), the resulting DISTANCE release is ignored
 
 			if (summon.equals(master.getSummon()))
 				master.setSummon(null);
@@ -81,7 +86,10 @@ public class SummonsService {
 			switch (unsummonType) {
 				case COMMAND:
 				case DISTANCE:
+				case SUMMON_DEATH:
+				case MASTER_DEATH:
 				case UNSPECIFIED:
+				case PET_ORDER_UNSUMMON_EFFECT:
 					SkillTemplate summoningSkill = DataManager.SKILL_DATA.getSkillTemplate(summon.getSummonedBySkillId());
 					if (summoningSkill != null && summoningSkill.getCooldown() > 0)
 						master.setSkillCoolDown(summoningSkill.getCooldownId(), summoningSkill.getCooldown() * 100 + System.currentTimeMillis());
@@ -101,20 +109,16 @@ public class SummonsService {
 		}
 
 		public void scheduleOrRun() {
-			switch (unsummonType) {
-				case DISTANCE:
-				case LOGOUT:
-					run();
-					break;
-				default:
-					Future<?> releaseTask = ThreadPoolManager.getInstance().schedule(this, 5000);
-					if (unsummonType == UnsummonType.COMMAND) { // make it cancelable if released by master, master hate will be added delayed
-						PacketSendUtility.sendPacket(summon.getMaster(), SM_SYSTEM_MESSAGE.STR_SKILL_SUMMON_UNSUMMON_FOLLOWER(summon.getL10n()));
-						PacketSendUtility.sendPacket(summon.getMaster(), new SM_SUMMON_UPDATE(summon));
-						summon.setReleaseTask(releaseTask);
-					} else
-						scheduleAddMasterHate(summon);
+			if (unsummonType.isInstant()) {
+				run();
+				return;
 			}
+			release.setTask(ThreadPoolManager.getInstance().schedule(this, unsummonType.getDelayMillis()));
+			if (unsummonType.isCancelableByMaster()) { // master hate is added delayed, he may still take the order back
+				PacketSendUtility.sendPacket(summon.getMaster(), SM_SYSTEM_MESSAGE.STR_SKILL_SUMMON_UNSUMMON_FOLLOWER(summon.getL10n()));
+				PacketSendUtility.sendPacket(summon.getMaster(), new SM_SUMMON_UPDATE(summon));
+			} else
+				scheduleAddMasterHate(summon);
 		}
 
 		private void scheduleAddMasterHate(Summon summon) {
@@ -198,8 +202,14 @@ public class SummonsService {
 		if (summon.getMaster() == null)
 			return;
 
-		if (unsummonType == UnsummonType.COMMAND && summonMode != SummonMode.RELEASE)
-			summon.cancelReleaseTask();
+		if (unsummonType == UnsummonType.COMMAND) {
+			if (summon.isReleaseUncancelable())
+				return;
+			if (summonMode == SummonMode.ATTACK && !summon.getController().canAttack(targetObjId))
+				return; // don't cancel a pending release for an order that won't be carried out
+			if (summonMode != SummonMode.RELEASE)
+				summon.cancelReleaseByMaster();
+		}
 
 		switch (summonMode) {
 			case REST:

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/PetOrderUnSummonEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/PetOrderUnSummonEffect.java
@@ -7,7 +7,6 @@ import javax.xml.bind.annotation.XmlType;
 import com.aionemu.gameserver.model.gameobjects.Creature;
 import com.aionemu.gameserver.model.gameobjects.Summon;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
-import com.aionemu.gameserver.model.summons.SummonMode;
 import com.aionemu.gameserver.model.summons.UnsummonType;
 import com.aionemu.gameserver.services.summons.SummonsService;
 import com.aionemu.gameserver.skillengine.model.Effect;
@@ -25,7 +24,7 @@ public class PetOrderUnSummonEffect extends EffectTemplate {
 		if (effected instanceof Player) {
 			Summon summon = ((Player) effected).getSummon();
 			if (summon != null) {
-				SummonsService.doMode(SummonMode.RELEASE, summon, UnsummonType.UNSPECIFIED);
+				SummonsService.release(summon, UnsummonType.PET_ORDER_UNSUMMON_EFFECT);
 			}
 		}
 	}

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/PetOrderUseUltraSkillEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/PetOrderUseUltraSkillEffect.java
@@ -28,7 +28,7 @@ public class PetOrderUseUltraSkillEffect extends EffectTemplate {
 	public void applyEffect(Effect effect) {
 		Player effector = (Player) effect.getEffector();
 
-		if (effector.getSummon() == null) {
+		if (effector.getSummon() == null || effector.getSummon().isBeingReleased()) {
 			return;
 		}
 
@@ -44,7 +44,6 @@ public class PetOrderUseUltraSkillEffect extends EffectTemplate {
 				.warn("Couldn't find summon skill template for ID {} (summon order skill ID {})", petUseSkillId, orderSkillId);
 			return;
 		}
-
 		int skillLvl = skillTemplate.getLvl();
 		int targetId = effect.getEffected().getObjectId();
 		int hate = effect.getEffectHate() > 1 ? effect.getEffectHate() : 0;


### PR DESCRIPTION
Adjusted pet unsummon delay from 5s to 3s to match retail behavior.

Added instant pet despawn for skills with PetOrderUnSummonEffect ([Spirit's Empowerment](https://aioncodex.com/48/skill/3541/)), and for death of the pet or its master.

Reworked how release causes interact. release() bailed out whenever the pet was already in RELEASE mode, so the first cause always won and `PetOrderUnSummonEffect` did nothing while another release was pending. Each cause now carries its own delay and whether the master can cancel it, and an instant cause takes over a scheduled one.

Also fixed retail behavior where a summon cannot use any skills while being released. Skills are no longer queued during the release process.