### PR TITLE
Fixed the quest npcs of 29 quests

### DIFF
--- a/game-server/data/static_data/quest_script_data/beluslan.xml
+++ b/game-server/data/static_data/quest_script_data/beluslan.xml
@@ -512,7 +512,7 @@
 	<monster_hunt id="4525" start_npc_ids="832820"/>
 	<monster_hunt id="4526" start_npc_ids="204789"/>
 	<monster_hunt id="4527" start_npc_ids="204702"/>
-	<monster_hunt id="4528" start_npc_ids="212211"/>
+	<monster_hunt id="4528" start_npc_ids="204781"/>
 	<monster_hunt id="4529" start_npc_ids="798117" end_npc_ids="798118"/>
 	<monster_hunt id="4531" start_npc_ids="798118"/>
 	<monster_hunt id="4532" start_npc_ids="204805"/>

--- a/game-server/data/static_data/quest_script_data/brusthonin.xml
+++ b/game-server/data/static_data/quest_script_data/brusthonin.xml
@@ -214,7 +214,7 @@
 	<monster_hunt id="4107" start_npc_ids="205156"/>
 	<monster_hunt id="4108" start_npc_ids="205151"/>
 	<monster_hunt id="4111" start_npc_ids="730103"/>
-	<monster_hunt id="4112" start_npc_ids="205163"/>
+	<monster_hunt id="4112" start_npc_ids="205225"/>
 	<monster_hunt id="4120" start_npc_ids="205150" end_npc_ids="205225"/>
 	<monster_hunt id="39001" start_npc_ids="800500"/>
 	<monster_hunt id="39002" start_npc_ids="800500"/>

--- a/game-server/data/static_data/quest_script_data/danuar_reliquary.xml
+++ b/game-server/data/static_data/quest_script_data/danuar_reliquary.xml
@@ -10,6 +10,6 @@
 	-->
 	
 	<!-- COLLECTING QUESTS -->
-	<item_collecting id="16921" start_npc_ids="801543"/>
-	<item_collecting id="26921" start_npc_ids="801547"/>
+	<item_collecting id="16921" start_npc_ids="802431"/>
+	<item_collecting id="26921" start_npc_ids="802433"/>
 </quest_scripts>

--- a/game-server/data/static_data/quest_script_data/eltnen.xml
+++ b/game-server/data/static_data/quest_script_data/eltnen.xml
@@ -324,7 +324,7 @@
 	<item_collecting id="1402" start_npc_ids="203942"/>
 	<item_collecting id="1403" start_npc_ids="203942"/>
 	<item_collecting id="1405" start_npc_ids="203995"/>
-	<item_collecting id="1408" start_npc_ids="285972"/>
+	<item_collecting id="1408" start_npc_ids="203991"/>
 	<item_collecting id="1411" start_npc_ids="203989"/>
 	<item_collecting id="1415" start_npc_ids="203989"/>
 	<item_collecting id="1419" start_npc_ids="203931"/>

--- a/game-server/data/static_data/quest_script_data/heiron.xml
+++ b/game-server/data/static_data/quest_script_data/heiron.xml
@@ -512,10 +512,10 @@
 	<monster_hunt id="3538" start_npc_ids="204551"/>
 	<monster_hunt id="3541" start_npc_ids="204600"/>
 	<monster_hunt id="3543" start_npc_ids="204552"/>
-	<monster_hunt id="16902" start_npc_ids="258230" end_npc_ids="204612" end_dialog_id="2375"/>
-	<monster_hunt id="16903" start_npc_ids="258230" end_npc_ids="204656" end_dialog_id="2375"/>
-	<monster_hunt id="16907" start_npc_ids="258230" end_npc_ids="204500"/>
-	<monster_hunt id="16908" start_npc_ids="258230" end_npc_ids="204500"/>
+	<monster_hunt id="16902" start_npc_ids="204500" end_npc_ids="204612" end_dialog_id="2375"/>
+	<monster_hunt id="16903" start_npc_ids="204500" end_npc_ids="204656" end_dialog_id="2375"/>
+	<monster_hunt id="16907" start_npc_ids="204500"/>
+	<monster_hunt id="16908" start_npc_ids="204500"/>
 	<monster_hunt id="18605" start_npc_ids="205230"/>
 	<monster_hunt id="18606" start_npc_ids="205231"/>
 	<monster_hunt id="18617" start_npc_ids="205230"/>

