### PR TITLE
Quest Engine Improvements

### DIFF
--- a/game-server/data/handlers/admincommands/Quest.java
+++ b/game-server/data/handlers/admincommands/Quest.java
@@ -1,7 +1,6 @@
 package admincommands;
 
 import java.util.Arrays;
-import java.util.List;
 
 import com.aionemu.gameserver.configs.administration.AdminConfig;
 import com.aionemu.gameserver.dataholders.DataManager;
@@ -9,8 +8,6 @@ import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.model.gameobjects.player.npcFaction.ENpcFactionQuestState;
 import com.aionemu.gameserver.model.gameobjects.player.npcFaction.NpcFaction;
 import com.aionemu.gameserver.model.templates.QuestTemplate;
-import com.aionemu.gameserver.model.templates.quest.FinishedQuestCond;
-import com.aionemu.gameserver.model.templates.quest.XMLStartCondition;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_DIALOG_WINDOW;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_QUEST_ACTION;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_QUEST_ACTION.ActionType;
@@ -190,23 +187,9 @@ public class Quest extends AdminCommand {
 		} else if (qs != null && qs.getStatus() == QuestStatus.COMPLETE && !qs.canRepeat()) {
 			sendInfo(admin, "Quest is already completed.");
 		} else {
-			StringBuilder sb = new StringBuilder();
-			List<XMLStartCondition> preconditions = template.getXMLStartConditions();
-			if (preconditions != null) {
-				for (XMLStartCondition condition : preconditions) {
-					List<FinishedQuestCond> finisheds = condition.getFinishedPreconditions();
-					if (finisheds != null) {
-						for (FinishedQuestCond fcondition : finisheds) {
-							QuestState qs1 = target.getQuestStateList().getQuestState(fcondition.getQuestId());
-							if (qs1 == null || qs1.getStatus() != QuestStatus.COMPLETE) {
-								sb.append("\n\t" + ChatUtil.quest(fcondition.getQuestId()));
-							}
-						}
-					}
-				}
-			}
-			sendInfo(admin,
-				"Quest not started. " + (sb.length() > 0 ? "These quest(s) must be completed first:" + sb.toString() : "Some preconditions failed."));
+			StringBuilder denialReason = new StringBuilder();
+			QuestService.checkStartConditions(target, questId, false, 0, false, false, false, denialReason::append);
+			sendInfo(admin, "Quest not started" + (denialReason.isEmpty() ? "." : ", " + target.getName() + " fails: " + denialReason));
 		}
 	}
 
@@ -251,8 +234,7 @@ public class Quest extends AdminCommand {
 		else
 			PacketSendUtility.sendPacket(target, new SM_QUEST_ACTION(ActionType.ABANDON, qs));
 		target.getController().updateNearbyQuests();
-		if (!admin.equals(target))
-			sendInfo(admin, "Deleted " + ChatUtil.quest(questId) + " for player " + target.getName() + ".");
+		sendInfo(admin, "Deleted " + ChatUtil.quest(questId) + " (was " + qs.getStatus() + ") for player " + target.getName() + ".");
 	}
 
 	private void showQuestStatus(Player admin, Player target, int questId) {
@@ -270,8 +252,11 @@ public class Quest extends AdminCommand {
 			for (int i = 0; i <= 5; i++)
 				sb.append(" " + qs.getQuestVarById(i));
 			sb.append(", encoded [" + qs.getQuestVars().getQuestVars() + "]");
-			sb.append("\n\tQuest flags: " + (qs.getFlags() & 0x3F) + " " + qs.getStepGroup()); // needs rework when flags are implemented like vars
+			sb.append("\n\tQuest flags: " + qs.getFlagValue() + ", step group: " + qs.getStepGroup());
 			sb.append(", encoded [" + qs.getFlags() + "]");
+			sb.append("\n\tComplete count: " + qs.getCompleteCount() + ", reward group: " + qs.getRewardGroup());
+			int timerQuestId = target.getController().getQuestTimerQuestId();
+			sb.append("\n\tQuest timer: " + (timerQuestId == 0 ? "none" : "running for " + ChatUtil.quest(timerQuestId)));
 		}
 		sendInfo(admin, sb.toString());
 	}

--- a/game-server/data/handlers/ai/quests/QuestUseNpcAI.java
+++ b/game-server/data/handlers/ai/quests/QuestUseNpcAI.java
@@ -4,6 +4,7 @@ import com.aionemu.gameserver.ai.AIName;
 import com.aionemu.gameserver.ai.handler.TalkEventHandler;
 import com.aionemu.gameserver.model.gameobjects.Npc;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
+import com.aionemu.gameserver.questEngine.QuestEngine;
 
 import ai.ActionItemNpcAI;
 
