### PR TITLE
Fixed physical defense penalties applying to the base value only

### DIFF
--- a/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
@@ -113,9 +113,8 @@ public class AttackUtil {
 			boolean isPhysical = element == SkillElement.NONE;
 			StatEnum attackStat = isPhysical ? StatEnum.PHYSICAL_ATTACK : StatEnum.MAGICAL_ATTACK;
 			StatEnum defenseStat = isPhysical ? StatEnum.PHYSICAL_DEFENSE : StatEnum.MAGICAL_DEFEND;
-			float defenseBase = isPhysical ? attacked.getGameStats().getPDef().getBase() : attacked.getGameStats().getMDef().getBase();
-			float defenseBonus = isPhysical ? attacked.getGameStats().getPDef().getBonus() : attacked.getGameStats().getMDef().getBonus();
-			float defense = StatFunctions.adjustStatByMovementModifier(attacked, defenseStat, defenseBase) + defenseBonus;
+			float defenseStatValue = isPhysical ? attacked.getGameStats().getPDef().getCurrent() : attacked.getGameStats().getMDef().getCurrent();
+			float defense = StatFunctions.adjustStatByMovementModifier(attacked, defenseStat, defenseStatValue);
 			float damage = attackResultList.get(i).getDamage() - (defense / 10);
 			damage *= damageMultiplier;
 			damage = StatFunctions.adjustStatByMovementModifier(attacker, attackStat, damage);
@@ -329,8 +328,7 @@ public class AttackUtil {
 		}
 
 		if (isPhysical) {
-			float def = effected.getGameStats().getPDef().getBonus() + StatFunctions.adjustStatByMovementModifier(effected, StatEnum.PHYSICAL_DEFENSE,
-					effected.getGameStats().getPDef().getBase());
+			float def = StatFunctions.adjustStatByMovementModifier(effected, StatEnum.PHYSICAL_DEFENSE, effected.getGameStats().getPDef().getCurrent());
 			damage -= def / 10;
 		}
 

--- a/game-server/src/com/aionemu/gameserver/model/stats/calc/Stat2.java
+++ b/game-server/src/com/aionemu/gameserver/model/stats/calc/Stat2.java
@@ -13,6 +13,7 @@ public abstract class Stat2 {
 	float base;
 	float bonus;
 	float fixedBonusRate;
+	float finalRate = 1f;
 	private final Creature owner;
 	protected final StatEnum stat;
 
@@ -66,15 +67,15 @@ public abstract class Stat2 {
 	}
 
 	public final int getCurrent() {
-		return (int) (base * baseRate + bonus * bonusRate + base * fixedBonusRate);
+		return (int) getExactCurrent();
 	}
 
 	public final float getExactCurrent() {
-		return base * baseRate + bonus * bonusRate + base * fixedBonusRate;
+		return (base * baseRate + bonus * bonusRate + base * fixedBonusRate) * finalRate;
 	}
 
 	public final float getExactCurrentWithoutFixedBonus() {
-		return base * baseRate + bonus * bonusRate;
+		return (base * baseRate + bonus * bonusRate) * finalRate;
 	}
 
 	public final void setBonus(float bonus) {
@@ -97,6 +98,18 @@ public abstract class Stat2 {
 
 	public float getFixedBonusRate() {
 		return fixedBonusRate;
+	}
+
+	/**
+	 * Rate applied to the final value (base and bonus alike), meant for situational penalties which are not part of the stat itself, like the physical
+	 * defense loss while flying. Must be set after all stat functions have been applied, since caps are calculated without it.
+	 */
+	public final void setFinalRate(float finalRate) {
+		this.finalRate = finalRate;
+	}
+
+	public final float getFinalRate() {
+		return finalRate;
 	}
 
 	public abstract float calculatePercent(int delta);

--- a/game-server/src/com/aionemu/gameserver/model/stats/calc/functions/PlayerStatFunctions.java
+++ b/game-server/src/com/aionemu/gameserver/model/stats/calc/functions/PlayerStatFunctions.java
@@ -12,8 +12,8 @@ import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.model.stats.calc.Stat2;
 import com.aionemu.gameserver.model.stats.container.StatEnum;
 import com.aionemu.gameserver.model.templates.item.ItemTemplate;
-import com.aionemu.gameserver.utils.stats.CalculationType;
 import com.aionemu.gameserver.model.templates.world.WorldMapTemplate;
+import com.aionemu.gameserver.utils.stats.CalculationType;
 
 /**
  * @author ATracer
@@ -28,6 +28,7 @@ public class PlayerStatFunctions {
 		FUNCTIONS.add(new AttackSpeedFunction());
 		FUNCTIONS.add(new BoostCastingTimeFunction());
 		FUNCTIONS.add(new PvPAttackRatioFunction());
+		FUNCTIONS.add(new PDefFunction());
 		FUNCTIONS.add(new MaxHpFunction());
 		FUNCTIONS.add(new MaxMpFunction());
 		FUNCTIONS.add(new BlockFunction());
@@ -129,6 +130,19 @@ class MagicalAttackFunction extends StatFunction {
 	@Override
 	public int getPriority() {
 		return 30;
+	}
+}
+
+class PDefFunction extends StatFunction {
+
+	PDefFunction() {
+		stat = StatEnum.PHYSICAL_DEFENSE;
+	}
+
+	@Override
+	public void apply(Stat2 stat, CalculationType... calculationTypes) {
+		if (stat.getOwner().isInFlyingState())
+			stat.setFinalRate(0.6f);
 	}
 }
 

--- a/game-server/src/com/aionemu/gameserver/model/stats/calc/functions/PlayerStatFunctions.java
+++ b/game-server/src/com/aionemu/gameserver/model/stats/calc/functions/PlayerStatFunctions.java
@@ -28,7 +28,6 @@ public class PlayerStatFunctions {
 		FUNCTIONS.add(new AttackSpeedFunction());
 		FUNCTIONS.add(new BoostCastingTimeFunction());
 		FUNCTIONS.add(new PvPAttackRatioFunction());
-		FUNCTIONS.add(new PDefFunction());
 		FUNCTIONS.add(new MaxHpFunction());
 		FUNCTIONS.add(new MaxMpFunction());
 		FUNCTIONS.add(new BlockFunction());
@@ -130,24 +129,6 @@ class MagicalAttackFunction extends StatFunction {
 	@Override
 	public int getPriority() {
 		return 30;
-	}
-}
-
-class PDefFunction extends StatFunction {
-
-	PDefFunction() {
-		stat = StatEnum.PHYSICAL_DEFENSE;
-	}
-
-	@Override
-	public void apply(Stat2 stat, CalculationType... calculationTypes) {
-		if (stat.getOwner().isInFlyingState())
-			stat.setBonus(stat.getBonus() - (stat.getBase() / 2));
-	}
-
-	@Override
-	public int getPriority() {
-		return 60;
 	}
 }
 

--- a/game-server/src/com/aionemu/gameserver/model/stats/container/PlayerGameStats.java
+++ b/game-server/src/com/aionemu/gameserver/model/stats/container/PlayerGameStats.java
@@ -26,6 +26,8 @@ import com.aionemu.gameserver.utils.stats.CalculationType;
  */
 public class PlayerGameStats extends CreatureGameStats<Player> {
 
+	private static final float FLIGHT_PHYSICAL_DEFENSE_RATE = 0.6f;
+
 	private StatsTemplate statsTemplate;
 	private int cachedAttackSpeed;
 	private int maxDamageChance;
@@ -137,6 +139,14 @@ public class PlayerGameStats extends CreatureGameStats<Player> {
 		if (offHandWeapon != null && !equipment.isShieldEquipped())
 			minWeaponRange = Math.min(minWeaponRange, offHandWeapon.getItemTemplate().getWeaponStats().getAttackRange());
 		return getStat(StatEnum.ATTACK_RANGE, minWeaponRange == Integer.MAX_VALUE ? base : minWeaponRange);
+	}
+
+	@Override
+	public Stat2 getPDef() {
+		Stat2 pDef = super.getPDef();
+		if (owner.isInFlyingState())
+			pDef.setFinalRate(FLIGHT_PHYSICAL_DEFENSE_RATE);
+		return pDef;
 	}
 
 	@Override

--- a/game-server/src/com/aionemu/gameserver/model/stats/container/PlayerGameStats.java
+++ b/game-server/src/com/aionemu/gameserver/model/stats/container/PlayerGameStats.java
@@ -26,8 +26,6 @@ import com.aionemu.gameserver.utils.stats.CalculationType;
  */
 public class PlayerGameStats extends CreatureGameStats<Player> {
 
-	private static final float FLIGHT_PHYSICAL_DEFENSE_RATE = 0.6f;
-
 	private StatsTemplate statsTemplate;
 	private int cachedAttackSpeed;
 	private int maxDamageChance;
@@ -139,14 +137,6 @@ public class PlayerGameStats extends CreatureGameStats<Player> {
 		if (offHandWeapon != null && !equipment.isShieldEquipped())
 			minWeaponRange = Math.min(minWeaponRange, offHandWeapon.getItemTemplate().getWeaponStats().getAttackRange());
 		return getStat(StatEnum.ATTACK_RANGE, minWeaponRange == Integer.MAX_VALUE ? base : minWeaponRange);
-	}
-
-	@Override
-	public Stat2 getPDef() {
-		Stat2 pDef = super.getPDef();
-		if (owner.isInFlyingState())
-			pDef.setFinalRate(FLIGHT_PHYSICAL_DEFENSE_RATE);
-		return pDef;
 	}
 
 	@Override


### PR DESCRIPTION
`PDefFunction` reduced physical defense while flying by subtracting half the **base** and leaving all bonuses untouched, so the penalty was -50% from **base** instead of -40% of the total. `StatFunctions#adjustStatByMovementModifier` had the same flaw at its `AttackUtil` call sites: applied to the base, with the bonus added afterwards. (magical defense bonus was already working as it should)

Both now scale the final value:

```
pDef = (base * (1 + pDef%/100) + flat) * flyMode * movementModifier
```

Verified on retail with base `1946`, `+900` from gear bonuses and the templar flight passive Winged Defense (skill 371, `PERCENT 10` -> 10% of base, added to the bonus pool before the penalty):

```
(2846 + 194.6) * 0.6 = 1824.36  ->  1824 shown in the client
```
### Notes
* Defense in damage calculation now reads `getCurrent()` instead of `getBase() + getBonus()`, so summons use the halved master item bonuses (`bonusRate` 0.5) that `SM_SUMMON_PANEL` and `SM_SUMMON_UPDATE` already display.