--- a/game-server/data/static_data/quest_script_data/inggison.xml
+++ b/game-server/data/static_data/quest_script_data/inggison.xml
@@ -300,7 +300,7 @@
 	<item_collecting id="11015" start_npc_ids="798910"/>
 	<item_collecting id="11016" start_npc_ids="798910"/>
 	<item_collecting id="11022" start_npc_ids="798914"/>
-	<item_collecting id="11024" start_npc_ids="799049"/>
+	<item_collecting id="11024" start_npc_ids="798950"/>
 	<item_collecting id="11025" start_npc_ids="798950"/>
 	<item_collecting id="11028" start_npc_ids="798951"/>
 	<item_collecting id="11037" start_npc_ids="798956"/>
@@ -371,7 +371,7 @@
 	<item_collecting id="11454" start_npc_ids="799070"/>
 	<item_collecting id="11457" start_npc_ids="798953"/>
 	<item_collecting id="11461" start_npc_ids="798955"/>
-	<item_collecting id="11303" start_npc_ids="799038"/>
+	<item_collecting id="11303" start_npc_ids="799038" end_npc_ids="798316"/>
 	<item_collecting id="21233" start_npc_ids="799354"/>
 	<item_collecting id="21234" start_npc_ids="799354"/>
 	<item_collecting id="21235" start_npc_ids="799360"/>

--- a/game-server/data/static_data/quest_script_data/kaldor.xml
+++ b/game-server/data/static_data/quest_script_data/kaldor.xml
@@ -52,7 +52,7 @@
 	-->
 	
 	<!-- REPORTING QUESTS -->
-	<report_to_many id="13800" start_npc_ids="800527">
+	<report_to_many id="13800" start_npc_ids="804699">
 		<npc_infos npc_ids="800958"/>
 		<npc_infos npc_ids="801163"/>
 	</report_to_many> 
@@ -66,7 +66,7 @@
 		<npc_infos npc_ids="804595"/>
 		<npc_infos npc_ids="804586"/>
 	</report_to_many>
-	<report_to_many id="23800" start_npc_ids="800529">
+	<report_to_many id="23800" start_npc_ids="804719">
 		<npc_infos npc_ids="800980"/>
 		<npc_infos npc_ids="802433"/>
 	</report_to_many> 

--- a/game-server/data/static_data/quest_script_data/levinshor.xml
+++ b/game-server/data/static_data/quest_script_data/levinshor.xml
@@ -121,10 +121,10 @@
 	<item_collecting id="23743" start_npc_ids="802353"/>
 	
 	<!-- REPORTING QUESTS -->
-	<report_to id="13700" start_npc_ids="800527" end_npc_ids="802350"/>
+	<report_to id="13700" start_npc_ids="804699" end_npc_ids="802350"/>
 	<report_to id="13701" start_npc_ids="798926" end_npc_ids="802350"/>
-	<report_to id="23700" start_npc_ids="800529" end_npc_ids="802353"/>
-	<report_to id="23701" start_npc_ids="800529" end_npc_ids="802353"/>
+	<report_to id="23700" start_npc_ids="804719" end_npc_ids="802353"/>
+	<report_to id="23701" start_npc_ids="799225" end_npc_ids="802353"/>
 	
 	<!-- HUNTING QUESTS -->
 	<monster_hunt id="13702" start_npc_ids="802350" end_npc_ids="802352" end_dialog_id="2375"/>

