### PR TITLE
Apply item skill effects immediately

### DIFF
--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
@@ -644,13 +644,21 @@ public class Skill {
 		if (!blockedPenaltySkill)
 			startPenaltySkill();
 
-		if (isInstantSkill())
+		boolean isItemSkill = skillMethod == SkillMethod.ITEM;
+		boolean sentCastSpellResultPacket = false;
+		// the client must learn the hit time before any HP change reaches it, or it updates the status bar before displaying the hit
+		if (isItemSkill)
+			sentCastSpellResultPacket = sendCastSpellEnd(dashStatus, effects);
+
+		// item skills apply their effects immediately, hitTime only tells the client when to display the hit
+		if (isInstantSkill() || isItemSkill)
 			applyEffect(effects);
 		else
 			ThreadPoolManager.getInstance().schedule(() -> applyEffect(effects), hitTime);
 
-		if (skillMethod == SkillMethod.PENALTY || skillMethod == SkillMethod.CAST || skillMethod == SkillMethod.ITEM) {
-			boolean sentCastSpellResultPacket = sendCastSpellEnd(dashStatus, effects);
+		if (skillMethod == SkillMethod.PENALTY || skillMethod == SkillMethod.CAST || isItemSkill) {
+			if (!isItemSkill)
+				sentCastSpellResultPacket = sendCastSpellEnd(dashStatus, effects);
 			if (sentCastSpellResultPacket && skillMethod != SkillMethod.PENALTY && effector instanceof Player player) {
 				// animation times must be calculated after applyEffect of instant skills in order to honor speed buffs from this skill
 				AnimationTimes animation = DataManager.MOTION_DATA.calculateAnimationTimesAfterLastHit(player, this);


### PR DESCRIPTION
Item skills applied their effects `hitTime` (~400–1400 ms) late. Teleport scrolls only ported after the cast had already ended, leaving a window in which the player could still walk a step, bombs applied their stun late.

`hitTime` only tells the client when to display the hit the effect itself has to be applied at once. `SM_CASTSPELL_RESULT` is now sent before `applyEffect()`, since otherwise the hp change from `SM_ATTACK_STATUS` reaches the client first and it drops the status bar before showing the hit.

Verified items (4.6 and 5.8 pts): 
 - Explosive Bead `164000140` (`activation_mode=Combat`): stun and combat log immediate, status bar and floating hit number only at `hitTime`.
- `164000003` and `164000314` (`activation_mode=Both`): no cast animation, everything immediate.