@@ -15,6 +16,13 @@ public class QuestUseNpcAI extends ActionItemNpcAI {
 
 	public QuestUseNpcAI(Npc owner) {
 		super(owner);
+	}
+
+	@Override
+	protected void handleDialogStart(Player player) {
+		// on retail a quest object doesn't react at all as long as no quest step of the player needs it
+		if (QuestEngine.getInstance().isNpcNeededByAnyQuestOf(player, getNpcId()))
+			super.handleDialogStart(player);
 	}
 
 	@Override

--- a/game-server/data/handlers/ai/quests/QuestUseNpcAI.java
+++ b/game-server/data/handlers/ai/quests/QuestUseNpcAI.java
@@ -20,7 +20,7 @@ public class QuestUseNpcAI extends ActionItemNpcAI {
 
 	@Override
 	protected void handleDialogStart(Player player) {
-		// on retail a quest object doesn't react at all as long as no quest step of the player needs it
+		// a quest object stays silent as long as no quest step of the player needs it
 		if (QuestEngine.getInstance().isNpcNeededByAnyQuestOf(player, getNpcId()))
 			super.handleDialogStart(player);
 	}

--- a/game-server/data/handlers/consolecommands/Addquest.java
+++ b/game-server/data/handlers/consolecommands/Addquest.java
@@ -1,17 +1,12 @@
 package consolecommands;
 
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.aionemu.gameserver.dataholders.DataManager;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.model.templates.QuestTemplate;
-import com.aionemu.gameserver.model.templates.quest.FinishedQuestCond;
-import com.aionemu.gameserver.model.templates.quest.XMLStartCondition;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
-import com.aionemu.gameserver.questEngine.model.QuestState;
-import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.QuestService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
 import com.aionemu.gameserver.utils.chathandlers.ConsoleCommand;
@@ -48,28 +43,21 @@ public class Addquest extends ConsoleCommand {
 			return;
 		}
 
-		QuestEnv env = new QuestEnv(null, player, id);
-
-		if (QuestService.startQuest(env)) {
-			PacketSendUtility.sendMessage(admin, "Quest started.");
-		} else {
-			QuestTemplate template = DataManager.QUEST_DATA.getQuestById(id);
-			List<XMLStartCondition> preconditions = template.getXMLStartConditions();
-			if (preconditions != null && preconditions.size() > 0) {
-				for (XMLStartCondition condition : preconditions) {
-					List<FinishedQuestCond> finisheds = condition.getFinishedPreconditions();
-					if (finisheds != null && finisheds.size() > 0) {
-						for (FinishedQuestCond fcondition : finisheds) {
-							QuestState qs1 = admin.getQuestStateList().getQuestState(fcondition.getQuestId());
-							if (qs1 == null || qs1.getStatus() != QuestStatus.COMPLETE) {
-								PacketSendUtility.sendMessage(admin, "You have to finish " + fcondition.getQuestId() + " first!");
-							}
-						}
-					}
-				}
-			}
-			PacketSendUtility.sendMessage(admin, "Quest not started. Some preconditions failed");
+		QuestTemplate template = DataManager.QUEST_DATA.getQuestById(id);
+		if (template == null) {
+			PacketSendUtility.sendMessage(admin, "Quest " + id + " does not exist.");
+			return;
 		}
+
+		if (QuestService.startQuest(new QuestEnv(null, player, id))) {
+			PacketSendUtility.sendMessage(admin, "Quest started.");
+			return;
+		}
+
+		StringBuilder denialReason = new StringBuilder();
+		QuestService.checkStartConditions(player, id, false, 0, false, false, false, denialReason::append);
+		PacketSendUtility.sendMessage(admin,
+			"Quest not started" + (denialReason.isEmpty() ? "." : ", " + player.getName() + " fails: " + denialReason));
 	}
 
 	@Override

--- a/game-server/data/static_data/items/item_templates.xsd
+++ b/game-server/data/static_data/items/item_templates.xsd
@@ -155,6 +155,7 @@
 			<xs:element name="skilluse" type="SkillUseAction" minOccurs="0" maxOccurs="1"/>
 			<xs:element name="enchant" type="EnchantItemAction" minOccurs="0" maxOccurs="1"/>
 			<xs:element name="queststart" type="QuestStartAction" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="questuse" type="QuestUseAction" minOccurs="0" maxOccurs="1"/>
 			<xs:element name="dye" type="DyeAction" minOccurs="0" maxOccurs="1"/>
 			<xs:element name="craftlearn" type="CraftLearnAction" minOccurs="0" maxOccurs="1"/>
 			<xs:element name="extract" type="ExtractAction" minOccurs="0" maxOccurs="1"/>
@@ -288,6 +289,11 @@
 			<xs:extension base="AbstractItemAction">
 				<xs:attribute name="questid" type="xs:int"/>
 			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="QuestUseAction">
+		<xs:complexContent>
+			<xs:extension base="AbstractItemAction"/>
 		</xs:complexContent>
 	</xs:complexType>
 	<xs:complexType name="CraftLearnAction">

--- a/game-server/data/static_data/quest_script_data/cygnea.xml
+++ b/game-server/data/static_data/quest_script_data/cygnea.xml
@@ -10,7 +10,7 @@
 			10505 [SCRIPT] Sneeze Attack (Campaign)
 			10506 [SCRIPT] Mind Over Matter (Campaign)
 			10507 [SCRIPT] A Big Plot to Foil (Campaign)
-			15000 [ToDo] Not Any Fool's Tool (Multistep)
+			15000 [XML] Not Any Fool's Tool
 			15001 [XML] Lending Both Hands (Monster Hunt)
 			15002 [XML] Cold Hands, Warm Luciferin (Collect Item)
 			15003 [UNUSED] HOLD
@@ -205,4 +205,72 @@
 	<monster_hunt id="15202" start_npc_ids="804704"/>
 	<monster_hunt id="15203" start_npc_ids="804704"/>
 	<monster_hunt id="18971" start_npc_ids="804865" end_npc_ids="805213 805214 805215"/>
+
+	<!-- MULTISTEP QUESTS -->
+	<xml_quest id="15000" start_npc_ids="804874" end_npc_ids="804874">
+		<on_talk_event ids="804874">
+			<conditions operate="AND">
+				<quest_status value="START" op="EQUAL"/>
+			</conditions>
+			<var value="0"><!-- bring the odium shard to Milliard -->
+				<npc id="804874">
+					<dialog id="31">
+						<operations>
+							<npc_dialog id="1011"/>
+						</operations>
+					</dialog>
+					<dialog id="39">
+						<operations>
+							<collect_items>
+								<true>
+									<set_quest_var var_id="0" value="1"/>
+									<npc_dialog id="10000"/>
+								</true>
+								<false>
+									<npc_dialog id="10001"/>
+								</false>
+							</collect_items>
+						</operations>
+					</dialog>
+				</npc>
+			</var>
+			<var value="1"><!-- he hands over the tool -->
+				<npc id="804874">
+					<dialog id="31">
+						<operations>
+							<npc_dialog id="1352"/>
+						</operations>
+					</dialog>
+					<dialog id="1352">
+						<operations>
+							<npc_dialog id="1352"/>
+						</operations>
+					</dialog>
+					<dialog id="1353">
+						<operations>
+							<npc_dialog id="1353"/>
+						</operations>
+					</dialog>
+					<dialog id="10001">
+						<operations>
+							<give_item item_id="182215662" count="1"/>
+							<set_quest_var var_id="0" value="2"/>
+							<npc_dialog id="0" quest_id="0"/>
+						</operations>
+					</dialog>
+				</npc>
+			</var>
+		</on_talk_event>
+		<on_item_use_event item_ids="182215662">
+			<conditions operate="AND">
+				<quest_status value="START" op="EQUAL"/>
+				<quest_var var_id="0" value="2" op="EQUAL"/>
+			</conditions>
+			<operations>
+				<take_item item_id="182215662" count="1"/>
+				<set_quest_var var_id="0" value="3"/>
+				<set_quest_status status="REWARD"/>
+			</operations>
+		</on_item_use_event>
+	</xml_quest>
 </quest_scripts>

--- a/game-server/data/static_data/quest_script_data/enshar.xml
+++ b/game-server/data/static_data/quest_script_data/enshar.xml
@@ -32,8 +32,8 @@
 			25073 [SCRIPT] No Revival for the Balaur
 			25080 [XML] Hot Shards! (Collect Item)
 			25081 [XML] Red Coral Delights (Collect Item)
-			25082 [ToDo] Tyrant Take Out (MultiStep)
-			25084 [ToDo] Is This a Trap? (MultiStep)
+			25082 [XML] Tyrant Take Out
+			25084 [XML] Is This a Trap?
 			25085 [ToDo] Intercept the Ide (Collect Item)
 			25090 [XML] They Chose Poorly (Monster Hunt)
 			25091 [XML] The More You Know... (Collect Item)
@@ -122,4 +122,145 @@
 	<monster_hunt id="25202" start_npc_ids="804914"/>
 	<monster_hunt id="25203" start_npc_ids="804914"/>
 	<monster_hunt id="28971" start_npc_ids="804924" end_npc_ids="805216 805217 805218"/>
+
+	<!-- MULTISTEP QUESTS -->
+	<xml_quest id="25082" start_npc_ids="804923" end_npc_ids="804924">
+		<on_talk_event ids="731559">
+			<conditions operate="AND">
+				<quest_status value="START" op="EQUAL"/>
+			</conditions>
+			<var value="0"><!-- put the meat on the luring bonfire -->
+				<npc id="731559">
+					<dialog id="31">
+						<operations>
+							<npc_dialog id="1011"/>
+						</operations>
+					</dialog>
+					<dialog id="39">
+						<operations>
+							<collect_items>
+								<true>
+									<set_quest_var var_id="0" value="1"/>
+									<npc_dialog id="10000"/>
+								</true>
+								<false>
+									<npc_dialog id="10001"/>
+								</false>
+							</collect_items>
+						</operations>
+					</dialog>
+				</npc>
+			</var>
+			<var value="1"><!-- light it and lure the tyrant out -->
+				<npc id="731559">
+					<dialog id="31">
+						<operations>
+							<npc_dialog id="1352"/>
+						</operations>
+					</dialog>
+					<dialog id="1352">
+						<operations>
+							<npc_dialog id="1352"/>
+						</operations>
+					</dialog>
+					<dialog id="10001">
+						<operations>
+							<spawn_npc npc_id="833465" x="1056" y="194" z="227" h="30" lifetime="30"/>
+							<!-- retail has the burning bonfires ai spawn the tyrant on its own point, three seconds after it appears -->
+							<spawn_npc npc_id="220037" x="1056" y="194" z="227" aggro="true"/>
+							<add_timer seconds="300"/>
+							<set_quest_var var_id="0" value="2"/>
+							<npc_dialog id="0" quest_id="0"/>
+						</operations>
+					</dialog>
+				</npc>
+			</var>
+		</on_talk_event>
+		<on_kill_event ids="220037"><!-- only counts while the timer runs, like retail -->
+			<conditions operate="AND">
+				<quest_status value="START" op="EQUAL"/>
+				<quest_var var_id="0" value="2" op="EQUAL"/>
+			</conditions>
+			<monster var="1" start_var="0" end_var="1" npc_ids="220037" step="2"/>
+			<complite>
+				<set_quest_var var_id="1" value="0"/>
+				<set_quest_var var_id="0" value="3"/>
+				<set_quest_status status="REWARD"/>
+			</complite>
+		</on_kill_event>
+		<on_timer_end_event><!-- the bonfire can be lit again, the tyrant stays but no longer counts -->
+			<conditions operate="AND">
+				<quest_status value="START" op="EQUAL"/>
+				<quest_var var_id="0" value="2" op="EQUAL"/>
+			</conditions>
+			<operations>
+				<set_quest_var var_id="0" value="1"/>
+			</operations>
+		</on_timer_end_event>
+		<on_enter_world_event><!-- the timer didn't survive the relog, so the step has to become available again -->
+			<conditions operate="AND">
+				<quest_status value="START" op="EQUAL"/>
+				<quest_var var_id="0" value="2" op="EQUAL"/>
+				<quest_timer running="false" op="EQUAL"/>
+			</conditions>
+			<operations>
+				<set_quest_var var_id="0" value="1"/>
+			</operations>
+		</on_enter_world_event>
+	</xml_quest>
+	<xml_quest id="25084" start_npc_ids="804926" end_npc_ids="804927">
+		<on_talk_event ids="804925 804926">
+			<conditions operate="AND">
+				<quest_status value="START" op="EQUAL"/>
+			</conditions>
+			<var value="0"><!-- bring the shells to Coli -->
+				<npc id="804925">
+					<dialog id="31">
+						<operations>
+							<npc_dialog id="1011"/>
+						</operations>
+					</dialog>
+					<dialog id="39">
+						<operations>
+							<collect_items>
+								<true>
+									<set_quest_var var_id="0" value="1"/>
+									<npc_dialog id="10000"/>
+								</true>
+								<false>
+									<npc_dialog id="10001"/>
+								</false>
+							</collect_items>
+						</operations>
+					</dialog>
+				</npc>
+			</var>
+			<var value="1"><!-- report back to Zake -->
+				<npc id="804926">
+					<dialog id="31">
+						<operations>
+							<npc_dialog id="1352"/>
+						</operations>
+					</dialog>
+					<dialog id="10001">
+						<operations>
+							<set_quest_var var_id="0" value="2"/>
+							<npc_dialog id="0" quest_id="0"/>
+						</operations>
+					</dialog>
+				</npc>
+			</var>
+		</on_talk_event>
+		<on_enter_zone_event zones="DF5_SENSORYAREA_Q25084_206403_6_220080000">
+			<conditions operate="AND">
+				<quest_status value="START" op="EQUAL"/>
+				<quest_var var_id="0" value="2" op="EQUAL"/>
+			</conditions>
+			<operations>
+				<spawn_npc npc_id="220038" count="2" distance="7" lifetime="300" aggro="true"/>
+				<set_quest_var var_id="0" value="3"/>
+				<set_quest_status status="REWARD"/>
+			</operations>
+		</on_enter_zone_event>
+	</xml_quest>
 </quest_scripts>

--- a/game-server/data/static_data/quest_script_data/enshar.xml
+++ b/game-server/data/static_data/quest_script_data/enshar.xml
@@ -166,8 +166,8 @@
 					<dialog id="10001">
 						<operations>
 							<spawn_npc npc_id="833465" x="1056" y="194" z="227" h="30" lifetime="30"/>
-							<!-- retail has the burning bonfires ai spawn the tyrant on its own point, three seconds after it appears -->
-							<spawn_npc npc_id="220037" x="1056" y="194" z="227" aggro="true"/>
+							<!-- the burning bonfire lures the tyrant out three seconds later -->
+							<spawn_npc npc_id="220037" x="1056" y="194" z="227" aggro="true" delay="3"/>
 							<add_timer seconds="300"/>
 							<set_quest_var var_id="0" value="2"/>
 							<npc_dialog id="0" quest_id="0"/>
@@ -176,7 +176,7 @@
 				</npc>
 			</var>
 		</on_talk_event>
-		<on_kill_event ids="220037"><!-- only counts while the timer runs, like retail -->
+		<on_kill_event ids="220037"><!-- only counts while the timer runs -->
 			<conditions operate="AND">
 				<quest_status value="START" op="EQUAL"/>
 				<quest_var var_id="0" value="2" op="EQUAL"/>

--- a/game-server/data/static_data/quest_script_data/quest_script_data.xsd
+++ b/game-server/data/static_data/quest_script_data/quest_script_data.xsd
@@ -36,6 +36,11 @@
 				<xs:sequence>
 					<xs:element name="on_talk_event" type="OnTalkEvent" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element name="on_kill_event" type="OnKillEvent" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="on_enter_zone_event" type="OnEnterZoneEvent" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="on_item_use_event" type="OnItemUseEvent" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="on_timer_end_event" type="OnTimerEndEvent" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="on_enter_world_event" type="OnEnterWorldEvent" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="on_level_up_event" type="OnLevelUpEvent" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
 				<xs:attribute name="start_npc_ids" type="IntListType"/>
 				<xs:attribute name="end_npc_ids" type="IntListType"/>
@@ -91,6 +96,39 @@
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
+	<xs:complexType name="OnItemUseEvent">
+		<xs:complexContent>
+			<xs:extension base="QuestEvent">
+				<xs:attribute name="item_ids" type="NumberListType" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="OnEnterZoneEvent">
+		<xs:complexContent>
+			<xs:extension base="QuestEvent">
+				<xs:attribute name="zones" type="StringListType" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="OnTimerEndEvent">
+		<xs:complexContent>
+			<xs:extension base="QuestEvent"/>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="OnEnterWorldEvent">
+		<xs:complexContent>
+			<xs:extension base="QuestEvent">
+				<xs:attribute name="world_ids" type="NumberListType"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="OnLevelUpEvent">
+		<xs:complexContent>
+			<xs:extension base="QuestEvent">
+				<xs:attribute name="level" type="xs:int"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
 	<xs:complexType name="QuestConditions">
 		<xs:sequence minOccurs="0" maxOccurs="unbounded">
 			<xs:element name="dialog_id" type="DialogIdCondition" minOccurs="0" maxOccurs="unbounded"/>
@@ -98,6 +136,7 @@
 			<xs:element name="pc_inventory" type="PcInventoryCondition" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="quest_status" type="QuestStatusCondition" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="quest_var" type="QuestVarCondition" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="quest_timer" type="QuestTimerCondition" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 		<xs:attribute name="operate" type="ConditionUnionType" use="required"/>
 	</xs:complexType>
@@ -110,6 +149,10 @@
 			<xs:element name="start_quest" type="StartQuestOperation" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="take_item" type="TakeItemOperation" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="collect_items" type="CollectItemQuestOperation" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="spawn_npc" type="SpawnNpcOperation" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="add_timer" type="AddTimerOperation" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="teleport" type="TeleportOperation" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="play_cutscene" type="PlayCutsceneOperation" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="npc_use" type="ActionItemUseOperation" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="kill" type="KillOperation" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
@@ -150,6 +193,55 @@
 			<xs:extension base="QuestCondition">
 				<xs:attribute name="value" type="xs:int" use="required"/>
 				<xs:attribute name="var_id" type="xs:int" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="QuestTimerCondition">
+		<xs:complexContent>
+			<xs:extension base="QuestCondition">
+				<xs:attribute name="running" type="xs:boolean" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SpawnNpcOperation">
+		<xs:complexContent>
+			<xs:extension base="QuestOperation">
+				<xs:attribute name="npc_id" type="xs:int" use="required"/>
+				<xs:attribute name="count" type="xs:int"/>
+				<xs:attribute name="lifetime" type="xs:int"/>
+				<xs:attribute name="distance" type="xs:float"/>
+				<xs:attribute name="x" type="xs:float"/>
+				<xs:attribute name="y" type="xs:float"/>
+				<xs:attribute name="z" type="xs:float"/>
+				<xs:attribute name="h" type="xs:byte"/>
+				<xs:attribute name="aggro" type="xs:boolean"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="AddTimerOperation">
+		<xs:complexContent>
+			<xs:extension base="QuestOperation">
+				<xs:attribute name="seconds" type="xs:int" use="required"/>
+				<xs:attribute name="visible" type="xs:boolean"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="TeleportOperation">
+		<xs:complexContent>
+			<xs:extension base="QuestOperation">
+				<xs:attribute name="world_id" type="xs:int"/>
+				<xs:attribute name="x" type="xs:float" use="required"/>
+				<xs:attribute name="y" type="xs:float" use="required"/>
+				<xs:attribute name="z" type="xs:float" use="required"/>
+				<xs:attribute name="h" type="xs:byte"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PlayCutsceneOperation">
+		<xs:complexContent>
+			<xs:extension base="QuestOperation">
+				<xs:attribute name="id" type="xs:int" use="required"/>
+				<xs:attribute name="movie" type="xs:boolean"/>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>

--- a/game-server/data/static_data/quest_script_data/quest_script_data.xsd
+++ b/game-server/data/static_data/quest_script_data/quest_script_data.xsd
@@ -223,6 +223,7 @@
 				<xs:attribute name="z" type="xs:float"/>
 				<xs:attribute name="h" type="xs:byte"/>
 				<xs:attribute name="aggro" type="xs:boolean"/>
+				<xs:attribute name="delay" type="xs:int"/>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>

--- a/game-server/data/static_data/quest_script_data/quest_script_data.xsd
+++ b/game-server/data/static_data/quest_script_data/quest_script_data.xsd
@@ -41,6 +41,7 @@
 					<xs:element name="on_timer_end_event" type="OnTimerEndEvent" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element name="on_enter_world_event" type="OnEnterWorldEvent" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element name="on_level_up_event" type="OnLevelUpEvent" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="on_movie_end_event" type="OnMovieEndEvent" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
 				<xs:attribute name="start_npc_ids" type="IntListType"/>
 				<xs:attribute name="end_npc_ids" type="IntListType"/>
@@ -126,6 +127,13 @@
 		<xs:complexContent>
 			<xs:extension base="QuestEvent">
 				<xs:attribute name="level" type="xs:int"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="OnMovieEndEvent">
+		<xs:complexContent>
+			<xs:extension base="QuestEvent">
+				<xs:attribute name="movie_ids" type="NumberListType" use="required"/>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>

--- a/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
@@ -85,6 +85,15 @@ public class PlayerController extends CreatureController<Player> {
 	private long lastAttackMillis = 0;
 	private long lastAttackedMillis = 0;
 	private StanceObserver stanceObserver;
+	private int questTimerQuestId; // only one quest timer can run at a time, this is the quest it belongs to
+
+	public int getQuestTimerQuestId() {
+		return questTimerQuestId;
+	}
+
+	public void setQuestTimerQuestId(int questId) {
+		questTimerQuestId = questId;
+	}
 
 	@Override
 	public void see(VisibleObject object) {

--- a/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,7 +87,8 @@ public class PlayerController extends CreatureController<Player> {
 	private long lastAttackMillis = 0;
 	private long lastAttackedMillis = 0;
 	private StanceObserver stanceObserver;
-	private int questTimerQuestId; // only one quest timer can run at a time, this is the quest it belongs to
+	private int questTimerQuestId; // only one visible quest timer can run at a time, this is the quest it belongs to
+	private final Map<Integer, Future<?>> invisibleQuestTimers = new ConcurrentHashMap<>();
 
 	public int getQuestTimerQuestId() {
 		return questTimerQuestId;
@@ -93,6 +96,32 @@ public class PlayerController extends CreatureController<Player> {
 
 	public void setQuestTimerQuestId(int questId) {
 		questTimerQuestId = questId;
+	}
+
+	/**
+	 * Invisible quest timers are independent of the visible one, so every quest can have its own.
+	 */
+	public void addInvisibleQuestTimer(int questId, Future<?> task) {
+		Future<?> runningTimer = invisibleQuestTimers.put(questId, task);
+		if (runningTimer != null)
+			runningTimer.cancel(false);
+	}
+
+	public boolean hasInvisibleQuestTimer(int questId) {
+		return invisibleQuestTimers.containsKey(questId);
+	}
+
+	public void cancelInvisibleQuestTimer(int questId) {
+		Future<?> task = invisibleQuestTimers.remove(questId);
+		if (task != null)
+			task.cancel(false);
+	}
+
+	@Override
+	public void onDelete() {
+		invisibleQuestTimers.values().forEach(task -> task.cancel(false));
+		invisibleQuestTimers.clear();
+		super.onDelete();
 	}
 
 	@Override

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/player/QuestStateList.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/player/QuestStateList.java
@@ -83,15 +83,15 @@ public class QuestStateList {
 	}
 
 	/**
-	 * @return All normal (light blue) quests, that are currently active.
+	 * @return All currently active quests of a category which counts towards the basic quest limit.
 	 */
-	public List<QuestState> getNormalQuests() {
+	public List<QuestState> getQuestsCountingTowardsLimit() {
 		List<QuestState> questList = new ArrayList<>();
 		for (QuestState qs : getAllQuestState()) {
 			QuestCategory qc = DataManager.QUEST_DATA.getQuestById(qs.getQuestId()).getCategory();
 			QuestStatus s = qs.getStatus();
 
-			if (qc == QuestCategory.QUEST && s != QuestStatus.COMPLETE && s != QuestStatus.LOCKED) {
+			if (qc.countsTowardsQuestLimit() && s != QuestStatus.COMPLETE && s != QuestStatus.LOCKED) {
 				questList.add(qs);
 			}
 		}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ItemActions.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ItemActions.java
@@ -14,7 +14,8 @@ public class ItemActions {
 
 	@XmlElements({ @XmlElement(name = "skilllearn", type = SkillLearnAction.class), @XmlElement(name = "extract", type = ExtractAction.class),
 		@XmlElement(name = "skilluse", type = SkillUseAction.class), @XmlElement(name = "enchant", type = EnchantItemAction.class),
-		@XmlElement(name = "queststart", type = QuestStartAction.class), @XmlElement(name = "dye", type = DyeAction.class),
+		@XmlElement(name = "queststart", type = QuestStartAction.class), @XmlElement(name = "questuse", type = QuestUseAction.class),
+		@XmlElement(name = "dye", type = DyeAction.class),
 		@XmlElement(name = "craftlearn", type = CraftLearnAction.class), @XmlElement(name = "toypetspawn", type = ToyPetSpawnAction.class),
 		@XmlElement(name = "decompose", type = DecomposeAction.class), @XmlElement(name = "titleadd", type = TitleAddAction.class),
 		@XmlElement(name = "learnemotion", type = EmotionLearnAction.class), @XmlElement(name = "read", type = ReadAction.class),

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/QuestUseAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/QuestUseAction.java
@@ -1,0 +1,65 @@
+package com.aionemu.gameserver.model.templates.item.actions;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+
+import com.aionemu.gameserver.controllers.observer.ItemUseObserver;
+import com.aionemu.gameserver.model.TaskId;
+import com.aionemu.gameserver.model.gameobjects.Item;
+import com.aionemu.gameserver.model.gameobjects.player.Player;
+import com.aionemu.gameserver.network.aion.serverpackets.SM_ITEM_USAGE_ANIMATION;
+import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
+import com.aionemu.gameserver.questEngine.QuestEngine;
+import com.aionemu.gameserver.questEngine.model.QuestEnv;
+import com.aionemu.gameserver.utils.PacketSendUtility;
+import com.aionemu.gameserver.utils.ThreadPoolManager;
+
+/**
+ * Items which advance a quest step when used, the counterpart of {@link QuestStartAction} for quests that are already running. The client data
+ * marks them with quest_label 2 and gives them a casting delay, but no effect of their own, since what happens is up to the quest.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "QuestUseAction")
+public class QuestUseAction extends AbstractItemAction {
+
+	@Override
+	public boolean canAct(Player player, Item parentItem, Item targetItem, Object... params) {
+		return true; // like QuestStartAction, the cast plays first and the quest decides afterwards
+	}
+
+	@Override
+	public void act(Player player, Item parentItem, Item targetItem, Object... params) {
+		int castingDelay = parentItem.getItemTemplate().getCastingDelay();
+		if (castingDelay <= 0) {
+			finishUse(player, parentItem);
+			return;
+		}
+		PacketSendUtility.broadcastPacket(player,
+			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), castingDelay, 0, 1), true);
+		final ItemUseObserver observer = new ItemUseObserver() {
+
+			@Override
+			public void abort() {
+				player.getController().cancelTask(TaskId.ITEM_USE);
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
+				PacketSendUtility.broadcastPacket(player,
+					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0), true);
+			}
+		};
+
+		player.getObserveController().attach(observer);
+		player.getController().addTask(TaskId.ITEM_USE, ThreadPoolManager.getInstance().schedule(() -> {
+			player.getObserveController().removeObserver(observer);
+			finishUse(player, parentItem);
+		}, castingDelay));
+	}
+
+	private void finishUse(Player player, Item item) {
+		player.startCooldown(item);
+		PacketSendUtility.broadcastPacketAndReceive(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), item.getObjectId(), item.getItemId()));
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_USE_ITEM(item.getL10n()));
+		// CM_USE_ITEM skips onItemUseEvent for these items so it doesn't fire before the cast, the quest is notified here instead
+		QuestEngine.getInstance().onItemUseEvent(new QuestEnv(null, player, 0), item);
+	}
+}

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ReadAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ReadAction.java
@@ -24,8 +24,9 @@ public class ReadAction extends AbstractItemAction {
 
 	@Override
 	public void act(Player player, Item parentItem, Item targetItem, Object... params) {
-		// items combining <queststart> with <read> get their "used" message and usage animation from QuestStartAction already
-		if (parentItem.getItemTemplate().getActions().getItemActions().stream().anyMatch(a -> a instanceof QuestStartAction))
+		// items combining <read> with a quest action get their "used" message and usage animation from that action already
+		if (parentItem.getItemTemplate().getActions().getItemActions().stream()
+			.anyMatch(a -> a instanceof QuestStartAction || a instanceof QuestUseAction))
 			return;
 
 		int castingDelay = parentItem.getItemTemplate().getCastingDelay();

--- a/game-server/src/com/aionemu/gameserver/model/templates/quest/QuestCategory.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/quest/QuestCategory.java
@@ -22,4 +22,14 @@ public enum QuestCategory {
 	PUBLIC,
 	LEGION,
 	PRIMARY;
+
+	/**
+	 * @return True if quests of this category count towards the basic quest limit (mission, task, faction, event, non_count and public don't).
+	 */
+	public boolean countsTowardsQuestLimit() {
+		return switch (this) {
+			case QUEST, SEEN_MARKER, IMPORTANT, SIGNIFICANT, CHALLENGE_TASK, LEGION -> true;
+			default -> false;
+		};
+	}
 }

--- a/game-server/src/com/aionemu/gameserver/model/templates/quest/XMLStartCondition.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/quest/XMLStartCondition.java
@@ -115,13 +115,12 @@ public class XMLStartCondition {
 	}
 
 	private boolean checkEquippedItems(Player player, boolean warn) {
-		if (!warn)
-			return true;
 		int missingItemId = getMissingEquippedItem(player);
 		if (missingItemId == 0)
 			return true;
-		PacketSendUtility.sendPacket(player,
-			SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_EQUIP_ITEM(DataManager.ITEM_DATA.getItemTemplate(missingItemId).getL10n()));
+		if (warn)
+			PacketSendUtility.sendPacket(player,
+				SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_EQUIP_ITEM(DataManager.ITEM_DATA.getItemTemplate(missingItemId).getL10n()));
 		return false;
 	}
 

--- a/game-server/src/com/aionemu/gameserver/model/templates/quest/XMLStartCondition.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/quest/XMLStartCondition.java
@@ -104,19 +104,25 @@ public class XMLStartCondition {
 		return true;
 	}
 
+	private int getMissingEquippedItem(Player player) {
+		if (equipped != null) {
+			for (int itemId : equipped) {
+				if (!player.getEquipment().getEquippedItemIds().contains(itemId))
+					return itemId;
+			}
+		}
+		return 0;
+	}
+
 	private boolean checkEquippedItems(Player player, boolean warn) {
 		if (!warn)
 			return true;
-		if (equipped != null && equipped.size() > 0) {
-			for (int itemId : equipped) {
-				if (!player.getEquipment().getEquippedItemIds().contains(itemId)) {
-					String requiredItem = DataManager.ITEM_DATA.getItemTemplate(itemId).getL10n();
-					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_EQUIP_ITEM(requiredItem));
-					return false;
-				}
-			}
-		}
-		return true;
+		int missingItemId = getMissingEquippedItem(player);
+		if (missingItemId == 0)
+			return true;
+		PacketSendUtility.sendPacket(player,
+			SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_EQUIP_ITEM(DataManager.ITEM_DATA.getItemTemplate(missingItemId).getL10n()));
+		return false;
 	}
 
 	private boolean isRequiredTitleDisplayed(Player player) {
@@ -134,5 +140,36 @@ public class XMLStartCondition {
 
 	public List<FinishedQuestCond> getFinishedPreconditions() {
 		return finished;
+	}
+
+	/** Names the sub condition which made {@link #check} fail, for diagnostics. */
+	public String getFailureDescription(Player player) {
+		QuestStateList qsl = player.getQuestStateList();
+		if (!checkFinishedQuests(qsl)) {
+			StringBuilder sb = new StringBuilder("finished");
+			for (FinishedQuestCond fqc : finished) {
+				QuestState qs = qsl.getQuestState(fqc.getQuestId());
+				sb.append(" q").append(fqc.getQuestId()).append('=')
+					.append(qs == null ? "never acquired" : qs.getStatus() + ", completeCount " + qs.getCompleteCount() + ", rewardGroup " + qs.getRewardGroup());
+				if (fqc.getReward() >= 0)
+					sb.append(" (required rewardGroup ").append(fqc.getReward()).append(')');
+				QuestTemplate template = DataManager.QUEST_DATA.getQuestById(fqc.getQuestId());
+				if (template != null && template.isRepeatable() && template.getMaxRepeatCount() != 255)
+					sb.append(" (must be completed ").append(template.getMaxRepeatCount()).append(" times)");
+			}
+			return sb.toString();
+		}
+		if (!checkUnfinishedQuests(qsl))
+			return "unfinished " + unfinished;
+		if (!checkAcquiredQuests(qsl))
+			return "acquired " + acquired;
+		if (!checkNoAcquiredQuests(qsl))
+			return "noacquired " + noacquired;
+		int missingEquippedItem = getMissingEquippedItem(player);
+		if (missingEquippedItem != 0)
+			return "equipped " + equipped + " (missing " + missingEquippedItem + ")";
+		if (!isRequiredTitleDisplayed(player))
+			return "required_title " + requiredTitle + " (player has " + player.getCommonData().getTitleId() + ")";
+		return "none";
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/model/templates/quest/XMLStartCondition.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/quest/XMLStartCondition.java
@@ -124,9 +124,13 @@ public class XMLStartCondition {
 		return false;
 	}
 
-	private boolean isRequiredTitleDisplayed(Player player) {
-		if (requiredTitle != 0 && player.getCommonData().getTitleId() != requiredTitle)
+	private boolean isRequiredTitleDisplayed(Player player, boolean warn) {
+		if (requiredTitle != 0 && player.getCommonData().getTitleId() != requiredTitle) {
+			if (warn)
+				PacketSendUtility.sendPacket(player,
+					SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_TITLE(DataManager.TITLE_DATA.getTitleTemplate(requiredTitle).getL10n()));
 			return false;
+		}
 		return true;
 	}
 
@@ -134,7 +138,7 @@ public class XMLStartCondition {
 	public boolean check(Player player, boolean warn) {
 		QuestStateList qsl = player.getQuestStateList();
 		return checkFinishedQuests(qsl) && checkUnfinishedQuests(qsl) && checkAcquiredQuests(qsl) && checkNoAcquiredQuests(qsl)
-			&& checkEquippedItems(player, warn) && isRequiredTitleDisplayed(player);
+			&& checkEquippedItems(player, warn) && isRequiredTitleDisplayed(player, warn);
 	}
 
 	public List<FinishedQuestCond> getFinishedPreconditions() {
@@ -167,7 +171,7 @@ public class XMLStartCondition {
 		int missingEquippedItem = getMissingEquippedItem(player);
 		if (missingEquippedItem != 0)
 			return "equipped " + equipped + " (missing " + missingEquippedItem + ")";
-		if (!isRequiredTitleDisplayed(player))
+		if (!isRequiredTitleDisplayed(player, false))
 			return "required_title " + requiredTitle + " (player has " + player.getCommonData().getTitleId() + ")";
 		return "none";
 	}

--- a/game-server/src/com/aionemu/gameserver/model/templates/quest/XMLStartCondition.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/quest/XMLStartCondition.java
@@ -127,7 +127,7 @@ public class XMLStartCondition {
 			&& getMissingEquippedItem(player) == 0 && isRequiredTitleDisplayed(player);
 	}
 
-	/** Tells the player why {@link #check} failed. Retail answers the quest link conditions with a generic message. */
+	/** Tells the player why {@link #check} failed. The conditions linking quests to each other are answered with a generic message. */
 	public void sendFailureMessage(Player player) {
 		int missingItemId = getMissingEquippedItem(player);
 		if (missingItemId != 0)

--- a/game-server/src/com/aionemu/gameserver/model/templates/quest/XMLStartCondition.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/quest/XMLStartCondition.java
@@ -114,31 +114,30 @@ public class XMLStartCondition {
 		return 0;
 	}
 
-	private boolean checkEquippedItems(Player player, boolean warn) {
-		int missingItemId = getMissingEquippedItem(player);
-		if (missingItemId == 0)
-			return true;
-		if (warn)
-			PacketSendUtility.sendPacket(player,
-				SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_EQUIP_ITEM(DataManager.ITEM_DATA.getItemTemplate(missingItemId).getL10n()));
-		return false;
-	}
-
-	private boolean isRequiredTitleDisplayed(Player player, boolean warn) {
-		if (requiredTitle != 0 && player.getCommonData().getTitleId() != requiredTitle) {
-			if (warn)
-				PacketSendUtility.sendPacket(player,
-					SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_TITLE(DataManager.TITLE_DATA.getTitleTemplate(requiredTitle).getL10n()));
+	private boolean isRequiredTitleDisplayed(Player player) {
+		if (requiredTitle != 0 && player.getCommonData().getTitleId() != requiredTitle)
 			return false;
-		}
 		return true;
 	}
 
 	/** Check all conditions */
-	public boolean check(Player player, boolean warn) {
+	public boolean check(Player player) {
 		QuestStateList qsl = player.getQuestStateList();
 		return checkFinishedQuests(qsl) && checkUnfinishedQuests(qsl) && checkAcquiredQuests(qsl) && checkNoAcquiredQuests(qsl)
-			&& checkEquippedItems(player, warn) && isRequiredTitleDisplayed(player, warn);
+			&& getMissingEquippedItem(player) == 0 && isRequiredTitleDisplayed(player);
+	}
+
+	/** Tells the player why {@link #check} failed. Retail answers the quest link conditions with a generic message. */
+	public void sendFailureMessage(Player player) {
+		int missingItemId = getMissingEquippedItem(player);
+		if (missingItemId != 0)
+			PacketSendUtility.sendPacket(player,
+				SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_EQUIP_ITEM(DataManager.ITEM_DATA.getItemTemplate(missingItemId).getL10n()));
+		else if (!isRequiredTitleDisplayed(player))
+			PacketSendUtility.sendPacket(player,
+				SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_TITLE(DataManager.TITLE_DATA.getTitleTemplate(requiredTitle).getL10n()));
+		else
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_DEFAULT());
 	}
 
 	public List<FinishedQuestCond> getFinishedPreconditions() {
@@ -171,7 +170,7 @@ public class XMLStartCondition {
 		int missingEquippedItem = getMissingEquippedItem(player);
 		if (missingEquippedItem != 0)
 			return "equipped " + equipped + " (missing " + missingEquippedItem + ")";
-		if (!isRequiredTitleDisplayed(player, false))
+		if (!isRequiredTitleDisplayed(player))
 			return "required_title " + requiredTitle + " (player has " + player.getCommonData().getTitleId() + ")";
 		return "none";
 	}

--- a/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_DELETE_QUEST.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_DELETE_QUEST.java
@@ -3,12 +3,11 @@ package com.aionemu.gameserver.network.aion.clientpackets;
 import java.util.Set;
 
 import com.aionemu.gameserver.dataholders.DataManager;
-import com.aionemu.gameserver.model.TaskId;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.model.templates.QuestTemplate;
 import com.aionemu.gameserver.network.aion.AionClientPacket;
 import com.aionemu.gameserver.network.aion.AionConnection.State;
-import com.aionemu.gameserver.network.aion.serverpackets.SM_QUEST_ACTION;
+import com.aionemu.gameserver.questEngine.model.QuestEnv;
 import com.aionemu.gameserver.services.QuestService;
 
 public class CM_DELETE_QUEST extends AionClientPacket {
@@ -29,10 +28,8 @@ public class CM_DELETE_QUEST extends AionClientPacket {
 		Player player = getConnection().getActivePlayer();
 		QuestTemplate qt = DataManager.QUEST_DATA.getQuestById(questId);
 
-		if (qt != null && qt.isTimer()) {
-			player.getController().cancelTask(TaskId.QUEST_TIMER);
-			sendPacket(new SM_QUEST_ACTION(questId, 0));
-		}
+		if (qt != null && qt.isTimer())
+			QuestService.questTimerEnd(new QuestEnv(null, player, questId)); // only ends it if it belongs to this quest
 		QuestService.abandonQuest(player, questId);
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_USE_ITEM.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_USE_ITEM.java
@@ -13,6 +13,7 @@ import com.aionemu.gameserver.model.templates.item.actions.DyeAction;
 import com.aionemu.gameserver.model.templates.item.actions.InstanceTimeClear;
 import com.aionemu.gameserver.model.templates.item.actions.MultiReturnAction;
 import com.aionemu.gameserver.model.templates.item.actions.QuestStartAction;
+import com.aionemu.gameserver.model.templates.item.actions.QuestUseAction;
 import com.aionemu.gameserver.network.aion.AionClientPacket;
 import com.aionemu.gameserver.network.aion.AionConnection.State;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
@@ -85,8 +86,8 @@ public class CM_USE_ITEM extends AionClientPacket {
 		List<AbstractItemAction> itemActions = item.getItemTemplate().getActions() == null ? Collections.emptyList()
 			: item.getItemTemplate().getActions().getItemActions();
 
-		// QuestStartAction opens the quest dialog itself (after the casting delay), quest handlers must not open it a second time
-		HandlerResult result = itemActions.stream().anyMatch(a -> a instanceof QuestStartAction) ? HandlerResult.UNKNOWN
+		// QuestStartAction and QuestUseAction notify the quest themselves (after the casting delay), so it must not fire here as well
+		HandlerResult result = itemActions.stream().anyMatch(a -> a instanceof QuestStartAction || a instanceof QuestUseAction) ? HandlerResult.UNKNOWN
 			: QuestEngine.getInstance().onItemUseEvent(new QuestEnv(null, player, 0), item);
 
 		if (itemActions.isEmpty() && result != HandlerResult.SUCCESS) {

--- a/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_SYSTEM_MESSAGE.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_SYSTEM_MESSAGE.java
@@ -25982,6 +25982,13 @@ public final class SM_SYSTEM_MESSAGE extends AionServerPacket {
 	}
 
 	/**
+	 * You cannot receive a quest.
+	 */
+	public static SM_SYSTEM_MESSAGE STR_QUEST_ACQUIRE_ERROR_DEFAULT() {
+		return new SM_SYSTEM_MESSAGE(1401559);
+	}
+
+	/**
 	 * Tiamat has regained power and escaped to safety.
 	 */
 	public static SM_SYSTEM_MESSAGE IDTIAMAT_TIAMAT_COUNTDOWN_OVER() {

--- a/game-server/src/com/aionemu/gameserver/questEngine/QuestEngine.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/QuestEngine.java
@@ -881,6 +881,26 @@ public class QuestEngine implements GameEngine {
 		return questHandlers.get(questId);
 	}
 
+	/**
+	 * @return True if any quest of the player currently expects him to interact with this npc, be it to start, continue or hand in a quest.
+	 */
+	public boolean isNpcNeededByAnyQuestOf(Player player, int npcId) {
+		QuestNpc questNpc = getQuestNpc(npcId);
+		for (int questId : questNpc.getOnTalkEvent()) {
+			QuestState qs = player.getQuestStateList().getQuestState(questId);
+			if (qs == null || qs.getStatus() != QuestStatus.START && qs.getStatus() != QuestStatus.REWARD)
+				continue;
+			AbstractQuestHandler questHandler = getQuestHandlerByQuestId(questId);
+			if (questHandler == null || questHandler.isWaitingForInteractionWith(player, npcId))
+				return true;
+		}
+		for (int questId : questNpc.getOnQuestStart()) {
+			if (QuestService.checkStartConditions(player, questId, false))
+				return true;
+		}
+		return false;
+	}
+
 	public int getQuestHandlerCount() {
 		return questHandlers.size();
 	}

--- a/game-server/src/com/aionemu/gameserver/questEngine/QuestEngine.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/QuestEngine.java
@@ -525,14 +525,15 @@ public class QuestEngine implements GameEngine {
 		}
 	}
 
+	/**
+	 * Notifies the quest whose timer expired, since invisible timers belong to a quest, not to the player.
+	 */
 	public void onInvisibleTimerEnd(QuestEnv env) {
 		try {
-			for (int questId : onInvisibleTimerEnd) {
-				AbstractQuestHandler questHandler = getQuestHandlerByQuestId(questId);
-				if (questHandler != null) {
-					env.setQuestId(questId);
+			if (onInvisibleTimerEnd.contains(env.getQuestId())) {
+				AbstractQuestHandler questHandler = getQuestHandlerByQuestId(env.getQuestId());
+				if (questHandler != null)
 					questHandler.onInvisibleTimerEndEvent(env);
-				}
 			}
 		} catch (Exception ex) {
 			log.error("QE: exception in onInvisibleTimerEnd", ex);

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/AbstractQuestHandler.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/AbstractQuestHandler.java
@@ -114,6 +114,14 @@ public abstract class AbstractQuestHandler {
 	}
 
 	/**
+	 * @return True if this quest expects the player to interact with the given npc in its current state. Handlers which can't tell answer true, so
+	 *         they keep behaving as before.
+	 */
+	public boolean isWaitingForInteractionWith(Player player, int npcId) {
+		return true;
+	}
+
+	/**
 	 * This method is called on every handler (which registered the event), after a player entered a map.
 	 */
 	public boolean onEnterWorldEvent(QuestEnv env) {

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/AbstractQuestHandler.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/AbstractQuestHandler.java
@@ -434,10 +434,8 @@ public abstract class AbstractQuestHandler {
 							npcHasActiveQuest = true; // TODO correct way to make sure that active quest can be continued at this npc
 					}
 				}
-				boolean npcHasNewQuest = false;
 				for (Integer questId : questNpc.getOnQuestStart()) { // all quest IDs that are registered to be started at this npc
 					if (QuestService.checkStartConditions(player, questId, false)) {
-						npcHasNewQuest = true;
 						QuestTemplate template = DataManager.QUEST_DATA.getQuestById(questId);
 						for (XMLStartCondition startCondition : template.getXMLStartConditions()) {
 							List<FinishedQuestCond> finishedQuests = startCondition.getFinishedPreconditions();
@@ -454,7 +452,8 @@ public abstract class AbstractQuestHandler {
 						}
 					}
 				}
-				return npcHasActiveQuest || npcHasNewQuest ? sendQuestSelectionDialog(env) : closeDialogWindow(env);
+				// on retail the window closes even when the npc still has quests to offer, only an ongoing one keeps it open
+				return npcHasActiveQuest ? sendQuestSelectionDialog(env) : closeDialogWindow(env);
 			}
 		} else {
 			switch (dialogActionId) {

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/AbstractQuestHandler.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/AbstractQuestHandler.java
@@ -460,7 +460,7 @@ public abstract class AbstractQuestHandler {
 						}
 					}
 				}
-				// on retail the window closes even when the npc still has quests to offer, only an ongoing one keeps it open
+				// only an ongoing quest keeps the window open, quests the npc merely offers don't
 				return npcHasActiveQuest ? sendQuestSelectionDialog(env) : closeDialogWindow(env);
 			}
 		} else {

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/AbstractQuestHandler.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/AbstractQuestHandler.java
@@ -1023,7 +1023,7 @@ public abstract class AbstractQuestHandler {
 
 		// Check the quests, that have to be done before starting this one and other start conditions, listed in quest_data
 		for (XMLStartCondition cond : template.getXMLStartConditions()) {
-			if (!cond.check(player, false)) {
+			if (!cond.check(player)) {
 				if (qs == null && template.isMission())
 					QuestService.addOrUpdateQuest(player, questId, QuestStatus.LOCKED);
 				return false;
@@ -1089,7 +1089,7 @@ public abstract class AbstractQuestHandler {
 		// Check the quests, that have to be done before starting this one and other start conditions, listed in quest_data
 		missingRequirement = false;
 		for (XMLStartCondition cond : template.getXMLStartConditions()) {
-			if (!cond.check(player, false)) {
+			if (!cond.check(player)) {
 				if (qs != null || !template.isMission()) // fast return if its already locked or no campaign quest
 					return false;
 				else if (hasAnyPreQuestFinished(qsl, cond)) { // recursive check

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/XmlQuestData.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/XmlQuestData.java
@@ -11,15 +11,21 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 
 import com.aionemu.gameserver.questEngine.QuestEngine;
+import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnEnterWorldEvent;
+import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnEnterZoneEvent;
+import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnItemUseEvent;
 import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnKillEvent;
+import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnLevelUpEvent;
 import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnTalkEvent;
+import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnTimerEndEvent;
 import com.aionemu.gameserver.questEngine.handlers.template.XmlQuest;
 
 /**
  * @author Mr. Poke, Pad
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "XmlQuest", propOrder = { "onTalkEvents", "onKillEvents" })
+@XmlType(name = "XmlQuest", propOrder = { "onTalkEvents", "onKillEvents", "onEnterZoneEvents", "onItemUseEvents", "onTimerEndEvents",
+	"onEnterWorldEvents", "onLevelUpEvents" })
 public class XmlQuestData extends XMLQuest {
 
 	@XmlElement(name = "on_talk_event")
@@ -27,6 +33,21 @@ public class XmlQuestData extends XMLQuest {
 
 	@XmlElement(name = "on_kill_event")
 	protected List<OnKillEvent> onKillEvents;
+
+	@XmlElement(name = "on_enter_zone_event")
+	protected List<OnEnterZoneEvent> onEnterZoneEvents;
+
+	@XmlElement(name = "on_item_use_event")
+	protected List<OnItemUseEvent> onItemUseEvents;
+
+	@XmlElement(name = "on_timer_end_event")
+	protected List<OnTimerEndEvent> onTimerEndEvents;
+
+	@XmlElement(name = "on_enter_world_event")
+	protected List<OnEnterWorldEvent> onEnterWorldEvents;
+
+	@XmlElement(name = "on_level_up_event")
+	protected List<OnLevelUpEvent> onLevelUpEvents;
 
 	@XmlAttribute(name = "start_npc_ids")
 	protected List<Integer> startNpcIds;
@@ -36,7 +57,43 @@ public class XmlQuestData extends XMLQuest {
 
 	@Override
 	public void register(QuestEngine questEngine) {
-		questEngine.addQuestHandler(new XmlQuest(id, startNpcIds, endNpcIds, onTalkEvents, onKillEvents));
+		questEngine.addQuestHandler(new XmlQuest(this));
+	}
+
+	public List<Integer> getStartNpcIds() {
+		return startNpcIds;
+	}
+
+	public List<Integer> getEndNpcIds() {
+		return endNpcIds;
+	}
+
+	public List<OnTalkEvent> getOnTalkEvents() {
+		return onTalkEvents;
+	}
+
+	public List<OnKillEvent> getOnKillEvents() {
+		return onKillEvents;
+	}
+
+	public List<OnEnterZoneEvent> getOnEnterZoneEvents() {
+		return onEnterZoneEvents;
+	}
+
+	public List<OnItemUseEvent> getOnItemUseEvents() {
+		return onItemUseEvents;
+	}
+
+	public List<OnTimerEndEvent> getOnTimerEndEvents() {
+		return onTimerEndEvents;
+	}
+
+	public List<OnEnterWorldEvent> getOnEnterWorldEvents() {
+		return onEnterWorldEvents;
+	}
+
+	public List<OnLevelUpEvent> getOnLevelUpEvents() {
+		return onLevelUpEvents;
 	}
 
 	@Override

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/XmlQuestData.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/XmlQuestData.java
@@ -16,6 +16,7 @@ import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnEnte
 import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnItemUseEvent;
 import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnKillEvent;
 import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnLevelUpEvent;
+import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnMovieEndEvent;
 import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnTalkEvent;
 import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnTimerEndEvent;
 import com.aionemu.gameserver.questEngine.handlers.template.XmlQuest;
@@ -25,7 +26,7 @@ import com.aionemu.gameserver.questEngine.handlers.template.XmlQuest;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "XmlQuest", propOrder = { "onTalkEvents", "onKillEvents", "onEnterZoneEvents", "onItemUseEvents", "onTimerEndEvents",
-	"onEnterWorldEvents", "onLevelUpEvents" })
+	"onEnterWorldEvents", "onLevelUpEvents", "onMovieEndEvents" })
 public class XmlQuestData extends XMLQuest {
 
 	@XmlElement(name = "on_talk_event")
@@ -48,6 +49,9 @@ public class XmlQuestData extends XMLQuest {
 
 	@XmlElement(name = "on_level_up_event")
 	protected List<OnLevelUpEvent> onLevelUpEvents;
+
+	@XmlElement(name = "on_movie_end_event")
+	protected List<OnMovieEndEvent> onMovieEndEvents;
 
 	@XmlAttribute(name = "start_npc_ids")
 	protected List<Integer> startNpcIds;
@@ -94,6 +98,10 @@ public class XmlQuestData extends XMLQuest {
 
 	public List<OnLevelUpEvent> getOnLevelUpEvents() {
 		return onLevelUpEvents;
+	}
+
+	public List<OnMovieEndEvent> getOnMovieEndEvents() {
+		return onMovieEndEvents;
 	}
 
 	@Override

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/QuestNpc.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/QuestNpc.java
@@ -25,6 +25,10 @@ public class QuestNpc {
 	@XmlAttribute(required = true)
 	protected int id;
 
+	public int getId() {
+		return id;
+	}
+
 	public boolean operate(QuestEnv env, QuestState qs) {
 		int npcId = -1;
 		if (env.getVisibleObject() instanceof Npc)

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/QuestVar.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/QuestVar.java
@@ -24,6 +24,17 @@ public class QuestVar {
 	@XmlAttribute(required = true)
 	protected int value;
 
+	/** @return True if this branch is the current one and holds a dialog for the given npc. */
+	public boolean isCurrentAndHandles(QuestState qs, int npcId) {
+		if ((qs == null ? -1 : qs.getQuestVars().getQuestVars()) != value)
+			return false;
+		for (QuestNpc questNpc : npc) {
+			if (questNpc.getId() == npcId)
+				return true;
+		}
+		return false;
+	}
+
 	public boolean operate(QuestEnv env, QuestState qs) {
 		int var = -1;
 		if (qs != null)

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/conditions/QuestCondition.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/conditions/QuestCondition.java
@@ -14,7 +14,8 @@ import com.aionemu.gameserver.questEngine.model.QuestEnv;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "QuestCondition")
-@XmlSeeAlso({ NpcIdCondition.class, DialogIdCondition.class, PcInventoryCondition.class, QuestVarCondition.class, QuestStatusCondition.class })
+@XmlSeeAlso({ NpcIdCondition.class, DialogIdCondition.class, PcInventoryCondition.class, QuestVarCondition.class, QuestStatusCondition.class,
+	QuestTimerCondition.class })
 public abstract class QuestCondition {
 
 	@XmlAttribute(required = true)

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/conditions/QuestConditions.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/conditions/QuestConditions.java
@@ -21,7 +21,8 @@ public class QuestConditions {
 
 	@XmlElements({ @XmlElement(name = "quest_status", type = QuestStatusCondition.class), @XmlElement(name = "npc_id", type = NpcIdCondition.class),
 		@XmlElement(name = "pc_inventory", type = PcInventoryCondition.class), @XmlElement(name = "quest_var", type = QuestVarCondition.class),
-		@XmlElement(name = "dialog_id", type = DialogIdCondition.class) })
+		@XmlElement(name = "dialog_id", type = DialogIdCondition.class),
+		@XmlElement(name = "quest_timer", type = QuestTimerCondition.class) })
 	protected List<QuestCondition> conditions;
 	@XmlAttribute(required = true)
 	protected ConditionUnionType operate;

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/conditions/QuestTimerCondition.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/conditions/QuestTimerCondition.java
@@ -1,0 +1,29 @@
+package com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.conditions;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+import com.aionemu.gameserver.questEngine.model.QuestEnv;
+
+/**
+ * Checks whether a timer of this quest is running. Timers don't survive a relog, so a step waiting for one needs a way to notice it's gone.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "QuestTimerCondition")
+public class QuestTimerCondition extends QuestCondition {
+
+	@XmlAttribute(required = true)
+	protected boolean running;
+
+	@Override
+	public boolean doCheck(QuestEnv env) {
+		boolean isRunning = env.getPlayer().getController().getQuestTimerQuestId() == env.getQuestId();
+		return switch (getOp()) {
+			case EQUAL -> isRunning == running;
+			case NOT_EQUAL -> isRunning != running;
+			default -> false;
+		};
+	}
+}

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/conditions/QuestTimerCondition.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/conditions/QuestTimerCondition.java
@@ -5,6 +5,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 
+import com.aionemu.gameserver.controllers.PlayerController;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
 
 /**
@@ -19,7 +20,8 @@ public class QuestTimerCondition extends QuestCondition {
 
 	@Override
 	public boolean doCheck(QuestEnv env) {
-		boolean isRunning = env.getPlayer().getController().getQuestTimerQuestId() == env.getQuestId();
+		PlayerController controller = env.getPlayer().getController();
+		boolean isRunning = controller.getQuestTimerQuestId() == env.getQuestId() || controller.hasInvisibleQuestTimer(env.getQuestId());
 		return switch (getOp()) {
 			case EQUAL -> isRunning == running;
 			case NOT_EQUAL -> isRunning != running;

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/OnEnterWorldEvent.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/OnEnterWorldEvent.java
@@ -1,0 +1,30 @@
+package com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+import com.aionemu.gameserver.questEngine.model.QuestEnv;
+
+/**
+ * Runs its operations when the player enters one of the listed worlds, or any world if none are listed.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "OnEnterWorldEvent")
+public class OnEnterWorldEvent extends QuestEvent {
+
+	@XmlAttribute(name = "world_ids")
+	protected List<Integer> worldIds;
+
+	@Override
+	public boolean operate(QuestEnv env) {
+		if (worldIds != null && !worldIds.contains(env.getPlayer().getWorldId()))
+			return false;
+		if (conditions != null && !conditions.checkConditionOfSet(env))
+			return false;
+		return operations != null && operations.operate(env);
+	}
+}

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/OnEnterZoneEvent.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/OnEnterZoneEvent.java
@@ -1,0 +1,37 @@
+package com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+import com.aionemu.gameserver.questEngine.model.QuestEnv;
+import com.aionemu.gameserver.world.zone.ZoneName;
+
+/**
+ * Runs its operations when the player enters one of the listed zones.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "OnEnterZoneEvent")
+public class OnEnterZoneEvent extends QuestEvent {
+
+	@XmlAttribute(name = "zones", required = true)
+	protected List<String> zones;
+
+	public List<String> getZones() {
+		if (zones == null)
+			zones = new ArrayList<>();
+		return zones;
+	}
+
+	public boolean operate(QuestEnv env, ZoneName zoneName) {
+		if (zones == null || !zones.contains(zoneName.name()))
+			return false;
+		if (conditions != null && !conditions.checkConditionOfSet(env))
+			return false;
+		return operations != null && operations.operate(env);
+	}
+}

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/OnItemUseEvent.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/OnItemUseEvent.java
@@ -1,0 +1,36 @@
+package com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+import com.aionemu.gameserver.questEngine.model.QuestEnv;
+
+/**
+ * Runs its operations when the player uses one of the listed quest items.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "OnItemUseEvent")
+public class OnItemUseEvent extends QuestEvent {
+
+	@XmlAttribute(name = "item_ids", required = true)
+	protected List<Integer> itemIds;
+
+	public List<Integer> getItemIds() {
+		if (itemIds == null)
+			itemIds = new ArrayList<>();
+		return itemIds;
+	}
+
+	public boolean operate(QuestEnv env, int itemId) {
+		if (itemIds == null || !itemIds.contains(itemId))
+			return false;
+		if (conditions != null && !conditions.checkConditionOfSet(env))
+			return false;
+		return operations != null && operations.operate(env);
+	}
+}

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/OnKillEvent.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/OnKillEvent.java
@@ -42,6 +42,9 @@ public class OnKillEvent extends QuestEvent {
 		if (monster == null || !(env.getVisibleObject() instanceof Npc))
 			return false;
 
+		if (conditions != null && !conditions.checkConditionOfSet(env))
+			return false;
+
 		QuestState qs = env.getPlayer().getQuestStateList().getQuestState(env.getQuestId());
 		if (qs == null)
 			return false;

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/OnLevelUpEvent.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/OnLevelUpEvent.java
@@ -1,0 +1,28 @@
+package com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+import com.aionemu.gameserver.questEngine.model.QuestEnv;
+
+/**
+ * Runs its operations when the players level changed, optionally only from the given level upwards.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "OnLevelUpEvent")
+public class OnLevelUpEvent extends QuestEvent {
+
+	@XmlAttribute
+	protected int level;
+
+	@Override
+	public boolean operate(QuestEnv env) {
+		if (level > 0 && env.getPlayer().getLevel() < level)
+			return false;
+		if (conditions != null && !conditions.checkConditionOfSet(env))
+			return false;
+		return operations != null && operations.operate(env);
+	}
+}

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/OnMovieEndEvent.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/OnMovieEndEvent.java
@@ -1,0 +1,36 @@
+package com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+import com.aionemu.gameserver.questEngine.model.QuestEnv;
+
+/**
+ * Runs its operations when one of the listed cutscenes finished playing, which is also the moment the player skipped it.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "OnMovieEndEvent")
+public class OnMovieEndEvent extends QuestEvent {
+
+	@XmlAttribute(name = "movie_ids", required = true)
+	protected List<Integer> movieIds;
+
+	public List<Integer> getMovieIds() {
+		if (movieIds == null)
+			movieIds = new ArrayList<>();
+		return movieIds;
+	}
+
+	public boolean operate(QuestEnv env, int movieId) {
+		if (movieIds == null || !movieIds.contains(movieId))
+			return false;
+		if (conditions != null && !conditions.checkConditionOfSet(env))
+			return false;
+		return operations != null && operations.operate(env);
+	}
+}

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/OnTalkEvent.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/OnTalkEvent.java
@@ -21,6 +21,18 @@ public class OnTalkEvent extends QuestEvent {
 	@XmlElement(name = "var")
 	protected List<QuestVar> var;
 
+	/** @return True if the quest expects the player to talk to the given npc in its current state. */
+	public boolean isWaitingFor(QuestEnv env, int npcId) {
+		if (conditions != null && !conditions.checkConditionOfSet(env))
+			return false;
+		QuestState qs = env.getPlayer().getQuestStateList().getQuestState(env.getQuestId());
+		for (QuestVar questVar : var) {
+			if (questVar.isCurrentAndHandles(qs, npcId))
+				return true;
+		}
+		return false;
+	}
+
 	@Override
 	public boolean operate(QuestEnv env) {
 		if (conditions == null || conditions.checkConditionOfSet(env)) {

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/OnTimerEndEvent.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/OnTimerEndEvent.java
@@ -1,0 +1,22 @@
+package com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+
+import com.aionemu.gameserver.questEngine.model.QuestEnv;
+
+/**
+ * Runs its operations when a timer started by {@code add_timer} expires. Timers don't survive a relog, so the operations must leave the quest
+ * in a state the player can continue from.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "OnTimerEndEvent")
+public class OnTimerEndEvent extends QuestEvent {
+
+	public boolean operate(QuestEnv env) {
+		if (conditions != null && !conditions.checkConditionOfSet(env))
+			return false;
+		return operations != null && operations.operate(env);
+	}
+}

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/QuestEvent.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/QuestEvent.java
@@ -18,7 +18,8 @@ import com.aionemu.gameserver.questEngine.model.QuestEnv;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "QuestEvent", propOrder = { "conditions", "operations" })
-@XmlSeeAlso({ OnKillEvent.class, OnTalkEvent.class })
+@XmlSeeAlso({ OnKillEvent.class, OnTalkEvent.class, OnEnterZoneEvent.class, OnItemUseEvent.class, OnTimerEndEvent.class, OnEnterWorldEvent.class,
+	OnLevelUpEvent.class })
 public abstract class QuestEvent {
 
 	protected QuestConditions conditions;

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/QuestEvent.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/events/QuestEvent.java
@@ -19,7 +19,7 @@ import com.aionemu.gameserver.questEngine.model.QuestEnv;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "QuestEvent", propOrder = { "conditions", "operations" })
 @XmlSeeAlso({ OnKillEvent.class, OnTalkEvent.class, OnEnterZoneEvent.class, OnItemUseEvent.class, OnTimerEndEvent.class, OnEnterWorldEvent.class,
-	OnLevelUpEvent.class })
+	OnLevelUpEvent.class, OnMovieEndEvent.class })
 public abstract class QuestEvent {
 
 	protected QuestConditions conditions;

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/AddTimerOperation.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/AddTimerOperation.java
@@ -1,0 +1,31 @@
+package com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.operations;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+import com.aionemu.gameserver.questEngine.model.QuestEnv;
+import com.aionemu.gameserver.services.QuestService;
+
+/**
+ * Starts a quest timer which fires {@code on_timer_end_event} when it expires. Visible timers also show the remaining time to the player.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "AddTimerOperation")
+public class AddTimerOperation extends QuestOperation {
+
+	@XmlAttribute(required = true)
+	protected int seconds;
+	/** whether the player sees the remaining time */
+	@XmlAttribute
+	protected boolean visible;
+
+	@Override
+	public void doOperate(QuestEnv env) {
+		if (visible)
+			QuestService.questTimerStart(env, seconds);
+		else
+			QuestService.invisibleTimerStart(env, seconds);
+	}
+}

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/PlayCutsceneOperation.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/PlayCutsceneOperation.java
@@ -1,0 +1,29 @@
+package com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.operations;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+import com.aionemu.gameserver.network.aion.serverpackets.SM_PLAY_MOVIE;
+import com.aionemu.gameserver.questEngine.model.QuestEnv;
+import com.aionemu.gameserver.utils.PacketSendUtility;
+
+/**
+ * Plays a cutscene or, with {@code movie="true"}, a movie. Retail declares both as one action with the type in front of the id.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "PlayCutsceneOperation")
+public class PlayCutsceneOperation extends QuestOperation {
+
+	@XmlAttribute(required = true)
+	protected int id;
+	@XmlAttribute
+	protected boolean movie;
+
+	@Override
+	public void doOperate(QuestEnv env) {
+		int targetObjectId = env.getVisibleObject() == null ? 0 : env.getVisibleObject().getObjectId();
+		PacketSendUtility.sendPacket(env.getPlayer(), new SM_PLAY_MOVIE(movie, targetObjectId, env.getQuestId(), id, true));
+	}
+}

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/PlayCutsceneOperation.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/PlayCutsceneOperation.java
@@ -10,7 +10,7 @@ import com.aionemu.gameserver.questEngine.model.QuestEnv;
 import com.aionemu.gameserver.utils.PacketSendUtility;
 
 /**
- * Plays a cutscene or, with {@code movie="true"}, a movie. Retail declares both as one action with the type in front of the id.
+ * Plays a cutscene or, with {@code movie="true"}, a movie. The quest is notified by {@code on_movie_end_event} when it finished playing.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "PlayCutsceneOperation")

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/QuestOperation.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/QuestOperation.java
@@ -13,7 +13,8 @@ import com.aionemu.gameserver.questEngine.model.QuestEnv;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "QuestOperation")
 @XmlSeeAlso({ TakeItemOperation.class, StartQuestOperation.class, SetQuestVarOperation.class, NpcDialogOperation.class, GiveItemOperation.class,
-	SetQuestStatusOperation.class })
+	SetQuestStatusOperation.class, SpawnNpcOperation.class, AddTimerOperation.class, TeleportOperation.class,
+	PlayCutsceneOperation.class })
 public abstract class QuestOperation {
 
 	public abstract void doOperate(QuestEnv env);

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/QuestOperations.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/QuestOperations.java
@@ -19,7 +19,10 @@ public class QuestOperations {
 		@XmlElement(name = "set_quest_status", type = SetQuestStatusOperation.class), @XmlElement(name = "give_item", type = GiveItemOperation.class),
 		@XmlElement(name = "start_quest", type = StartQuestOperation.class), @XmlElement(name = "npc_use", type = ActionItemUseOperation.class),
 		@XmlElement(name = "set_quest_var", type = SetQuestVarOperation.class),
-		@XmlElement(name = "collect_items", type = CollectItemQuestOperation.class) })
+		@XmlElement(name = "collect_items", type = CollectItemQuestOperation.class),
+		@XmlElement(name = "spawn_npc", type = SpawnNpcOperation.class), @XmlElement(name = "add_timer", type = AddTimerOperation.class),
+		@XmlElement(name = "teleport", type = TeleportOperation.class),
+		@XmlElement(name = "play_cutscene", type = PlayCutsceneOperation.class) })
 	protected List<QuestOperation> operations;
 	@XmlAttribute
 	protected Boolean override;

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/SetQuestStatusOperation.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/SetQuestStatusOperation.java
@@ -31,7 +31,7 @@ public class SetQuestStatusOperation extends QuestOperation {
 		if (qs != null) {
 			qs.setStatus(status);
 			PacketSendUtility.sendPacket(player, new SM_QUEST_ACTION(ActionType.UPDATE, qs));
-			if (qs.getStatus() == QuestStatus.COMPLETE)
+			if (qs.getStatus() == QuestStatus.COMPLETE || qs.getStatus() == QuestStatus.REWARD)
 				player.getController().updateNearbyQuests();
 		}
 	}

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/SpawnNpcOperation.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/SpawnNpcOperation.java
@@ -1,0 +1,79 @@
+package com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.operations;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+import com.aionemu.commons.utils.Rnd;
+import com.aionemu.gameserver.geoEngine.math.Vector3f;
+import com.aionemu.gameserver.model.gameobjects.Npc;
+import com.aionemu.gameserver.model.gameobjects.player.Player;
+import com.aionemu.gameserver.questEngine.model.QuestEnv;
+import com.aionemu.gameserver.spawnengine.SpawnEngine;
+import com.aionemu.gameserver.utils.ThreadPoolManager;
+import com.aionemu.gameserver.world.WorldPosition;
+import com.aionemu.gameserver.world.geo.GeoService;
+
+/**
+ * Spawns npcs for the player, like the ambushes and props retail sets up on a quest step. Without x/y/z they appear
+ * around the player, otherwise at the given position.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SpawnNpcOperation")
+public class SpawnNpcOperation extends QuestOperation {
+
+	@XmlAttribute(name = "npc_id", required = true)
+	protected int npcId;
+	@XmlAttribute
+	protected int count = 1;
+	/** seconds until the spawn despawns again, 0 keeps it until it dies */
+	@XmlAttribute
+	protected int lifetime;
+	/** distance to the player, only used when no position is given */
+	@XmlAttribute
+	protected float distance = 5;
+	@XmlAttribute
+	protected Float x;
+	@XmlAttribute
+	protected Float y;
+	@XmlAttribute
+	protected Float z;
+	@XmlAttribute
+	protected Byte h;
+	/** whether the spawns should attack the player right away */
+	@XmlAttribute
+	protected boolean aggro;
+
+	@Override
+	public void doOperate(QuestEnv env) {
+		Player player = env.getPlayer();
+		WorldPosition position = player.getPosition();
+		for (int i = 0; i < count; i++) {
+			float spawnX, spawnY, spawnZ;
+			if (x != null && y != null && z != null) {
+				spawnX = x;
+				spawnY = y;
+				spawnZ = z;
+			} else {
+				double angle = Math.toRadians(Rnd.nextFloat(360f));
+				Vector3f collision = GeoService.getInstance().getClosestCollision(player, position.getX() + (float) (Math.cos(angle) * distance),
+					position.getY() + (float) (Math.sin(angle) * distance), position.getZ());
+				spawnX = collision.getX();
+				spawnY = collision.getY();
+				spawnZ = collision.getZ();
+			}
+			Npc npc = (Npc) SpawnEngine.spawnObject(
+				SpawnEngine.newSingleTimeSpawn(position.getMapId(), npcId, spawnX, spawnY, spawnZ, h == null ? 0 : h), position.getInstanceId());
+			if (npc == null)
+				return; // npc id doesn't exist, the spawn engine logged it
+			if (aggro)
+				npc.getAggroList().addHate(player, 1000);
+			if (lifetime > 0)
+				ThreadPoolManager.getInstance().schedule(() -> {
+					if (npc.isSpawned())
+						npc.getController().delete();
+				}, lifetime * 1000L);
+		}
+	}
+}

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/SpawnNpcOperation.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/SpawnNpcOperation.java
@@ -16,8 +16,8 @@ import com.aionemu.gameserver.world.WorldPosition;
 import com.aionemu.gameserver.world.geo.GeoService;
 
 /**
- * Spawns npcs for the player, like the ambushes and props retail sets up on a quest step. Without x/y/z they appear
- * around the player, otherwise at the given position.
+ * Spawns npcs for the player, like the ambushes and props a quest step sets up. Without x/y/z they appear around the player, otherwise at
+ * the given position.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "SpawnNpcOperation")
@@ -44,10 +44,24 @@ public class SpawnNpcOperation extends QuestOperation {
 	/** whether the spawns should attack the player right away */
 	@XmlAttribute
 	protected boolean aggro;
+	/** seconds until the npcs appear */
+	@XmlAttribute
+	protected int delay;
 
 	@Override
 	public void doOperate(QuestEnv env) {
 		Player player = env.getPlayer();
+		int mapId = player.getWorldId();
+		int instanceId = player.getInstanceId();
+		if (delay > 0)
+			ThreadPoolManager.getInstance().schedule(() -> spawnAll(player, mapId, instanceId), delay * 1000L);
+		else
+			spawnAll(player, mapId, instanceId);
+	}
+
+	private void spawnAll(Player player, int mapId, int instanceId) {
+		if (player.getWorldId() != mapId || player.getInstanceId() != instanceId)
+			return; // the player left before the spawns were due
 		WorldPosition position = player.getPosition();
 		for (int i = 0; i < count; i++) {
 			float spawnX, spawnY, spawnZ;
@@ -63,8 +77,8 @@ public class SpawnNpcOperation extends QuestOperation {
 				spawnY = collision.getY();
 				spawnZ = collision.getZ();
 			}
-			Npc npc = (Npc) SpawnEngine.spawnObject(
-				SpawnEngine.newSingleTimeSpawn(position.getMapId(), npcId, spawnX, spawnY, spawnZ, h == null ? 0 : h), position.getInstanceId());
+			Npc npc = (Npc) SpawnEngine
+				.spawnObject(SpawnEngine.newSingleTimeSpawn(mapId, npcId, spawnX, spawnY, spawnZ, h == null ? 0 : h), instanceId);
 			if (npc == null)
 				return; // npc id doesn't exist, the spawn engine logged it
 			if (aggro)

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/TeleportOperation.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/models/xmlQuest/operations/TeleportOperation.java
@@ -1,0 +1,35 @@
+package com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.operations;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+import com.aionemu.gameserver.model.gameobjects.player.Player;
+import com.aionemu.gameserver.questEngine.model.QuestEnv;
+import com.aionemu.gameserver.services.teleport.TeleportService;
+
+/**
+ * Teleports the player, staying in his current world when no world id is given.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TeleportOperation")
+public class TeleportOperation extends QuestOperation {
+
+	@XmlAttribute(name = "world_id")
+	protected int worldId;
+	@XmlAttribute(required = true)
+	protected float x;
+	@XmlAttribute(required = true)
+	protected float y;
+	@XmlAttribute(required = true)
+	protected float z;
+	@XmlAttribute
+	protected byte h;
+
+	@Override
+	public void doOperate(QuestEnv env) {
+		Player player = env.getPlayer();
+		TeleportService.teleportTo(player, worldId == 0 ? player.getWorldId() : worldId, x, y, z, h);
+	}
+}

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/template/XmlQuest.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/template/XmlQuest.java
@@ -8,64 +8,121 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.aionemu.gameserver.dataholders.DataManager;
+import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
+import com.aionemu.gameserver.questEngine.handlers.HandlerResult;
 import com.aionemu.gameserver.questEngine.handlers.models.Monster;
+import com.aionemu.gameserver.questEngine.handlers.models.XmlQuestData;
+import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnEnterWorldEvent;
+import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnEnterZoneEvent;
+import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnItemUseEvent;
 import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnKillEvent;
+import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnLevelUpEvent;
 import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnTalkEvent;
+import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnTimerEndEvent;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
 import com.aionemu.gameserver.questEngine.model.QuestState;
 import com.aionemu.gameserver.questEngine.model.QuestStatus;
+import com.aionemu.gameserver.world.zone.ZoneName;
 
 /**
  * @author Mr.Poke, Bobobear, Pad
  */
 public class XmlQuest extends AbstractTemplateQuestHandler {
 
+	private static final Logger log = LoggerFactory.getLogger(XmlQuest.class);
+
 	private final Set<Integer> startNpcIds = new HashSet<>();
 	private final Set<Integer> endNpcIds = new HashSet<>();
 	private final List<OnTalkEvent> onTalkEvents = new ArrayList<>();
 	private final List<OnKillEvent> onKillEvents = new ArrayList<>();
+	private final List<OnEnterZoneEvent> onEnterZoneEvents = new ArrayList<>();
+	private final List<OnItemUseEvent> onItemUseEvents = new ArrayList<>();
+	private final List<OnTimerEndEvent> onTimerEndEvents = new ArrayList<>();
+	private final List<OnEnterWorldEvent> onEnterWorldEvents = new ArrayList<>();
+	private final List<OnLevelUpEvent> onLevelUpEvents = new ArrayList<>();
 	private final boolean isDataDriven;
 
-	public XmlQuest(int questId, List<Integer> startNpcIds, List<Integer> endNpcIds, List<OnTalkEvent> onTalkEvents, List<OnKillEvent> onKillEvents) {
-		super(questId);
-		if (startNpcIds != null)
-			this.startNpcIds.addAll(startNpcIds);
-		if (endNpcIds != null)
-			this.endNpcIds.addAll(endNpcIds);
+	public XmlQuest(XmlQuestData data) {
+		super(data.getId());
+		if (data.getStartNpcIds() != null)
+			this.startNpcIds.addAll(data.getStartNpcIds());
+		if (data.getEndNpcIds() != null)
+			this.endNpcIds.addAll(data.getEndNpcIds());
 		else
 			this.endNpcIds.addAll(this.startNpcIds);
-		if (onTalkEvents != null)
-			this.onTalkEvents.addAll(onTalkEvents);
-		if (onKillEvents != null)
-			this.onKillEvents.addAll(onKillEvents);
+		if (data.getOnTalkEvents() != null)
+			this.onTalkEvents.addAll(data.getOnTalkEvents());
+		if (data.getOnKillEvents() != null)
+			this.onKillEvents.addAll(data.getOnKillEvents());
+		if (data.getOnEnterZoneEvents() != null)
+			this.onEnterZoneEvents.addAll(data.getOnEnterZoneEvents());
+		if (data.getOnItemUseEvents() != null)
+			this.onItemUseEvents.addAll(data.getOnItemUseEvents());
+		if (data.getOnTimerEndEvents() != null)
+			this.onTimerEndEvents.addAll(data.getOnTimerEndEvents());
+		if (data.getOnEnterWorldEvents() != null)
+			this.onEnterWorldEvents.addAll(data.getOnEnterWorldEvents());
+		if (data.getOnLevelUpEvents() != null)
+			this.onLevelUpEvents.addAll(data.getOnLevelUpEvents());
 		isDataDriven = DataManager.QUEST_DATA.getQuestById(questId).isDataDriven();
 	}
 
 	@Override
 	public void register() {
 		for (Integer startNpcId : startNpcIds) {
+			if (!npcExists(startNpcId, "start_npc_ids"))
+				continue;
 			qe.registerQuestNpc(startNpcId).addOnQuestStart(questId);
 			qe.registerQuestNpc(startNpcId).addOnTalkEvent(questId);
 		}
 		if (!endNpcIds.equals(startNpcIds)) {
 			for (Integer endNpcId : endNpcIds) {
-				qe.registerQuestNpc(endNpcId).addOnTalkEvent(questId);
+				if (npcExists(endNpcId, "end_npc_ids"))
+					qe.registerQuestNpc(endNpcId).addOnTalkEvent(questId);
 			}
 		}
 		for (OnTalkEvent onTalkEvent : onTalkEvents) {
 			for (Integer npcId : onTalkEvent.getIds()) {
-				qe.registerQuestNpc(npcId).addOnTalkEvent(questId);
+				if (npcExists(npcId, "on_talk_event"))
+					qe.registerQuestNpc(npcId).addOnTalkEvent(questId);
 			}
 		}
 		for (OnKillEvent onKillEvent : onKillEvents) {
 			for (Monster monster : onKillEvent.getMonsters()) {
 				for (Integer monsterId : monster.getNpcIds()) {
-					qe.registerQuestNpc(monsterId).addOnKillEvent(questId);
+					if (npcExists(monsterId, "on_kill_event"))
+						qe.registerQuestNpc(monsterId).addOnKillEvent(questId);
 				}
 			}
 		}
+		for (OnEnterZoneEvent onEnterZoneEvent : onEnterZoneEvents) {
+			for (String zone : onEnterZoneEvent.getZones()) {
+				ZoneName zoneName = ZoneName.get(zone);
+				if (zoneName != ZoneName.NONE) // unknown zone names are logged by ZoneName.get
+					qe.registerOnEnterZone(zoneName, questId);
+			}
+		}
+		for (OnItemUseEvent onItemUseEvent : onItemUseEvents) {
+			for (Integer itemId : onItemUseEvent.getItemIds()) {
+				if (DataManager.ITEM_DATA.getItemTemplate(itemId) == null)
+					log.warn("Quest {} references item {} in on_item_use_event, which doesn't exist", questId, itemId);
+				else
+					qe.registerQuestItem(itemId, questId);
+			}
+		}
+		if (!onTimerEndEvents.isEmpty()) {
+			qe.registerOnQuestTimerEnd(questId);
+			qe.registerOnInvisibleTimerEnd(questId);
+		}
+		if (!onEnterWorldEvents.isEmpty())
+			qe.registerOnEnterWorld(questId);
+		if (!onLevelUpEvents.isEmpty())
+			qe.registerOnLevelChanged(questId);
 	}
 
 	@Override
@@ -101,6 +158,67 @@ public class XmlQuest extends AbstractTemplateQuestHandler {
 		//env.setQuestId(questId);
 		for (OnKillEvent onKillEvent : onKillEvents) {
 			if (onKillEvent.operate(env))
+				return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean onEnterZoneEvent(QuestEnv env, ZoneName zoneName) {
+		for (OnEnterZoneEvent onEnterZoneEvent : onEnterZoneEvents) {
+			if (onEnterZoneEvent.operate(env, zoneName))
+				return true;
+		}
+		return false;
+	}
+
+	@Override
+	public HandlerResult onItemUseEvent(QuestEnv env, Item item) {
+		for (OnItemUseEvent onItemUseEvent : onItemUseEvents) {
+			if (onItemUseEvent.operate(env, item.getItemId()))
+				return HandlerResult.SUCCESS;
+		}
+		return HandlerResult.UNKNOWN;
+	}
+
+	@Override
+	public boolean onEnterWorldEvent(QuestEnv env) {
+		for (OnEnterWorldEvent onEnterWorldEvent : onEnterWorldEvents) {
+			if (onEnterWorldEvent.operate(env))
+				return true;
+		}
+		return false;
+	}
+
+	@Override
+	public void onLevelChangedEvent(Player player) {
+		QuestEnv env = new QuestEnv(null, player, questId);
+		for (OnLevelUpEvent onLevelUpEvent : onLevelUpEvents) {
+			if (onLevelUpEvent.operate(env))
+				return;
+		}
+	}
+
+	@Override
+	public boolean onQuestTimerEndEvent(QuestEnv env) {
+		return operateTimerEndEvents(env);
+	}
+
+	@Override
+	public boolean onInvisibleTimerEndEvent(QuestEnv env) {
+		return operateTimerEndEvents(env);
+	}
+
+	private boolean npcExists(int npcId, String declaredIn) {
+		if (DataManager.NPC_DATA.getNpcTemplate(npcId) != null)
+			return true;
+		log.warn("Quest {} references npc {} in {}, which doesn't exist", questId, npcId, declaredIn);
+		return false;
+	}
+
+	private boolean operateTimerEndEvents(QuestEnv env) {
+		for (OnTimerEndEvent onTimerEndEvent : onTimerEndEvents) {
+			if (onTimerEndEvent.operate(env))
 				return true;
 		}
 		return false;

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/template/XmlQuest.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/template/XmlQuest.java
@@ -1,6 +1,7 @@
 package com.aionemu.gameserver.questEngine.handlers.template;
 
 import static com.aionemu.gameserver.model.DialogAction.QUEST_SELECT;
+import static com.aionemu.gameserver.model.DialogAction.USE_OBJECT;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -87,6 +88,9 @@ public class XmlQuest extends AbstractTemplateQuestHandler {
 					return sendQuestStartDialog(env);
 			}
 		} else if (qs.getStatus() == QuestStatus.REWARD && endNpcIds.contains(targetId)) {
+			// data driven quests let the npc comment on the result before the reward window opens
+			if (isDataDriven && (env.getDialogActionId() == QUEST_SELECT || env.getDialogActionId() == USE_OBJECT))
+				return sendQuestDialog(env, 10002);
 			return sendQuestEndDialog(env);
 		}
 		return false;

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/template/XmlQuest.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/template/XmlQuest.java
@@ -182,6 +182,19 @@ public class XmlQuest extends AbstractTemplateQuestHandler {
 	}
 
 	@Override
+	public boolean isWaitingForInteractionWith(Player player, int npcId) {
+		QuestEnv env = new QuestEnv(null, player, questId);
+		for (OnTalkEvent onTalkEvent : onTalkEvents) {
+			if (onTalkEvent.isWaitingFor(env, npcId))
+				return true;
+		}
+		QuestState qs = player.getQuestStateList().getQuestState(questId);
+		if (qs == null || qs.isStartable())
+			return startNpcIds.contains(npcId);
+		return qs.getStatus() == QuestStatus.REWARD && endNpcIds.contains(npcId);
+	}
+
+	@Override
 	public boolean onEnterWorldEvent(QuestEnv env) {
 		for (OnEnterWorldEvent onEnterWorldEvent : onEnterWorldEvents) {
 			if (onEnterWorldEvent.operate(env))

--- a/game-server/src/com/aionemu/gameserver/questEngine/handlers/template/XmlQuest.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/handlers/template/XmlQuest.java
@@ -22,6 +22,7 @@ import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnEnte
 import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnItemUseEvent;
 import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnKillEvent;
 import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnLevelUpEvent;
+import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnMovieEndEvent;
 import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnTalkEvent;
 import com.aionemu.gameserver.questEngine.handlers.models.xmlQuest.events.OnTimerEndEvent;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
@@ -45,6 +46,7 @@ public class XmlQuest extends AbstractTemplateQuestHandler {
 	private final List<OnTimerEndEvent> onTimerEndEvents = new ArrayList<>();
 	private final List<OnEnterWorldEvent> onEnterWorldEvents = new ArrayList<>();
 	private final List<OnLevelUpEvent> onLevelUpEvents = new ArrayList<>();
+	private final List<OnMovieEndEvent> onMovieEndEvents = new ArrayList<>();
 	private final boolean isDataDriven;
 
 	public XmlQuest(XmlQuestData data) {
@@ -69,6 +71,8 @@ public class XmlQuest extends AbstractTemplateQuestHandler {
 			this.onEnterWorldEvents.addAll(data.getOnEnterWorldEvents());
 		if (data.getOnLevelUpEvents() != null)
 			this.onLevelUpEvents.addAll(data.getOnLevelUpEvents());
+		if (data.getOnMovieEndEvents() != null)
+			this.onMovieEndEvents.addAll(data.getOnMovieEndEvents());
 		isDataDriven = DataManager.QUEST_DATA.getQuestById(questId).isDataDriven();
 	}
 
@@ -208,6 +212,14 @@ public class XmlQuest extends AbstractTemplateQuestHandler {
 		QuestEnv env = new QuestEnv(null, player, questId);
 		for (OnLevelUpEvent onLevelUpEvent : onLevelUpEvents) {
 			if (onLevelUpEvent.operate(env))
+				return;
+		}
+	}
+
+	@Override
+	public void onMovieEndEvent(QuestEnv env, int movieId) {
+		for (OnMovieEndEvent onMovieEndEvent : onMovieEndEvents) {
+			if (onMovieEndEvent.operate(env, movieId))
 				return;
 		}
 	}

--- a/game-server/src/com/aionemu/gameserver/questEngine/model/QuestState.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/model/QuestState.java
@@ -11,6 +11,10 @@ import com.aionemu.gameserver.model.templates.QuestTemplate;
  */
 public class QuestState implements Persistable {
 
+	/** The flags hold a value in their low bits and the step group above it */
+	private static final int STEP_GROUP_SHIFT = 6;
+	private static final int FLAG_VALUE_MASK = (1 << STEP_GROUP_SHIFT) - 1;
+
 	private int questId;
 	private QuestVars questVars;
 	private int questFlags;
@@ -155,11 +159,16 @@ public class QuestState implements Persistable {
 
 	/**
 	 * Possibly it is the second set of quest vars, now are named as flags
-	 * 
+	 *
 	 * @return the questFlags
 	 */
 	public int getFlags() {
 		return questFlags;
+	}
+
+	/** @return The value stored in the flag bits, without the step group above them. */
+	public int getFlagValue() {
+		return questFlags & FLAG_VALUE_MASK;
 	}
 
 	/**
@@ -174,10 +183,10 @@ public class QuestState implements Persistable {
 	}
 
 	public int getStepGroup() {
-		return questFlags >> 6;
+		return questFlags >> STEP_GROUP_SHIFT;
 	}
 
 	public void setStepGroup(int groupNumber) {
-		setFlags(groupNumber << 6);
+		setFlags(groupNumber << STEP_GROUP_SHIFT);
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/questEngine/model/QuestVars.java
+++ b/game-server/src/com/aionemu/gameserver/questEngine/model/QuestVars.java
@@ -7,7 +7,13 @@ import org.slf4j.LoggerFactory;
  */
 public class QuestVars {
 
-	private int[] questVars = new int[6];
+	private static final int VAR_COUNT = 6;
+	private static final int VAR_BITS = 6;
+	private static final int VAR_MASK = (1 << VAR_BITS) - 1;
+	/** The six vars don't fit into the stored integer, so the last one only has the two bits left above the other five */
+	private static final int LAST_VAR_MASK = (1 << (Integer.SIZE - VAR_BITS * (VAR_COUNT - 1))) - 1;
+
+	private int[] questVars = new int[VAR_COUNT];
 
 	public QuestVars() {
 	}
@@ -29,9 +35,13 @@ public class QuestVars {
 	 * @param var
 	 */
 	public void setVarById(int id, int var) {
-		if (var > 0x3F)
+		if (var > getMaxValue(id))
 			LoggerFactory.getLogger(QuestVars.class).warn("Out of range value was passed for quest var on index " + id, new IllegalArgumentException());
 		questVars[id] = var;
+	}
+
+	private static int getMaxValue(int id) {
+		return id == VAR_COUNT - 1 ? LAST_VAR_MASK : VAR_MASK;
 	}
 
 	/**
@@ -39,8 +49,8 @@ public class QuestVars {
 	 */
 	public int getQuestVars() {
 		int var = 0;
-		for (int i = 5; i >= 0; i--) {
-			var <<= 0x06;
+		for (int i = VAR_COUNT - 1; i >= 0; i--) {
+			var <<= VAR_BITS;
 			var |= questVars[i];
 		}
 		return var;
@@ -48,14 +58,14 @@ public class QuestVars {
 
 	/**
 	 * Fill the array with values, based on
-	 * 
+	 *
 	 * @param int
 	 *          value, represented like above
 	 */
 	public void setVar(int var) {
-		for (int i = 0; i <= 5; i++) {
-			questVars[i] = var & 0x3F;
-			var >>= 0x06;
+		for (int i = 0; i < VAR_COUNT; i++) {
+			questVars[i] = var & VAR_MASK;
+			var >>>= VAR_BITS; // unsigned, the last var occupies the sign bit
 		}
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/services/DialogService.java
+++ b/game-server/src/com/aionemu/gameserver/services/DialogService.java
@@ -30,6 +30,8 @@ import com.aionemu.gameserver.model.templates.zone.ZoneTemplate;
 import com.aionemu.gameserver.network.aion.serverpackets.*;
 import com.aionemu.gameserver.questEngine.QuestEngine;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
+import com.aionemu.gameserver.questEngine.model.QuestState;
+import com.aionemu.gameserver.questEngine.model.QuestStatus;
 import com.aionemu.gameserver.services.abyss.AbyssRankingCache;
 import com.aionemu.gameserver.services.craft.CraftSkillUpdateService;
 import com.aionemu.gameserver.services.craft.RelinquishCraftStatus;
@@ -285,6 +287,15 @@ public class DialogService {
 			env.setExtendedRewardIndex(extendedRewardIndex);
 			if (QuestEngine.getInstance().onDialog(env))
 				return;
+			if (dialogActionId == QUEST_SELECT) {
+				QuestState qs = player.getQuestStateList().getQuestState(questId);
+				if (qs != null && qs.getStatus() == QuestStatus.START) {
+					// the client offers the quest here, so its data and our declaration disagree about who owns it
+					log.warn("Quest {} is offered at npc {} but no handler claims it there", questId, npc.getNpcId());
+					PacketSendUtility.sendPacket(player, new SM_DIALOG_WINDOW(npc.getObjectId(), 11, questId)); // recap what's left to do
+					return;
+				}
+			}
 		}
 		// action id = next page id
 		PacketSendUtility.sendPacket(player, new SM_DIALOG_WINDOW(npc.getObjectId(), dialogActionId, questId));

--- a/game-server/src/com/aionemu/gameserver/services/QuestService.java
+++ b/game-server/src/com/aionemu/gameserver/services/QuestService.java
@@ -71,6 +71,9 @@ public final class QuestService {
 
 	private static final Logger log = LoggerFactory.getLogger(QuestService.class);
 
+	/** Maximum number of quests a player can work on at the same time, no matter their category */
+	private static final int MAX_WORKING_QUESTS = 266;
+
 	private static Map<Integer, List<QuestDrop>> questDrop = new HashMap<>();
 
 	private static boolean deny(Consumer<String> denialReason, String reason) {
@@ -444,7 +447,7 @@ public final class QuestService {
 		if (!checkStartConditions(player, id, warn))
 			return false;
 
-		if (!template.isNoCount() && !checkQuestListSize(qsl) && !player.hasPermission(MembershipConfig.QUEST_LIMIT_DISABLED)) {
+		if (!checkQuestListSize(qsl, template) && !player.hasPermission(MembershipConfig.QUEST_LIMIT_DISABLED)) {
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_MAX_NORMAL());
 			return false;
 		}
@@ -573,12 +576,18 @@ public final class QuestService {
 	}
 
 	/*
-	 * Check the player's quest list size for starting a new one
+	 * Check the player's quest list size for starting a new one. Retail has two limits, both rejecting with the same message: the total number of
+	 * quests a player can work on, and the number of quests of the categories which count towards the basic limit.
 	 * @param quest state list
+	 * @param template of the quest to start
 	 */
-	private static boolean checkQuestListSize(QuestStateList qsl) {
+	private static boolean checkQuestListSize(QuestStateList qsl, QuestTemplate template) {
 		// The player's quest list size + the new one to start
-		return (qsl.getNormalQuests().size() + 1) <= CustomConfig.BASIC_QUEST_SIZE_LIMIT;
+		if (qsl.getUncompletedQuests().size() + 1 > MAX_WORKING_QUESTS)
+			return false;
+		if (!template.getCategory().countsTowardsQuestLimit())
+			return true;
+		return (qsl.getQuestsCountingTowardsLimit().size() + 1) <= CustomConfig.BASIC_QUEST_SIZE_LIMIT;
 	}
 
 	public static boolean collectItemCheck(QuestEnv env, boolean removeItem) {

--- a/game-server/src/com/aionemu/gameserver/services/QuestService.java
+++ b/game-server/src/com/aionemu/gameserver/services/QuestService.java
@@ -843,10 +843,12 @@ public final class QuestService {
 
 			@Override
 			public void run() {
+				player.getController().setQuestTimerQuestId(0);
 				QuestEngine.getInstance().onQuestTimerEnd(new QuestEnv(null, player, 0));
 			}
 		}, timeInSeconds * 1000);
 		player.getController().addTask(TaskId.QUEST_TIMER, task);
+		player.getController().setQuestTimerQuestId(env.getQuestId());
 		PacketSendUtility.sendPacket(player, new SM_QUEST_ACTION(env.getQuestId(), timeInSeconds));
 		return true;
 	}
@@ -855,19 +857,28 @@ public final class QuestService {
 		final Player player = env.getPlayer();
 
 		// Schedule Action When Timer Finishes
-		ThreadPoolManager.getInstance().schedule(new Runnable() {
+		Future<?> task = ThreadPoolManager.getInstance().schedule(new Runnable() {
 
 			@Override
 			public void run() {
+				player.getController().setQuestTimerQuestId(0);
 				QuestEngine.getInstance().onInvisibleTimerEnd(new QuestEnv(null, player, 0));
 			}
 		}, timeInSeconds * 1000);
+		player.getController().addTask(TaskId.QUEST_TIMER, task); // so it's cancelled when the player leaves the world
+		player.getController().setQuestTimerQuestId(env.getQuestId());
 		return true;
 	}
 
+	/**
+	 * Ends the running quest timer, if it belongs to the quest of the given env.
+	 */
 	public static boolean questTimerEnd(QuestEnv env) {
 		final Player player = env.getPlayer();
 
+		if (player.getController().getQuestTimerQuestId() != env.getQuestId())
+			return false; // the timer belongs to another quest
+		player.getController().setQuestTimerQuestId(0);
 		player.getController().cancelTask(TaskId.QUEST_TIMER);
 		PacketSendUtility.sendPacket(player, new SM_QUEST_ACTION(env.getQuestId(), 0));
 		return true;

--- a/game-server/src/com/aionemu/gameserver/services/QuestService.java
+++ b/game-server/src/com/aionemu/gameserver/services/QuestService.java
@@ -8,6 +8,7 @@ import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.concurrent.Future;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -69,7 +70,14 @@ import com.aionemu.gameserver.utils.time.ServerTime;
 public final class QuestService {
 
 	private static final Logger log = LoggerFactory.getLogger(QuestService.class);
+
 	private static Map<Integer, List<QuestDrop>> questDrop = new HashMap<>();
+
+	private static boolean deny(Consumer<String> denialReason, String reason) {
+		if (denialReason != null)
+			denialReason.accept(reason);
+		return false;
+	}
 
 	/**
 	 * Finishes the quest and rewards the player.
@@ -301,13 +309,23 @@ public final class QuestService {
 	 */
 	public static boolean checkStartConditions(Player player, int questId, boolean warn, int allowedDiffToMinLevel, boolean skipStartedCheck,
 		boolean skipRepeatCountCheck, boolean skipXmlPreconditionCheck) {
+		return checkStartConditions(player, questId, warn, allowedDiffToMinLevel, skipStartedCheck, skipRepeatCountCheck, skipXmlPreconditionCheck, null);
+	}
+
+	/**
+	 * @param denialReason
+	 *          - Receives the condition which rejected the quest, for diagnostics. May be null.
+	 * @see #checkStartConditions(Player, int, boolean, int, boolean, boolean, boolean)
+	 */
+	public static boolean checkStartConditions(Player player, int questId, boolean warn, int allowedDiffToMinLevel, boolean skipStartedCheck,
+		boolean skipRepeatCountCheck, boolean skipXmlPreconditionCheck, Consumer<String> denialReason) {
 		try {
 			QuestState qs = player.getQuestStateList().getQuestState(questId);
 			if (qs != null) {
 				if (!skipStartedCheck && (qs.getStatus() == QuestStatus.START || qs.getStatus() == QuestStatus.REWARD)) {
 					if (warn)
 						PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_WORKING_QUEST());
-					return false;
+					return deny(denialReason, "quest already active (status " + qs.getStatus() + ")");
 				} else if (!skipRepeatCountCheck && qs.getStatus() == QuestStatus.COMPLETE && !qs.canRepeat()) {
 					QuestTemplate template = DataManager.QUEST_DATA.getQuestById(questId);
 					if (template.getMaxRepeatCount() > 1 && template.getMaxRepeatCount() != 255 && qs.getCompleteCount() >= template.getMaxRepeatCount()) {
@@ -318,7 +336,8 @@ public final class QuestService {
 						if (warn)
 							PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_NONE_REPEATABLE(ChatUtil.quest(questId)));
 					}
-					return false;
+					return deny(denialReason, "cannot repeat (completeCount " + qs.getCompleteCount() + " of maxRepeatCount " + template.getMaxRepeatCount()
+						+ ", nextRepeatTime " + qs.getNextRepeatTime() + ")");
 				}
 			}
 
@@ -326,7 +345,7 @@ public final class QuestService {
 			if (template.getRacePermitted() != null && template.getRacePermitted() != Race.PC_ALL && template.getRacePermitted() != player.getRace()) {
 				if (warn)
 					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_RACE());
-				return false;
+				return deny(denialReason, "race (quest wants " + template.getRacePermitted() + ")");
 			}
 
 			// min level - 2 so that the gray quest arrow shows when quest is almost available
@@ -334,32 +353,32 @@ public final class QuestService {
 			if (levelDiff > 0) {
 				if (warn)
 					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_MIN_LEVEL(template.getMinlevelPermitted()));
-				return false;
+				return deny(denialReason, "minlevel_permitted " + template.getMinlevelPermitted());
 			}
 
 			if (template.getMaxlevelPermitted() != 0 && player.getLevel() > template.getMaxlevelPermitted()) {
 				if (warn)
 					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_MAX_LEVEL(template.getMaxlevelPermitted()));
-				return false;
+				return deny(denialReason, "maxlevel_permitted " + template.getMaxlevelPermitted());
 			}
 
 			if (!template.getClassPermitted().isEmpty() && !template.getClassPermitted().contains(player.getPlayerClass())) {
 				if (warn)
 					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_CLASS());
-				return false;
+				return deny(denialReason, "class_permitted " + template.getClassPermitted());
 			}
 
 			if (template.getGenderPermitted() != null && template.getGenderPermitted() != player.getGender()) {
 				if (warn)
 					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_GENDER());
-				return false;
+				return deny(denialReason, "gender_permitted " + template.getGenderPermitted());
 			}
 
 			if (template.getRequiredRank() != 0 && player.getAbyssRank().getRank().getId() < template.getRequiredRank()) {
 				if (warn)
 					PacketSendUtility.sendPacket(player,
 						SM_SYSTEM_MESSAGE.STR_QUEST_ACQUIRE_ERROR_MIN_RANK(AbyssRankEnum.getRankL10n(player.getRace(), template.getRequiredRank())));
-				return false;
+				return deny(denialReason, "required_rank " + template.getRequiredRank());
 			}
 
 			if (!skipXmlPreconditionCheck) {
@@ -368,26 +387,34 @@ public final class QuestService {
 					if (startCondition.check(player, warn))
 						fulfilledStartConditions++;
 				}
-				if (fulfilledStartConditions < template.getRequiredConditionCount())
-					return false;
+				if (fulfilledStartConditions < template.getRequiredConditionCount()) {
+					StringBuilder sb = new StringBuilder("start_conditions (" + fulfilledStartConditions + " of " + template.getRequiredConditionCount()
+						+ " fulfilled)");
+					if (denialReason != null)
+						for (XMLStartCondition startCondition : template.getXMLStartConditions())
+							if (!startCondition.check(player, false))
+								sb.append(": ").append(startCondition.getFailureDescription(player));
+					return deny(denialReason, sb.toString());
+				}
 			}
 
 			QuestEnv env = new QuestEnv(null, player, questId);
 			if (!inventoryItemCheck(env, warn))
-				return false;
+				return deny(denialReason, "inventory_item missing");
 
 			if (!checkCombineSkill(env, warn))
-				return false;
+				return deny(denialReason, "combineskill " + template.getCombineSkill() + " needs level " + template.getCombineSkillPoint()
+					+ (template.getCategory() == QuestCategory.TASK ? "-" + (template.getCombineSkillPoint() + 40) : "+"));
 
 			// check if NpcFaction daily quest
 			if (template.getNpcFactionId() != 0) {
 				// check if the NpcFaction daily time limit has passed
 				if (!template.isTimeBased() && !player.getNpcFactions().canStartQuest(template))
-					return false;
+					return deny(denialReason, "npc_faction " + template.getNpcFactionId() + " daily time limit not passed");
 
 				NpcFaction faction = player.getNpcFactions().getFactionById(template.getNpcFactionId());
 				if (faction == null || !faction.isActive())
-					return false;
+					return deny(denialReason, "npc_faction " + template.getNpcFactionId() + (faction == null ? " not joined" : " not active"));
 			}
 
 			return true;

--- a/game-server/src/com/aionemu/gameserver/services/QuestService.java
+++ b/game-server/src/com/aionemu/gameserver/services/QuestService.java
@@ -387,16 +387,23 @@ public final class QuestService {
 			if (!skipXmlPreconditionCheck) {
 				int fulfilledStartConditions = 0;
 				for (XMLStartCondition startCondition : template.getXMLStartConditions()) {
-					if (startCondition.check(player, warn))
+					if (startCondition.check(player))
 						fulfilledStartConditions++;
 				}
 				if (fulfilledStartConditions < template.getRequiredConditionCount()) {
 					StringBuilder sb = new StringBuilder("start_conditions (" + fulfilledStartConditions + " of " + template.getRequiredConditionCount()
 						+ " fulfilled)");
-					if (denialReason != null)
-						for (XMLStartCondition startCondition : template.getXMLStartConditions())
-							if (!startCondition.check(player, false))
-								sb.append(": ").append(startCondition.getFailureDescription(player));
+					boolean warned = false;
+					for (XMLStartCondition startCondition : template.getXMLStartConditions()) {
+						if (startCondition.check(player))
+							continue;
+						if (warn && !warned) {
+							startCondition.sendFailureMessage(player);
+							warned = true;
+						}
+						if (denialReason != null)
+							sb.append(": ").append(startCondition.getFailureDescription(player));
+					}
 					return deny(denialReason, sb.toString());
 				}
 			}

--- a/game-server/src/com/aionemu/gameserver/services/QuestService.java
+++ b/game-server/src/com/aionemu/gameserver/services/QuestService.java
@@ -583,7 +583,7 @@ public final class QuestService {
 	}
 
 	/*
-	 * Check the player's quest list size for starting a new one. Retail has two limits, both rejecting with the same message: the total number of
+	 * Check the player's quest list size for starting a new one. There are two limits, both rejecting with the same message: the total number of
 	 * quests a player can work on, and the number of quests of the categories which count towards the basic limit.
 	 * @param quest state list
 	 * @param template of the quest to start
@@ -851,36 +851,39 @@ public final class QuestService {
 		return template == null ? 99 : template.getMinlevelPermitted() - playerLevel;
 	}
 
+	/**
+	 * Starts a timer which shows the player how much time is left.
+	 */
 	public static boolean questTimerStart(QuestEnv env, int timeInSeconds) {
-		final Player player = env.getPlayer();
-
-		// Schedule Action When Timer Finishes
-		Future<?> task = ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				player.getController().setQuestTimerQuestId(0);
-				QuestEngine.getInstance().onQuestTimerEnd(new QuestEnv(null, player, 0));
-			}
-		}, timeInSeconds * 1000);
-		player.getController().addTask(TaskId.QUEST_TIMER, task);
-		player.getController().setQuestTimerQuestId(env.getQuestId());
+		Player player = env.getPlayer();
+		if (!startTimer(env, timeInSeconds, () -> QuestEngine.getInstance().onQuestTimerEnd(new QuestEnv(null, player, 0))))
+			return false;
 		PacketSendUtility.sendPacket(player, new SM_QUEST_ACTION(env.getQuestId(), timeInSeconds));
 		return true;
 	}
 
+	/**
+	 * Starts a timer the player doesn't see.
+	 */
 	public static boolean invisibleTimerStart(QuestEnv env, int timeInSeconds) {
-		final Player player = env.getPlayer();
+		Player player = env.getPlayer();
+		return startTimer(env, timeInSeconds, () -> QuestEngine.getInstance().onInvisibleTimerEnd(new QuestEnv(null, player, 0)));
+	}
 
-		// Schedule Action When Timer Finishes
-		Future<?> task = ThreadPoolManager.getInstance().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				player.getController().setQuestTimerQuestId(0);
-				QuestEngine.getInstance().onInvisibleTimerEnd(new QuestEnv(null, player, 0));
-			}
-		}, timeInSeconds * 1000);
+	/**
+	 * A player has one timer slot, so a quest can only start a timer as long as no other quest occupies it. The player is told when it's taken.
+	 */
+	private static boolean startTimer(QuestEnv env, int timeInSeconds, Runnable timerEndAction) {
+		Player player = env.getPlayer();
+		int runningTimerQuestId = player.getController().getQuestTimerQuestId();
+		if (runningTimerQuestId != 0 && runningTimerQuestId != env.getQuestId()) {
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_QUEST_ANOTHER_SINGLE_STEP_NOT_COMPLETED());
+			return false;
+		}
+		Future<?> task = ThreadPoolManager.getInstance().schedule(() -> {
+			player.getController().setQuestTimerQuestId(0);
+			timerEndAction.run();
+		}, timeInSeconds * 1000L);
 		player.getController().addTask(TaskId.QUEST_TIMER, task); // so it's cancelled when the player leaves the world
 		player.getController().setQuestTimerQuestId(env.getQuestId());
 		return true;

--- a/game-server/src/com/aionemu/gameserver/services/QuestService.java
+++ b/game-server/src/com/aionemu/gameserver/services/QuestService.java
@@ -852,28 +852,10 @@ public final class QuestService {
 	}
 
 	/**
-	 * Starts a timer which shows the player how much time is left.
+	 * Starts a timer which shows the player how much time is left. There is one such slot per player, so it fails while another quest occupies it,
+	 * and the player is told to finish that quest first.
 	 */
 	public static boolean questTimerStart(QuestEnv env, int timeInSeconds) {
-		Player player = env.getPlayer();
-		if (!startTimer(env, timeInSeconds, () -> QuestEngine.getInstance().onQuestTimerEnd(new QuestEnv(null, player, 0))))
-			return false;
-		PacketSendUtility.sendPacket(player, new SM_QUEST_ACTION(env.getQuestId(), timeInSeconds));
-		return true;
-	}
-
-	/**
-	 * Starts a timer the player doesn't see.
-	 */
-	public static boolean invisibleTimerStart(QuestEnv env, int timeInSeconds) {
-		Player player = env.getPlayer();
-		return startTimer(env, timeInSeconds, () -> QuestEngine.getInstance().onInvisibleTimerEnd(new QuestEnv(null, player, 0)));
-	}
-
-	/**
-	 * A player has one timer slot, so a quest can only start a timer as long as no other quest occupies it. The player is told when it's taken.
-	 */
-	private static boolean startTimer(QuestEnv env, int timeInSeconds, Runnable timerEndAction) {
 		Player player = env.getPlayer();
 		int runningTimerQuestId = player.getController().getQuestTimerQuestId();
 		if (runningTimerQuestId != 0 && runningTimerQuestId != env.getQuestId()) {
@@ -882,10 +864,26 @@ public final class QuestService {
 		}
 		Future<?> task = ThreadPoolManager.getInstance().schedule(() -> {
 			player.getController().setQuestTimerQuestId(0);
-			timerEndAction.run();
+			QuestEngine.getInstance().onQuestTimerEnd(new QuestEnv(null, player, 0));
 		}, timeInSeconds * 1000L);
 		player.getController().addTask(TaskId.QUEST_TIMER, task); // so it's cancelled when the player leaves the world
 		player.getController().setQuestTimerQuestId(env.getQuestId());
+		PacketSendUtility.sendPacket(player, new SM_QUEST_ACTION(env.getQuestId(), timeInSeconds));
+		return true;
+	}
+
+	/**
+	 * Starts a timer the player doesn't see. Those belong to their quest instead of to the player, so they neither occupy the visible timer slot
+	 * nor cancel each other.
+	 */
+	public static boolean invisibleTimerStart(QuestEnv env, int timeInSeconds) {
+		Player player = env.getPlayer();
+		int questId = env.getQuestId();
+		Future<?> task = ThreadPoolManager.getInstance().schedule(() -> {
+			player.getController().cancelInvisibleQuestTimer(questId);
+			QuestEngine.getInstance().onInvisibleTimerEnd(new QuestEnv(null, player, questId));
+		}, timeInSeconds * 1000L);
+		player.getController().addInvisibleQuestTimer(questId, task);
 		return true;
 	}
 
@@ -935,6 +933,7 @@ public final class QuestService {
 
 		if (player.getController().hasTask(TaskId.QUEST_TIMER))
 			questTimerEnd(new QuestEnv(null, player, questId));
+		player.getController().cancelInvisibleQuestTimer(questId);
 
 		PacketSendUtility.sendPacket(player, new SM_QUEST_ACTION(ActionType.ABANDON, qs));
 		player.getController().updateNearbyQuests();


### PR DESCRIPTION
### Bugs

1) **`on_kill_event` ignored its own `<conditions>`.** The condition set was parsed and then never evaluated, so a kill counter kept counting after the step was finished.

2) **Quest markers were not refreshed when an `xml_quest` became rewardable.** `updateNearbyQuests()` only ran on `COMPLETE`, so the "star" above the npc appeared only after the player left and re-entered the npc's visibility range.

3) **The dialog window stayed open after handing a quest in** whenever the npc still had other quests to offer. On retail the window closes and only an ongoing quest that continues at the same npc keeps it open.

4) **Selecting an ongoing quest at an npc that no template handles produced `load fail`.** With no handler consuming the dialog action, `DialogService` echoed the action id back as a page id, for example 31, which is `HTML_PAGE_PACKAGE_LIMITATION` and is absent from quest html files. It now sends page 11, `HTML_PAGE_SELECT_PROGRESSIVE_QUEST_DESC`, which every quest file contains. This can only happen when a declaration disagrees with the client about which npc owns the quest, so it is logged as well.

5) **Data driven quests skipped the npc's comment on the result.** They now show page 10002 before the reward window, matching retail.

6) **A quest timer could be cancelled by a foreign quest.**

7) **Spent quest objects still reacted after use.**

### New features

1) **`<on_enter_zone_event zones="...">`** and **`<on_item_use_event item_ids="...">`** are two event types `xml_quest` was missing. The engine already dispatches both and 169 java handlers override them, so this is schema, binding and dispatch only.

2) **`<spawn_npc>`** spawns an npc relative to the player or at absolute coordinates, with optional count, lifetime and aggro.

3) **`<on_timer_end_event>`** with the **`<add_timer seconds="..." visible="...">`** operation, retail's extra action 10. The engine had both visible and invisible quest timers, only the binding was missing.

4) **`<on_enter_world_event world_ids="...">`** and **`<on_level_up_event level="...">`**, retail's EnterWorld and LevelUp progress categories.

5) **`<teleport>`** and **`<play_cutscene>`**  , **`<on_level_up_event level="...">`**, not used now. 

6) **`<quest_timer running="...">`** condition, so a step can notice that its timer is gone after a relog.

7) **`<questuse>` action.** (needs because of casting delay on item)

### Tooling

**Both quest commands now say why a quest could not be started.** `//quest <id> ...` and the GM console's `addquest` used to enumerate `finished` preconditions only and print "Some preconditions failed" for everything else, so rejections by level, race, class, gender, abyss rank, repeat count, inventory item, craft skill and npc faction were all silent. 

`addquest` additionally read the preconditions from the admin's own quest list rather than the target's, so it reported nonsense whenever it was used on another character.

### Quests included as consumers of the new features

| quest | uses |
| --- | --- |
| 15000 Not Any Fool's Tool | `on_item_use_event` |
| 25082 Tyrant Take Out |`spawn_npc`, `add_timer`, `on_timer_end_event`, `on_enter_world_event`, `quest_timer` |
| 25084 Is This a Trap? | `on_enter_zone_event`, `spawn_npc` |