--- a/game-server/data/static_data/quest_script_data/morheim.xml
+++ b/game-server/data/static_data/quest_script_data/morheim.xml
@@ -260,7 +260,7 @@
 	<report_to id="2330" start_npc_ids="204300" end_npc_ids="205128"/>
 	<report_to id="2361" start_npc_ids="204372" end_npc_ids="204363"/>
 	<report_to id="2364" start_npc_ids="204363" end_npc_ids="204342"/>
-	<report_to id="2383" start_npc_ids="204354" end_npc_ids="790011"/>
+	<report_to id="2383" start_npc_ids="204354" end_npc_ids="798080"/>
 	<report_to id="2395" start_npc_ids="204345" end_npc_ids="204369"/>
 	<report_to id="2414" start_npc_ids="204369" end_npc_ids="204361"/>
 	<report_to id="2417" start_npc_ids="204364" end_npc_ids="204390"/>
@@ -296,7 +296,7 @@
 	<item_collecting id="2359" start_npc_ids="204339"/>
 	<item_collecting id="2362" start_npc_ids="204363"/>
 	<item_collecting id="2369" start_npc_ids="798083"/>
-	<item_collecting id="2371" start_npc_ids="798089"/>
+	<item_collecting id="2371" start_npc_ids="798079"/>
 	<item_collecting id="2372" start_npc_ids="798056" end_npc_ids="798079"/>
 	<item_collecting id="2373" start_npc_ids="804606"/>
 	<item_collecting id="2378" start_npc_ids="204408"/>
@@ -335,14 +335,14 @@
 	<item_collecting id="2461" start_npc_ids="204424"/>
 	<item_collecting id="2462" start_npc_ids="204330"/>
 	<item_collecting id="2463" start_npc_ids="204387"/>
-	<item_collecting id="2464" start_npc_ids="204110" end_npc_ids="204387"/>
+	<item_collecting id="2464" start_npc_ids="204387"/>
 	<item_collecting id="2465" start_npc_ids="204393"/>
 	<item_collecting id="2466" start_npc_ids="204382"/>
 	<item_collecting id="2467" start_npc_ids="204382"/>
 	<item_collecting id="2468" start_npc_ids="204341"/>
 	<item_collecting id="2469" start_npc_ids="204341"/>
 	<item_collecting id="2470" start_npc_ids="204348"/>
-	<item_collecting id="2471" start_npc_ids="204110" end_npc_ids="204387"/>
+	<item_collecting id="2471" start_npc_ids="204387"/>
 	<item_collecting id="2472" start_npc_ids="204356"/>
 	<item_collecting id="2473" start_npc_ids="204356"/>
 	<item_collecting id="2474" start_npc_ids="204390" end_npc_ids="204364"/>
@@ -445,7 +445,7 @@
 	<monster_hunt id="4323" start_npc_ids="204352"/>
 	<monster_hunt id="4324" start_npc_ids="204349"/>
 	<monster_hunt id="4325" start_npc_ids="204363"/>
-	<monster_hunt id="4326" start_npc_ids="204359"/>
+	<monster_hunt id="4326" start_npc_ids="804606"/>
 	<monster_hunt id="4335" start_npc_ids="204369"/>
 	<monster_hunt id="26900" start_npc_ids="204301"/>
 	<monster_hunt id="26901" start_npc_ids="204301"/>

--- a/game-server/data/static_data/quest_script_data/pandaemonium.xml
+++ b/game-server/data/static_data/quest_script_data/pandaemonium.xml
@@ -324,7 +324,7 @@
 	<report_to id="4917" start_npc_ids="203385" end_npc_ids="798358"/>
 	<report_to id="4921" start_npc_ids="798358" end_npc_ids="279022"/>
 	<report_to id="4964" start_npc_ids="204286" end_npc_ids="204051"/>
-	<report_to id="4965" start_npc_ids="204182" end_npc_ids="204207"/>
+	<report_to id="4965" start_npc_ids="204837" end_npc_ids="204715"/>
 	<report_to id="29040" start_npc_ids="798385" end_npc_ids="798443"/>
 	<report_to id="29041" start_npc_ids="204051" end_npc_ids="204286"/>
 	<report_to id="29044" start_npc_ids="798443" end_npc_ids="798441"/>
@@ -427,8 +427,8 @@
 	<item_collecting id="4910" start_npc_ids="798317"/>
 	<item_collecting id="4911" start_npc_ids="798317"/>
 	<item_collecting id="4912" start_npc_ids="798317"/>
-	<item_collecting id="4915" start_npc_ids="203385"/>
-	<item_collecting id="4916" start_npc_ids="203385"/>
+	<item_collecting id="4915" start_npc_ids="204837"/>
+	<item_collecting id="4916" start_npc_ids="204837"/>
 	<item_collecting id="4918" start_npc_ids="798358"/>
 	<item_collecting id="4919" start_npc_ids="798358"/>
 	<item_collecting id="4945" start_npc_ids="204104"/>
@@ -528,7 +528,7 @@
 	
 	<!-- HUNTING QUESTS -->
 	<monster_hunt id="4213" start_npc_ids="204202"/>
-	<monster_hunt id="4977" start_npc_ids="203385"/>
+	<monster_hunt id="4977" start_npc_ids="204837"/>
 	<monster_hunt id="4978" start_npc_ids="204286"/>
 	<monster_hunt id="4979" start_npc_ids="204283"/>
 	<monster_hunt id="80013" start_npc_ids="799788"/>

--- a/game-server/data/static_data/quest_script_data/poeta.xml
+++ b/game-server/data/static_data/quest_script_data/poeta.xml
@@ -65,7 +65,7 @@
 	</report_to_many>
 	<report_to id="1119" start_npc_ids="203075" end_npc_ids="203080"/>
 	<report_to id="1230" start_npc_ids="801032" end_npc_ids="801033"/>
-	<report_to id="1231" start_npc_ids="801032" end_npc_ids="801033"/>
+	<report_to id="1231" start_npc_ids="801033" end_npc_ids="801032"/>
 	<xml_quest id="1127" start_npc_ids="798008">
 		<on_talk_event ids="700001">
 			<conditions operate="AND">

--- a/game-server/data/static_data/quest_script_data/sanctum.xml
+++ b/game-server/data/static_data/quest_script_data/sanctum.xml
@@ -454,8 +454,8 @@
 	<item_collecting id="3905" start_npc_ids="798316"/>
 	<item_collecting id="3906" start_npc_ids="798316"/>
 	<item_collecting id="3907" start_npc_ids="798316"/>
-	<item_collecting id="3915" start_npc_ids="203384"/>
-	<item_collecting id="3916" start_npc_ids="203384"/>
+	<item_collecting id="3915" start_npc_ids="204656"/>
+	<item_collecting id="3916" start_npc_ids="204656"/>
 	<item_collecting id="3918" start_npc_ids="798357"/>
 	<item_collecting id="3919" start_npc_ids="798357"/>
 	<item_collecting id="3941" start_npc_ids="203788"/>
@@ -562,7 +562,7 @@
 	<!-- HUNTING QUESTS -->
 	<monster_hunt id="1939" start_npc_ids="203703"/>
 	<monster_hunt id="3213" start_npc_ids="203735"/>
-	<monster_hunt id="3977" start_npc_ids="203384"/>
+	<monster_hunt id="3977" start_npc_ids="204656"/>
 	<monster_hunt id="3978" start_npc_ids="798319"/>
 	<monster_hunt id="3979" start_npc_ids="798322"/>
 	<monster_hunt id="80010" start_npc_ids="799767"/>


### PR DESCRIPTION
Their npc was a door, a test dummy, an instance boss, an npc that is not spawned anywhere or one standing in another region. Verified against the 5.8 PTS quest tables and in game.
[fixed-quests.csv](https://github.com/user-attachments/files/31110010/fixed-quests.csv)
