### PR TITLE
Movement modifiers

### DIFF
--- a/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
@@ -33,7 +33,6 @@ import com.aionemu.gameserver.utils.stats.StatFunctions;
  * @author ATracer
  */
 public class AttackUtil {
-	
 
 	/**
 	 * This method calculates the physical attack status and damage in the following order: <br>

--- a/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
@@ -1,10 +1,12 @@
 package com.aionemu.gameserver.controllers.attack;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.aionemu.commons.utils.Rnd;
@@ -34,14 +36,17 @@ import com.aionemu.gameserver.utils.stats.StatFunctions;
  */
 public class AttackUtil {
 
+	private static final Logger log = LoggerFactory.getLogger(AttackUtil.class);
+
 	/**
 	 * This method calculates the physical attack status and damage in the following order: <br>
 	 * 1. calculate status<br>
 	 * 2. calculate main & off hand damage<br>
 	 * 3. apply stat modifiers<br>
 	 * 4. amplify damage by hit count<br>
-	 * @param attacker Creature attacking
-	 * @param attacked Creature being attacked
+	 *
+	 * @param attacker         Creature attacking
+	 * @param attacked         Creature being attacked
 	 * @param calculationTypes
 	 * @return {@code List<AttackResult>} containing the results for each hand
 	 */
@@ -438,6 +443,7 @@ public class AttackUtil {
 			effect.setProtectorId(attackResult.getProtectorId());
 			effect.setShieldDefense(attackResult.getShieldType());
 		}
+		log.info("Time {}, dmg = {}, status = {}, hit_type = {}", OffsetDateTime.now(), damage, status, hitType);
 		effect.setReserveds(new EffectReserved(position, attackResult.getDamage(), ResourceType.HP, true, send), false);
 		effect.setAttackStatus(attackResult.getAttackStatus());
 		effect.setLaunchSubEffect(attackResult.isLaunchSubEffect());

--- a/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
@@ -1,12 +1,10 @@
 package com.aionemu.gameserver.controllers.attack;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.aionemu.commons.utils.Rnd;

--- a/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
@@ -35,8 +35,7 @@ import com.aionemu.gameserver.utils.stats.StatFunctions;
  * @author ATracer
  */
 public class AttackUtil {
-
-	private static final Logger log = LoggerFactory.getLogger(AttackUtil.class);
+	
 
 	/**
 	 * This method calculates the physical attack status and damage in the following order: <br>
@@ -443,7 +442,6 @@ public class AttackUtil {
 			effect.setProtectorId(attackResult.getProtectorId());
 			effect.setShieldDefense(attackResult.getShieldType());
 		}
-		log.info("Time {}, dmg = {}, status = {}, hit_type = {}", OffsetDateTime.now(), damage, status, hitType);
 		effect.setReserveds(new EffectReserved(position, attackResult.getDamage(), ResourceType.HP, true, send), false);
 		effect.setAttackStatus(attackResult.getAttackStatus());
 		effect.setLaunchSubEffect(attackResult.isLaunchSubEffect());

--- a/game-server/src/com/aionemu/gameserver/controllers/movement/MovementModifierDirection.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/movement/MovementModifierDirection.java
@@ -1,15 +1,28 @@
 package com.aionemu.gameserver.controllers.movement;
 
+import com.aionemu.gameserver.controllers.movement.MovementModifierState.MoveState;
+
 /**
- * Movement direction relative to the own heading, which determines the applied movement modifiers.<br>
- * The constants are declared in ascending priority order: while several directions are active at the same time, the modifiers of the last one apply
- * (verified on retail, see {@link MovementModifierState}).
+ * Movement direction relative to the own heading, which determines the applied movement modifiers.
+ * <p>
+ * Left and right are not distinguished, both count as sideways.
  *
  * @see com.aionemu.gameserver.utils.stats.StatFunctions#adjustStatByMovementModifier
  */
 public enum MovementModifierDirection {
-	NONE,
-	BACKWARD,
-	SIDEWAYS,
-	FORWARD
+
+	NONE(MoveState.NONE),
+	FORWARD(MoveState.FORWARD),
+	BACKWARD(MoveState.BACKWARD),
+	SIDEWAYS(MoveState.SIDEWAYS);
+
+	private final int moveStateFlag;
+
+	MovementModifierDirection(int moveStateFlag) {
+		this.moveStateFlag = moveStateFlag;
+	}
+
+	public int getMoveStateFlag() {
+		return moveStateFlag;
+	}
 }

--- a/game-server/src/com/aionemu/gameserver/controllers/movement/MovementModifierDirection.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/movement/MovementModifierDirection.java
@@ -1,0 +1,15 @@
+package com.aionemu.gameserver.controllers.movement;
+
+/**
+ * Movement direction relative to the own heading, which determines the applied movement modifiers.<br>
+ * The constants are declared in ascending priority order: while several directions are active at the same time, the modifiers of the last one apply
+ * (verified on retail, see {@link MovementModifierState}).
+ *
+ * @see com.aionemu.gameserver.utils.stats.StatFunctions#adjustStatByMovementModifier
+ */
+public enum MovementModifierDirection {
+	NONE,
+	BACKWARD,
+	SIDEWAYS,
+	FORWARD
+}

--- a/game-server/src/com/aionemu/gameserver/controllers/movement/MovementModifierState.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/movement/MovementModifierState.java
@@ -1,164 +1,94 @@
 package com.aionemu.gameserver.controllers.movement;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Tracks activation and deactivation of movement modifiers (the direction arrows shown next to the buff bar).
  * <p>
- * Retail behavior, based on frame by frame analysis of client recordings (see <a href="https://github.com/beyond-aion/aion-server/issues/102">#102</a>):
+ * The whole mechanism is two slots:
  * <ul>
- * <li>A direction is only confirmed after {@value #ACTIVATION_DELAY} ms of uninterrupted movement in it. Progress does not accumulate over
- * interruptions, so any direction change or stop before that restarts the timer from scratch.
- * <li>A confirmed direction stays active for another {@value #DEACTIVATION_DELAY} ms after movement in it ended, no matter what happens in between.
- * That's why the client shows several arrows at once while changing directions.
- * <li>While several directions are active, the modifiers of the highest priority one apply: forward, then sideways, then backward (verified via damage
- * output on retail).
- * <li>Left and right are tracked separately although they apply the same modifier, since frequently switching between them prevents activation.
- * <li>Jumping into a direction activates its modifiers immediately on landing, without waiting for the activation delay. Directions which are already
- * active are not affected by that.
+ * <li><b>pending</b> — the direction currently moved in, together with the time it started. It becomes effective once it has been held for more than
+ * {@value #ACTIVATION_DELAY} ms, so movement shorter than that never applies anything and progress cannot accumulate over interruptions.
+ * <li><b>confirmed</b> — the direction moved in before, but only if it had already become effective. It keeps being applied for another
+ * {@value #DEACTIVATION_DELAY} ms, which is why the client shows several arrows at once while changing direction.
  * </ul>
- * All state changes are time based, therefore no periodic task is needed: the current state is derived on demand in
- * {@link #getModifierDirection()}.
+ * The effective move state is the bit-wise or of both slots, so <b>at most two directions apply at the same time</b> and neither the state machine nor
+ * the modifier table can ever see all three at once.
+ * <p>
+ * All state is time based, so no periodic task is needed: the current state is derived on demand in {@link #getMoveState()}.
+ * <p>
+ * There is no idle timeout — if move packets simply stop arriving, the pending direction stays effective. That cannot normally happen, because the
+ * client always sends a stop packet and the state is also reset whenever a movement is rejected.
  */
 public class MovementModifierState {
 
-	private static final Logger log = LoggerFactory.getLogger(MovementModifierState.class);
+	/** Movement in the same direction needed before its modifier applies, exclusive. */
+	static final int ACTIVATION_DELAY = 666;
+	/** Time an already applied modifier keeps being applied after the direction changed, exclusive. */
+	static final int DEACTIVATION_DELAY = 1332;
+
+	private int pendingState = MoveState.NONE;
+	private long pendingSince;
+	private int confirmedState = MoveState.NONE;
+	private long confirmedSince;
 
 	/**
-	 * Temporary switch for diagnosing retail movement modifier behavior. Logs every state change with the prefix {@code MOVEDEBUG}, as well as the
-	 * incoming move packets and the modifiers applied to attack damage. Must be disabled (or the logging removed) before release.
+	 * @param moveState The direction currently moved in as a single {@link MoveState} flag, or {@link MoveState#NONE} when the movement ended.
 	 */
-	public static final boolean DEBUG = true;
-
-	/** Uninterrupted movement in the same direction needed to activate its modifier (observed: 838, 854, 863, 870, 879, 882 ms). */
-	private static final int ACTIVATION_DELAY = 850;
-	/** Time an activated modifier keeps being applied after movement in its direction ended (observed: 1350, 1367, 1384 ms). */
-	private static final int DEACTIVATION_DELAY = 1350;
-	/**
-	 * Safety net in case we never learn about the end of a movement (packet loss, connection loss): movement is assumed to have ended this long after the
-	 * last update. The game client sends position updates about every 672 ms while moving.
-	 */
-	private static final int MOVEMENT_UPDATE_TIMEOUT = 1000;
-
-	/** Expiration times of directions which are no longer moved in, indexed by {@link Direction#ordinal()} (0 = inactive). */
-	private final long[] activeUntil = new long[Direction.VALUES.length];
-	private Direction currentDirection;
-	private long movingSince;
-	private long lastMovementUpdate;
-
-	public void onMove(Direction direction) {
-		String stateBefore = DEBUG ? toString() : null;
-		onMove(direction, System.currentTimeMillis());
-		if (DEBUG)
-			logStateChange("onMove(" + direction + ")", stateBefore);
+	public void setMoveState(int moveState) {
+		setMoveState(moveState, System.currentTimeMillis());
 	}
 
-	void onMove(Direction direction, long now) {
-		lastMovementUpdate = now;
-		if (direction == currentDirection)
-			return; // keep the running activation timer, movement is uninterrupted
-		endCurrentMovement(now);
-		currentDirection = direction;
-		movingSince = now;
-	}
-
-	public void onStop() {
-		String stateBefore = DEBUG ? toString() : null;
-		onStop(System.currentTimeMillis());
-		if (DEBUG)
-			logStateChange("onStop", stateBefore);
-	}
-
-	void onStop(long now) {
-		endCurrentMovement(now);
-	}
-
-	/**
-	 * Activates the current direction without waiting for the remaining activation delay. Used on landing, since jumping into a direction applies its
-	 * modifiers immediately. Directions which are already active keep their original activation time, so their fade out is never shortened.
-	 */
-	public void commitCurrentDirection() {
-		String stateBefore = DEBUG ? toString() : null;
-		commitCurrentDirection(System.currentTimeMillis());
-		if (DEBUG)
-			logStateChange("commitCurrentDirection (landed)", stateBefore);
-	}
-
-	void commitCurrentDirection(long now) {
-		if (currentDirection != null)
-			movingSince = Math.min(movingSince, now - ACTIVATION_DELAY);
-	}
-
-	private void endCurrentMovement(long now) {
-		if (currentDirection == null)
+	void setMoveState(int moveState, long now) {
+		if (pendingState == moveState) // continued movement in the same direction never restarts the timer
 			return;
-		if (now - movingSince >= ACTIVATION_DELAY) // unconfirmed movement is discarded and doesn't activate anything
-			activeUntil[currentDirection.ordinal()] = now + DEACTIVATION_DELAY;
-		currentDirection = null;
-	}
-
-	public MovementModifierDirection getModifierDirection() {
-		return getModifierDirection(System.currentTimeMillis());
-	}
-
-	MovementModifierDirection getModifierDirection(long now) {
-		MovementModifierDirection result = MovementModifierDirection.NONE;
-		for (Direction direction : Direction.VALUES) {
-			if (isActive(direction, now) && direction.modifierDirection.ordinal() > result.ordinal())
-				result = direction.modifierDirection;
+		if (pendingState != MoveState.NONE && now - pendingSince > ACTIVATION_DELAY) {
+			// the outgoing direction had become effective, so it now starts fading out. Movement too short for that is discarded silently.
+			confirmedState = pendingState;
+			confirmedSince = now;
 		}
-		return result;
+		pendingState = moveState;
+		pendingSince = now;
 	}
 
-	private boolean isActive(Direction direction, long now) {
-		if (direction == currentDirection) {
-			long movementEnd = Math.min(now, lastMovementUpdate + MOVEMENT_UPDATE_TIMEOUT);
-			if (movementEnd - movingSince >= ACTIVATION_DELAY && movementEnd + DEACTIVATION_DELAY > now)
-				return true;
-		}
-		// a direction may still fade out from a previous activation, even while it's already moved in again
-		return activeUntil[direction.ordinal()] > now;
+	/**
+	 * @return The currently applied directions as a {@link MoveState} bit mask.
+	 */
+	public int getMoveState() {
+		return getMoveState(System.currentTimeMillis());
 	}
 
-	private void logStateChange(String event, String stateBefore) {
-		String stateAfter = toString();
-		if (!stateAfter.equals(stateBefore))
-			log.info("MOVEDEBUG state {}: {} => {}", event, stateBefore, stateAfter);
+	int getMoveState(long now) {
+		int moveState = MoveState.NONE;
+		if (confirmedState != MoveState.NONE && now - confirmedSince < DEACTIVATION_DELAY)
+			moveState = confirmedState;
+		if (pendingState != MoveState.NONE && now - pendingSince > ACTIVATION_DELAY)
+			moveState |= pendingState;
+		return moveState;
 	}
 
 	@Override
 	public String toString() {
 		long now = System.currentTimeMillis();
-		StringBuilder sb = new StringBuilder("[applied=").append(getModifierDirection(now));
-		if (currentDirection == null)
-			sb.append(", notMoving");
-		else
-			sb.append(", moving ").append(currentDirection).append(" since ").append(now - movingSince).append("ms, last update ")
-				.append(now - lastMovementUpdate).append("ms ago");
-		for (Direction direction : Direction.VALUES) {
-			if (activeUntil[direction.ordinal()] > now)
-				sb.append(", ").append(direction).append(" fades out in ").append(activeUntil[direction.ordinal()] - now).append("ms");
-		}
+		StringBuilder sb = new StringBuilder("[moveState=").append(getMoveState(now));
+		sb.append(", pending=").append(pendingState).append(" since ").append(now - pendingSince).append("ms");
+		if (confirmedState != MoveState.NONE && now - confirmedSince < DEACTIVATION_DELAY)
+			sb.append(", ").append(confirmedState).append(" fades out in ").append(DEACTIVATION_DELAY - (now - confirmedSince)).append("ms");
 		return sb.append(']').toString();
 	}
 
-	public enum Direction {
-		FORWARD(MovementModifierDirection.FORWARD),
-		BACKWARD(MovementModifierDirection.BACKWARD),
-		LEFT(MovementModifierDirection.SIDEWAYS),
-		RIGHT(MovementModifierDirection.SIDEWAYS);
+	/**
+	 * The simultaneously active directions as a bit mask, which indexes the modifier table in
+	 * {@link com.aionemu.gameserver.utils.stats.StatFunctions#adjustStatByMovementModifier}. Left and right share the sideways bit, so switching
+	 * between them is not a direction change and does not restart the activation timer.
+	 */
+	public static final class MoveState {
 
-		private static final Direction[] VALUES = values();
+		public static final int NONE = 0;
+		public static final int FORWARD = 1;
+		public static final int BACKWARD = 2;
+		public static final int SIDEWAYS = 4;
+		public static final int COUNT = 8;
 
-		private final MovementModifierDirection modifierDirection;
-
-		Direction(MovementModifierDirection modifierDirection) {
-			this.modifierDirection = modifierDirection;
-		}
-
-		public MovementModifierDirection getModifierDirection() {
-			return modifierDirection;
+		private MoveState() {
 		}
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/controllers/movement/MovementModifierState.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/movement/MovementModifierState.java
@@ -1,0 +1,164 @@
+package com.aionemu.gameserver.controllers.movement;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tracks activation and deactivation of movement modifiers (the direction arrows shown next to the buff bar).
+ * <p>
+ * Retail behavior, based on frame by frame analysis of client recordings (see <a href="https://github.com/beyond-aion/aion-server/issues/102">#102</a>):
+ * <ul>
+ * <li>A direction is only confirmed after {@value #ACTIVATION_DELAY} ms of uninterrupted movement in it. Progress does not accumulate over
+ * interruptions, so any direction change or stop before that restarts the timer from scratch.
+ * <li>A confirmed direction stays active for another {@value #DEACTIVATION_DELAY} ms after movement in it ended, no matter what happens in between.
+ * That's why the client shows several arrows at once while changing directions.
+ * <li>While several directions are active, the modifiers of the highest priority one apply: forward, then sideways, then backward (verified via damage
+ * output on retail).
+ * <li>Left and right are tracked separately although they apply the same modifier, since frequently switching between them prevents activation.
+ * <li>Jumping into a direction activates its modifiers immediately on landing, without waiting for the activation delay. Directions which are already
+ * active are not affected by that.
+ * </ul>
+ * All state changes are time based, therefore no periodic task is needed: the current state is derived on demand in
+ * {@link #getModifierDirection()}.
+ */
+public class MovementModifierState {
+
+	private static final Logger log = LoggerFactory.getLogger(MovementModifierState.class);
+
+	/**
+	 * Temporary switch for diagnosing retail movement modifier behavior. Logs every state change with the prefix {@code MOVEDEBUG}, as well as the
+	 * incoming move packets and the modifiers applied to attack damage. Must be disabled (or the logging removed) before release.
+	 */
+	public static final boolean DEBUG = true;
+
+	/** Uninterrupted movement in the same direction needed to activate its modifier (observed: 838, 854, 863, 870, 879, 882 ms). */
+	private static final int ACTIVATION_DELAY = 850;
+	/** Time an activated modifier keeps being applied after movement in its direction ended (observed: 1350, 1367, 1384 ms). */
+	private static final int DEACTIVATION_DELAY = 1350;
+	/**
+	 * Safety net in case we never learn about the end of a movement (packet loss, connection loss): movement is assumed to have ended this long after the
+	 * last update. The game client sends position updates about every 672 ms while moving.
+	 */
+	private static final int MOVEMENT_UPDATE_TIMEOUT = 1000;
+
+	/** Expiration times of directions which are no longer moved in, indexed by {@link Direction#ordinal()} (0 = inactive). */
+	private final long[] activeUntil = new long[Direction.VALUES.length];
+	private Direction currentDirection;
+	private long movingSince;
+	private long lastMovementUpdate;
+
+	public void onMove(Direction direction) {
+		String stateBefore = DEBUG ? toString() : null;
+		onMove(direction, System.currentTimeMillis());
+		if (DEBUG)
+			logStateChange("onMove(" + direction + ")", stateBefore);
+	}
+
+	void onMove(Direction direction, long now) {
+		lastMovementUpdate = now;
+		if (direction == currentDirection)
+			return; // keep the running activation timer, movement is uninterrupted
+		endCurrentMovement(now);
+		currentDirection = direction;
+		movingSince = now;
+	}
+
+	public void onStop() {
+		String stateBefore = DEBUG ? toString() : null;
+		onStop(System.currentTimeMillis());
+		if (DEBUG)
+			logStateChange("onStop", stateBefore);
+	}
+
+	void onStop(long now) {
+		endCurrentMovement(now);
+	}
+
+	/**
+	 * Activates the current direction without waiting for the remaining activation delay. Used on landing, since jumping into a direction applies its
+	 * modifiers immediately. Directions which are already active keep their original activation time, so their fade out is never shortened.
+	 */
+	public void commitCurrentDirection() {
+		String stateBefore = DEBUG ? toString() : null;
+		commitCurrentDirection(System.currentTimeMillis());
+		if (DEBUG)
+			logStateChange("commitCurrentDirection (landed)", stateBefore);
+	}
+
+	void commitCurrentDirection(long now) {
+		if (currentDirection != null)
+			movingSince = Math.min(movingSince, now - ACTIVATION_DELAY);
+	}
+
+	private void endCurrentMovement(long now) {
+		if (currentDirection == null)
+			return;
+		if (now - movingSince >= ACTIVATION_DELAY) // unconfirmed movement is discarded and doesn't activate anything
+			activeUntil[currentDirection.ordinal()] = now + DEACTIVATION_DELAY;
+		currentDirection = null;
+	}
+
+	public MovementModifierDirection getModifierDirection() {
+		return getModifierDirection(System.currentTimeMillis());
+	}
+
+	MovementModifierDirection getModifierDirection(long now) {
+		MovementModifierDirection result = MovementModifierDirection.NONE;
+		for (Direction direction : Direction.VALUES) {
+			if (isActive(direction, now) && direction.modifierDirection.ordinal() > result.ordinal())
+				result = direction.modifierDirection;
+		}
+		return result;
+	}
+
+	private boolean isActive(Direction direction, long now) {
+		if (direction == currentDirection) {
+			long movementEnd = Math.min(now, lastMovementUpdate + MOVEMENT_UPDATE_TIMEOUT);
+			if (movementEnd - movingSince >= ACTIVATION_DELAY && movementEnd + DEACTIVATION_DELAY > now)
+				return true;
+		}
+		// a direction may still fade out from a previous activation, even while it's already moved in again
+		return activeUntil[direction.ordinal()] > now;
+	}
+
+	private void logStateChange(String event, String stateBefore) {
+		String stateAfter = toString();
+		if (!stateAfter.equals(stateBefore))
+			log.info("MOVEDEBUG state {}: {} => {}", event, stateBefore, stateAfter);
+	}
+
+	@Override
+	public String toString() {
+		long now = System.currentTimeMillis();
+		StringBuilder sb = new StringBuilder("[applied=").append(getModifierDirection(now));
+		if (currentDirection == null)
+			sb.append(", notMoving");
+		else
+			sb.append(", moving ").append(currentDirection).append(" since ").append(now - movingSince).append("ms, last update ")
+				.append(now - lastMovementUpdate).append("ms ago");
+		for (Direction direction : Direction.VALUES) {
+			if (activeUntil[direction.ordinal()] > now)
+				sb.append(", ").append(direction).append(" fades out in ").append(activeUntil[direction.ordinal()] - now).append("ms");
+		}
+		return sb.append(']').toString();
+	}
+
+	public enum Direction {
+		FORWARD(MovementModifierDirection.FORWARD),
+		BACKWARD(MovementModifierDirection.BACKWARD),
+		LEFT(MovementModifierDirection.SIDEWAYS),
+		RIGHT(MovementModifierDirection.SIDEWAYS);
+
+		private static final Direction[] VALUES = values();
+
+		private final MovementModifierDirection modifierDirection;
+
+		Direction(MovementModifierDirection modifierDirection) {
+			this.modifierDirection = modifierDirection;
+		}
+
+		public MovementModifierDirection getModifierDirection() {
+			return modifierDirection;
+		}
+	}
+}

--- a/game-server/src/com/aionemu/gameserver/controllers/movement/MovementModifierState.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/movement/MovementModifierState.java
@@ -21,9 +21,9 @@ package com.aionemu.gameserver.controllers.movement;
 public class MovementModifierState {
 
 	/** Movement in the same direction needed before its modifier applies, exclusive. */
-	static final int ACTIVATION_DELAY = 666;
+	private static final int ACTIVATION_DELAY = 666;
 	/** Time an already applied modifier keeps being applied after the direction changed, exclusive. */
-	static final int DEACTIVATION_DELAY = 1332;
+	private static final int DEACTIVATION_DELAY = 1332;
 
 	private int pendingState = MoveState.NONE;
 	private long pendingSince;

--- a/game-server/src/com/aionemu/gameserver/controllers/movement/PlayableMoveController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/movement/PlayableMoveController.java
@@ -1,5 +1,8 @@
 package com.aionemu.gameserver.controllers.movement;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.aionemu.gameserver.model.gameobjects.Creature;
 import com.aionemu.gameserver.model.stats.container.StatEnum;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_MOVE;
@@ -14,8 +17,10 @@ import com.aionemu.gameserver.world.World;
  */
 public abstract class PlayableMoveController<T extends Creature> extends CreatureMoveController<T> {
 
+	private static final Logger log = LoggerFactory.getLogger(PlayableMoveController.class);
+
 	private boolean sendMovePacket = true;
-	private MovementModifierDirection movementModifierDirection = MovementModifierDirection.NONE;
+	private final MovementModifierState movementModifierState = new MovementModifierState();
 
 	public float vehicleX;
 	public float vehicleY;
@@ -60,6 +65,7 @@ public abstract class PlayableMoveController<T extends Creature> extends Creatur
 			if (started.compareAndSet(true, false)) {
 				setAndSendStopMove(owner);
 				updateLastMove();
+				onMovementStopped();
 			}
 			return;
 		}
@@ -76,7 +82,11 @@ public abstract class PlayableMoveController<T extends Creature> extends Creatur
 		if (dist < 0.01f)
 			return;
 
-		float currentSpeed = StatFunctions.adjustStatByMovementModifier(owner, StatEnum.SPEED, owner.getGameStats().getMovementSpeedFloat());
+		// server side controlled movement (fear, confuse) is not affected by the activation and deactivation delays of movement modifiers, since those
+		// only apply to movement requested by the client. The speed penalty for moving sideways or backwards applies immediately.
+		MovementModifierState.Direction direction = calculateMovementDirection();
+		MovementModifierDirection modifierDirection = direction == null ? MovementModifierDirection.NONE : direction.getModifierDirection();
+		float currentSpeed = StatFunctions.adjustStatByMovementModifier(modifierDirection, StatEnum.SPEED, owner.getGameStats().getMovementSpeedFloat());
 		long msElapsed = System.currentTimeMillis() - lastMoveUpdate;
 		float futureXYDistPassed = Math.min(currentSpeed * msElapsed / 1000f, dist);
 		float futureZDistPassed = isJumping() ? Math.min(2 * msElapsed / 1000f, dist) : futureXYDistPassed;
@@ -98,6 +108,7 @@ public abstract class PlayableMoveController<T extends Creature> extends Creatur
 	@Override
 	public void abortMove() {
 		started.set(false);
+		onMovementStopped();
 		PlayerMoveTaskManager.getInstance().removePlayer(owner);
 		targetDestX = 0;
 		targetDestY = 0;
@@ -111,26 +122,64 @@ public abstract class PlayableMoveController<T extends Creature> extends Creatur
 			sendMovePacket = true;
 		}
 		super.setNewDirection(x, y, z);
+	}
 
-		float relativeMovementAngle = PositionUtil.calculateAngleTowards(owner.getX(), owner.getY(), heading, targetDestX, targetDestY);
-		if (relativeMovementAngle >= -67.5 && relativeMovementAngle <= 67.5)
-			movementModifierDirection = MovementModifierDirection.FORWARD;
-		else if (relativeMovementAngle <= -112.5 || relativeMovementAngle >= 112.5)
-			movementModifierDirection = MovementModifierDirection.BACKWARD;
+	/**
+	 * Feeds the currently requested movement direction into the movement modifier state. Must only be called for movements requested by the client, since
+	 * movement modifiers don't apply to server side controlled movement (there are no direction arrows while under fear, for example).
+	 * <p>
+	 * The requested destination is used instead of the covered distance, because the client sends position updates only about every 672 ms. Movement
+	 * during that period is not necessarily a straight line, so the covered distance would be misclassified whenever the heading changes (turning with
+	 * the mouse while running forward would look like sideways movement).
+	 */
+	public void updateMovementModifierDirection() {
+		MovementModifierState.Direction direction = calculateMovementDirection();
+		if (MovementModifierState.DEBUG) {
+			log.info("MOVEDEBUG move {}: mask={} at {}/{} towards {}/{} (distance {}m), heading={} ({}°), relativeAngle={}° => {}", owner.getName(),
+				movementMask & 0xFF, owner.getX(), owner.getY(), targetDestX, targetDestY,
+				String.format("%.3f", PositionUtil.getDistance(owner.getX(), owner.getY(), targetDestX, targetDestY)), heading,
+				PositionUtil.convertHeadingToAngle(heading),
+				String.format("%.1f", PositionUtil.calculateAngleTowards(owner.getX(), owner.getY(), heading, targetDestX, targetDestY)),
+				direction == null ? "STOPPED" : direction);
+		}
+		if (direction == null)
+			onMovementStopped(); // no destination to move to (stop packet, turning on the spot or jumping on the spot)
 		else
-			movementModifierDirection = MovementModifierDirection.SIDEWAYS;
+			movementModifierState.onMove(direction);
+	}
+
+	/**
+	 * @return The direction of the movement towards the current destination, or null if there is no destination to move to. Must be called after the
+	 *         position update, since the direction is calculated from the current position towards the destination.
+	 */
+	private MovementModifierState.Direction calculateMovementDirection() {
+		if (PositionUtil.getDistance(owner.getX(), owner.getY(), targetDestX, targetDestY) < MOVE_CHECK_OFFSET)
+			return null;
+		return calculateDirection(PositionUtil.calculateAngleTowards(owner.getX(), owner.getY(), heading, targetDestX, targetDestY));
+	}
+
+	private static MovementModifierState.Direction calculateDirection(float relativeMovementAngle) {
+		if (relativeMovementAngle >= -67.5 && relativeMovementAngle <= 67.5)
+			return MovementModifierState.Direction.FORWARD;
+		if (relativeMovementAngle <= -112.5 || relativeMovementAngle >= 112.5)
+			return MovementModifierState.Direction.BACKWARD;
+		// negative angles are on the owners left side, see PositionUtil.calculateAngleTowards
+		// left and right apply the same modifier, but are tracked separately (see MovementModifierState)
+		return relativeMovementAngle < 0 ? MovementModifierState.Direction.LEFT : MovementModifierState.Direction.RIGHT;
+	}
+
+	public void onMovementStopped() {
+		movementModifierState.onStop();
+	}
+
+	/**
+	 * Activates the modifiers of the current movement direction immediately, without waiting for the usual activation delay.
+	 */
+	public void commitMovementModifierDirection() {
+		movementModifierState.commitCurrentDirection();
 	}
 
 	public MovementModifierDirection getMovementDirection() {
-		if (!isInMove() && System.currentTimeMillis() - lastMoveUpdate > 1000)
-			return MovementModifierDirection.NONE;
-		return movementModifierDirection;
-	}
-
-	public enum MovementModifierDirection {
-		NONE,
-		FORWARD,
-		SIDEWAYS,
-		BACKWARD
+		return movementModifierState.getModifierDirection();
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/controllers/movement/PlayableMoveController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/movement/PlayableMoveController.java
@@ -1,8 +1,5 @@
 package com.aionemu.gameserver.controllers.movement;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.aionemu.gameserver.model.gameobjects.Creature;
 import com.aionemu.gameserver.model.stats.container.StatEnum;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_MOVE;
@@ -16,8 +13,6 @@ import com.aionemu.gameserver.world.World;
  * @author ATracer base class for summon & player move controller
  */
 public abstract class PlayableMoveController<T extends Creature> extends CreatureMoveController<T> {
-
-	private static final Logger log = LoggerFactory.getLogger(PlayableMoveController.class);
 
 	private boolean sendMovePacket = true;
 	private final MovementModifierState movementModifierState = new MovementModifierState();
@@ -84,9 +79,7 @@ public abstract class PlayableMoveController<T extends Creature> extends Creatur
 
 		// server side controlled movement (fear, confuse) is not affected by the activation and deactivation delays of movement modifiers, since those
 		// only apply to movement requested by the client. The speed penalty for moving sideways or backwards applies immediately.
-		MovementModifierState.Direction direction = calculateMovementDirection();
-		MovementModifierDirection modifierDirection = direction == null ? MovementModifierDirection.NONE : direction.getModifierDirection();
-		float currentSpeed = StatFunctions.adjustStatByMovementModifier(modifierDirection, StatEnum.SPEED, owner.getGameStats().getMovementSpeedFloat());
+		float currentSpeed = StatFunctions.adjustSpeedByMovementModifier(calculateMovementDirection(), owner.getGameStats().getMovementSpeedFloat());
 		long msElapsed = System.currentTimeMillis() - lastMoveUpdate;
 		float futureXYDistPassed = Math.min(currentSpeed * msElapsed / 1000f, dist);
 		float futureZDistPassed = isJumping() ? Math.min(2 * msElapsed / 1000f, dist) : futureXYDistPassed;
@@ -133,53 +126,45 @@ public abstract class PlayableMoveController<T extends Creature> extends Creatur
 	 * the mouse while running forward would look like sideways movement).
 	 */
 	public void updateMovementModifierDirection() {
-		MovementModifierState.Direction direction = calculateMovementDirection();
-		if (MovementModifierState.DEBUG) {
-			log.info("MOVEDEBUG move {}: mask={} at {}/{} towards {}/{} (distance {}m), heading={} ({}°), relativeAngle={}° => {}", owner.getName(),
-				movementMask & 0xFF, owner.getX(), owner.getY(), targetDestX, targetDestY,
-				String.format("%.3f", PositionUtil.getDistance(owner.getX(), owner.getY(), targetDestX, targetDestY)), heading,
-				PositionUtil.convertHeadingToAngle(heading),
-				String.format("%.1f", PositionUtil.calculateAngleTowards(owner.getX(), owner.getY(), heading, targetDestX, targetDestY)),
-				direction == null ? "STOPPED" : direction);
-		}
-		if (direction == null)
-			onMovementStopped(); // no destination to move to (stop packet, turning on the spot or jumping on the spot)
-		else
-			movementModifierState.onMove(direction);
+		movementModifierState.setMoveState(calculateMovementDirection().getMoveStateFlag());
 	}
 
 	/**
-	 * @return The direction of the movement towards the current destination, or null if there is no destination to move to. Must be called after the
-	 *         position update, since the direction is calculated from the current position towards the destination.
+	 * @return The direction of the movement towards the current destination, or {@link MovementModifierDirection#NONE} if there is no destination to move
+	 *         to (stop packet, turning on the spot or jumping on the spot). Must be called after the position update, since the direction is calculated
+	 *         from the current position towards the destination.
 	 */
-	private MovementModifierState.Direction calculateMovementDirection() {
+	private MovementModifierDirection calculateMovementDirection() {
 		if (PositionUtil.getDistance(owner.getX(), owner.getY(), targetDestX, targetDestY) < MOVE_CHECK_OFFSET)
-			return null;
-		return calculateDirection(PositionUtil.calculateAngleTowards(owner.getX(), owner.getY(), heading, targetDestX, targetDestY));
+			return MovementModifierDirection.NONE;
+		return calculateDirection(PositionUtil.getHeadingTowards(owner.getX(), owner.getY(), targetDestX, targetDestY), heading);
 	}
 
-	private static MovementModifierState.Direction calculateDirection(float relativeMovementAngle) {
-		if (relativeMovementAngle >= -67.5 && relativeMovementAngle <= 67.5)
-			return MovementModifierState.Direction.FORWARD;
-		if (relativeMovementAngle <= -112.5 || relativeMovementAngle >= 112.5)
-			return MovementModifierState.Direction.BACKWARD;
-		// negative angles are on the owners left side, see PositionUtil.calculateAngleTowards
-		// left and right apply the same modifier, but are tracked separately (see MovementModifierState)
-		return relativeMovementAngle < 0 ? MovementModifierState.Direction.LEFT : MovementModifierState.Direction.RIGHT;
+	/**
+	 * Compares two client headings (120 units of 3° each), folds the difference into 0..60 and treats <= 15 units as forward and >= 45 units as
+	 * backward, i.e. a 90° wide forward cone.
+	 * <p>
+	 * The arithmetic must stay integer. Comparing degrees instead is asymmetric, because only the own heading is quantized to 3° steps while the angle
+	 * towards the destination is not: a diagonal then lands at 45° ± 1.5° and falls on either side of the boundary depending on which diagonal it is.
+	 * Quantizing both sides puts every diagonal at exactly 15 units.
+	 */
+	static MovementModifierDirection calculateDirection(byte destinationHeading, byte ownHeading) {
+		int headingDiff = (destinationHeading + 120 - ownHeading) % 120;
+		if (headingDiff > 60)
+			headingDiff = 120 - headingDiff;
+		if (headingDiff <= 15)
+			return MovementModifierDirection.FORWARD;
+		return headingDiff >= 45 ? MovementModifierDirection.BACKWARD : MovementModifierDirection.SIDEWAYS;
 	}
 
 	public void onMovementStopped() {
-		movementModifierState.onStop();
+		movementModifierState.setMoveState(MovementModifierState.MoveState.NONE);
 	}
 
 	/**
-	 * Activates the modifiers of the current movement direction immediately, without waiting for the usual activation delay.
+	 * @return The currently active movement directions as a {@link MovementModifierState.MoveState} bit mask.
 	 */
-	public void commitMovementModifierDirection() {
-		movementModifierState.commitCurrentDirection();
-	}
-
-	public MovementModifierDirection getMovementDirection() {
-		return movementModifierState.getModifierDirection();
+	public int getMoveState() {
+		return movementModifierState.getMoveState();
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/controllers/movement/PlayerMoveController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/movement/PlayerMoveController.java
@@ -58,6 +58,19 @@ public class PlayerMoveController extends PlayableMoveController<Player> {
 			lastPositionFromClient = new WorldPosition(owner.getWorldId(), owner.getX(), owner.getY(), owner.getZ(), owner.getHeading());
 		else
 			lastPositionFromClient.setXYZH(owner.getX(), owner.getY(), owner.getZ(), owner.getHeading());
+		updateMovementModifiers();
+	}
+
+	private void updateMovementModifiers() {
+		if ((getMovementMask() & MovementMask.FALL) == MovementMask.FALL) {
+			// While airborne the client doesn't request a direction, the horizontal movement is momentum from before the jump. Turning in mid air must
+			// therefore not change the movement direction (and reset its activation timer).
+			return;
+		}
+		// Must happen before the direction is updated, since the landing packet is a stop packet which would end the movement first.
+		if (lastFallZ != 0)
+			commitMovementModifierDirection(); // jumping into a direction activates its modifiers immediately on landing
+		updateMovementModifierDirection();
 	}
 
 	public void resetToLastPositionFromClient() {

--- a/game-server/src/com/aionemu/gameserver/controllers/movement/PlayerMoveController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/movement/PlayerMoveController.java
@@ -64,12 +64,10 @@ public class PlayerMoveController extends PlayableMoveController<Player> {
 	private void updateMovementModifiers() {
 		if ((getMovementMask() & MovementMask.FALL) == MovementMask.FALL) {
 			// While airborne the client doesn't request a direction, the horizontal movement is momentum from before the jump. Turning in mid air must
-			// therefore not change the movement direction (and reset its activation timer).
+			// therefore not change the movement direction (and reset its activation timer). The state is only cleared when neither POSITION nor FALL
+			// is set.
 			return;
 		}
-		// Must happen before the direction is updated, since the landing packet is a stop packet which would end the movement first.
-		if (lastFallZ != 0)
-			commitMovementModifierDirection(); // jumping into a direction activates its modifiers immediately on landing
 		updateMovementModifierDirection();
 	}
 

--- a/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_MOVE.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_MOVE.java
@@ -1,9 +1,14 @@
 package com.aionemu.gameserver.network.aion.clientpackets;
 
+import java.time.OffsetDateTime;
 import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.aionemu.gameserver.controllers.movement.GlideFlag;
 import com.aionemu.gameserver.controllers.movement.MovementMask;
+import com.aionemu.gameserver.controllers.movement.MovementModifierState;
 import com.aionemu.gameserver.controllers.movement.PlayerMoveController;
 import com.aionemu.gameserver.model.gameobjects.VisibleObject;
 import com.aionemu.gameserver.model.gameobjects.player.CustomPlayerState;
@@ -24,6 +29,8 @@ import com.aionemu.gameserver.world.World;
  * @author -Nemesiss-
  */
 public class CM_MOVE extends AionClientPacket {
+
+	private static final Logger log = LoggerFactory.getLogger(CM_MOVE.class);
 
 	private byte type;
 	private byte heading;
@@ -71,15 +78,26 @@ public class CM_MOVE extends AionClientPacket {
 			vehicleY = readF();
 			vehicleZ = readF();
 		}
+		log.info("CM_MOVE time: {}, {}", OffsetDateTime.now(), this);
 	}
 
 	@Override
 	protected void runImpl() {
 		Player player = getConnection().getActivePlayer();
-		if (player.isDead() || player.getEffectController().isUnderFear() || player.getEffectController().isConfused()) // just in case of bad timing
+		if (MovementModifierState.DEBUG) {
+			log.info("MOVEDEBUG packet {}: {}, serverPos={}/{}/{}, serverHeading={}, isInMove={}", player.getName(), this, player.getX(), player.getY(),
+				player.getZ(), player.getHeading(), player.getMoveController().isInMove());
+		}
+		if (player.isDead() || player.getEffectController().isUnderFear() || player.getEffectController().isConfused()) { // just in case of bad timing
+			if (MovementModifierState.DEBUG)
+				log.info("MOVEDEBUG packet {}: IGNORED (dead, feared or confused)", player.getName());
 			return;
-		if (handleBogusPacket(player))
+		}
+		if (handleBogusPacket(player)) {
+			if (MovementModifierState.DEBUG)
+				log.info("MOVEDEBUG packet {}: IGNORED (bogus packet)", player.getName());
 			return;
+		}
 
 		PlayerMoveController m = player.getMoveController();
 		boolean jumping = false;
@@ -106,6 +124,8 @@ public class CM_MOVE extends AionClientPacket {
 						World.getInstance().updatePosition(player, x2, y2, z2, heading);
 						m.onMoveFromClient();
 						PacketSendUtility.broadcastToSightedPlayers(player, new SM_POSITION(player), true);
+						if (MovementModifierState.DEBUG)
+							log.info("MOVEDEBUG packet {}: handled as teleportation mode move", player.getName());
 						return;
 					}
 				} else {
@@ -132,11 +152,16 @@ public class CM_MOVE extends AionClientPacket {
 
 		if (!AntiHackService.canMove(player, x, y, z, type)) {
 			player.getMoveController().setIsJumping(false);
+			if (MovementModifierState.DEBUG)
+				log.info("MOVEDEBUG packet {}: IGNORED (rejected by AntiHackService)", player.getName());
 			return;
 		}
 
-		if (!player.isSpawned()) // should be checked as late as possible, to prevent false warnings from World.updatePosition
+		if (!player.isSpawned()) { // should be checked as late as possible, to prevent false warnings from World.updatePosition
+			if (MovementModifierState.DEBUG)
+				log.info("MOVEDEBUG packet {}: IGNORED (not spawned)", player.getName());
 			return;
+		}
 		if (player.isProtectionActive() && (player.getX() != x || player.getY() != y || player.getZ() > z + 0.5f))
 			player.getController().stopProtectionActiveTask();
 		player.getMoveController().setIsJumping(jumping);
@@ -148,6 +173,8 @@ public class CM_MOVE extends AionClientPacket {
 			|| type == MovementMask.IMMEDIATE)
 			PacketSendUtility.broadcastToSightedPlayers(player, new SM_MOVE(player));
 
+		if (MovementModifierState.DEBUG && (type & MovementMask.FALL) != MovementMask.FALL)
+			log.info("MOVEDEBUG packet {}: not falling anymore (landing check follows)", player.getName());
 		if ((type & MovementMask.FALL) == MovementMask.FALL) {
 			player.getFlyController().onStopGliding();
 			m.updateFalling(z);

--- a/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_MOVE.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_MOVE.java
@@ -1,14 +1,9 @@
 package com.aionemu.gameserver.network.aion.clientpackets;
 
-import java.time.OffsetDateTime;
 import java.util.Set;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.aionemu.gameserver.controllers.movement.GlideFlag;
 import com.aionemu.gameserver.controllers.movement.MovementMask;
-import com.aionemu.gameserver.controllers.movement.MovementModifierState;
 import com.aionemu.gameserver.controllers.movement.PlayerMoveController;
 import com.aionemu.gameserver.model.gameobjects.VisibleObject;
 import com.aionemu.gameserver.model.gameobjects.player.CustomPlayerState;
@@ -29,8 +24,6 @@ import com.aionemu.gameserver.world.World;
  * @author -Nemesiss-
  */
 public class CM_MOVE extends AionClientPacket {
-
-	private static final Logger log = LoggerFactory.getLogger(CM_MOVE.class);
 
 	private byte type;
 	private byte heading;
@@ -78,24 +71,15 @@ public class CM_MOVE extends AionClientPacket {
 			vehicleY = readF();
 			vehicleZ = readF();
 		}
-		log.info("CM_MOVE time: {}, {}", OffsetDateTime.now(), this);
 	}
 
 	@Override
 	protected void runImpl() {
 		Player player = getConnection().getActivePlayer();
-		if (MovementModifierState.DEBUG) {
-			log.info("MOVEDEBUG packet {}: {}, serverPos={}/{}/{}, serverHeading={}, isInMove={}", player.getName(), this, player.getX(), player.getY(),
-				player.getZ(), player.getHeading(), player.getMoveController().isInMove());
-		}
 		if (player.isDead() || player.getEffectController().isUnderFear() || player.getEffectController().isConfused()) { // just in case of bad timing
-			if (MovementModifierState.DEBUG)
-				log.info("MOVEDEBUG packet {}: IGNORED (dead, feared or confused)", player.getName());
 			return;
 		}
 		if (handleBogusPacket(player)) {
-			if (MovementModifierState.DEBUG)
-				log.info("MOVEDEBUG packet {}: IGNORED (bogus packet)", player.getName());
 			return;
 		}
 
@@ -124,8 +108,6 @@ public class CM_MOVE extends AionClientPacket {
 						World.getInstance().updatePosition(player, x2, y2, z2, heading);
 						m.onMoveFromClient();
 						PacketSendUtility.broadcastToSightedPlayers(player, new SM_POSITION(player), true);
-						if (MovementModifierState.DEBUG)
-							log.info("MOVEDEBUG packet {}: handled as teleportation mode move", player.getName());
 						return;
 					}
 				} else {
@@ -152,14 +134,10 @@ public class CM_MOVE extends AionClientPacket {
 
 		if (!AntiHackService.canMove(player, x, y, z, type)) {
 			player.getMoveController().setIsJumping(false);
-			if (MovementModifierState.DEBUG)
-				log.info("MOVEDEBUG packet {}: IGNORED (rejected by AntiHackService)", player.getName());
 			return;
 		}
 
 		if (!player.isSpawned()) { // should be checked as late as possible, to prevent false warnings from World.updatePosition
-			if (MovementModifierState.DEBUG)
-				log.info("MOVEDEBUG packet {}: IGNORED (not spawned)", player.getName());
 			return;
 		}
 		if (player.isProtectionActive() && (player.getX() != x || player.getY() != y || player.getZ() > z + 0.5f))
@@ -173,8 +151,6 @@ public class CM_MOVE extends AionClientPacket {
 			|| type == MovementMask.IMMEDIATE)
 			PacketSendUtility.broadcastToSightedPlayers(player, new SM_MOVE(player));
 
-		if (MovementModifierState.DEBUG && (type & MovementMask.FALL) != MovementMask.FALL)
-			log.info("MOVEDEBUG packet {}: not falling anymore (landing check follows)", player.getName());
 		if ((type & MovementMask.FALL) == MovementMask.FALL) {
 			player.getFlyController().onStopGliding();
 			m.updateFalling(z);

--- a/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_MOVE.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_MOVE.java
@@ -76,12 +76,11 @@ public class CM_MOVE extends AionClientPacket {
 	@Override
 	protected void runImpl() {
 		Player player = getConnection().getActivePlayer();
-		if (player.isDead() || player.getEffectController().isUnderFear() || player.getEffectController().isConfused()) { // just in case of bad timing
+		if (player.isDead() || player.getEffectController().isUnderFear() || player.getEffectController().isConfused())  // just in case of bad timing
 			return;
-		}
-		if (handleBogusPacket(player)) {
+
+		if (handleBogusPacket(player))
 			return;
-		}
 
 		PlayerMoveController m = player.getMoveController();
 		boolean jumping = false;
@@ -137,9 +136,8 @@ public class CM_MOVE extends AionClientPacket {
 			return;
 		}
 
-		if (!player.isSpawned()) { // should be checked as late as possible, to prevent false warnings from World.updatePosition
+		if (!player.isSpawned())  // should be checked as late as possible, to prevent false warnings from World.updatePosition
 			return;
-		}
 		if (player.isProtectionActive() && (player.getX() != x || player.getY() != y || player.getZ() > z + 0.5f))
 			player.getController().stopProtectionActiveTask();
 		player.getMoveController().setIsJumping(jumping);

--- a/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
+++ b/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
@@ -4,8 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.aionemu.commons.utils.Rnd;
 import com.aionemu.gameserver.configs.main.FallDamageConfig;
@@ -43,8 +41,6 @@ import com.aionemu.gameserver.world.WorldMapInstance;
  * @author ATracer, alexa026, Neon
  */
 public class StatFunctions {
-
-	private static final Logger log = LoggerFactory.getLogger(StatFunctions.class);
 
 	/**
 	 * @param maxLevelInRange
@@ -639,58 +635,59 @@ public class StatFunctions {
 		return fallDamage;
 	}
 
+	/**
+	 * Movement modifier table, indexed by move state (see {@link MovementModifierState.MoveState}) and by the column constants below.<br>
+	 * The combined states are authored by hand rather than derived from their parts: forward combined with anything else loses its defense penalties,
+	 * and having all three active cancels every modifier.
+	 */
+	private static final int[][] MOVEMENT_MODIFIERS = {
+		//    atk%  def%  elem  parry  block  dodge  crit
+		{        0,    0,    0,     0,     0,     0,    0 }, // 0: not moving
+		{       10,  -20,  -50,     0,     0,     0,    0 }, // 1: forward
+		{      -20,    0,    0,   500,   500,     0,    0 }, // 2: backward
+		{       10,    0,    0,   500,   500,     0,    0 }, // 3: forward + backward
+		{      -20,    0,    0,     0,     0,   300,    0 }, // 4: sideways
+		{       10,    0,    0,     0,     0,   300,    0 }, // 5: forward + sideways
+		{      -20,    0,    0,   500,   500,   300,    0 }, // 6: backward + sideways
+		{        0,    0,    0,     0,     0,     0,    0 }, // 7: forward + backward + sideways
+	};
+
+	private static final int COLUMN_ATTACK = 0, COLUMN_DEFENSE = 1, COLUMN_ELEMENTAL_DEFENSE = 2, COLUMN_PARRY = 3, COLUMN_BLOCK = 4,
+		COLUMN_DODGE = 5;
+
 	public static float adjustStatByMovementModifier(Creature creature, StatEnum stat, float value) {
-		if (!(creature instanceof Player player))
+		if (stat == null || !(creature instanceof Player player))
 			return value;
-		MovementModifierDirection movementDirection = player.getMoveController().getMovementDirection();
-		float adjustedValue = adjustStatByMovementModifier(movementDirection, stat, value);
-		if (MovementModifierState.DEBUG && (stat == StatEnum.PHYSICAL_ATTACK || stat == StatEnum.MAGICAL_ATTACK)) {
-			log.info("MOVEDEBUG damage {}: {} {} => {} (direction {})", player.getName(), stat, value, adjustedValue, movementDirection);
-		}
-		return adjustedValue;
+		int moveState = player.getMoveController().getMoveState();
+		if (moveState == MovementModifierState.MoveState.NONE)
+			return value;
+		return adjustStatByMoveState(moveState, stat, value);
 	}
 
-	public static float adjustStatByMovementModifier(MovementModifierDirection movementDirection, StatEnum stat, float value) {
-		if (stat == null)
-			return value;
+	static float adjustStatByMoveState(int moveState, StatEnum stat, float value) {
+		int[] modifiers = MOVEMENT_MODIFIERS[moveState];
+		return switch (stat) {
+			case PHYSICAL_ATTACK, MAGICAL_ATTACK -> value * (1 + modifiers[COLUMN_ATTACK] / 100f);
+			case PHYSICAL_DEFENSE, MAGICAL_DEFEND -> value * (1 + modifiers[COLUMN_DEFENSE] / 100f);
+			case FIRE_RESISTANCE, EARTH_RESISTANCE, WATER_RESISTANCE, WIND_RESISTANCE, LIGHT_RESISTANCE, DARK_RESISTANCE ->
+				value + modifiers[COLUMN_ELEMENTAL_DEFENSE];
+			case PARRY -> value + modifiers[COLUMN_PARRY];
+			case BLOCK -> value + modifiers[COLUMN_BLOCK];
+			case EVASION -> value + modifiers[COLUMN_DODGE];
+			default -> value;
+		};
+	}
 
-		// https://web.archive.org/web/20170429204823/gameguide.na.aiononline.com/aion/Combat
-		switch (movementDirection) {
-			case FORWARD:
-				switch (stat) {
-					case PHYSICAL_ATTACK:
-					case MAGICAL_ATTACK:
-						return value * 1.1f; // verified on 4.6 PTS
-					case FIRE_RESISTANCE, EARTH_RESISTANCE, WATER_RESISTANCE, WIND_RESISTANCE, LIGHT_RESISTANCE, DARK_RESISTANCE:
-						return value - 50; // verified on 4.6 PTS
-					case MAGICAL_DEFEND, PHYSICAL_DEFENSE:
-						return value * 0.8f; // verified on 4.6 PTS
-				}
-				break;
-			case SIDEWAYS:
-				switch (stat) {
-					case PHYSICAL_ATTACK:
-					case MAGICAL_ATTACK:
-					case SPEED:
-						return value * 0.8f; // verified on 4.6 PTS
-					case EVASION:
-						return value + 300;
-				}
-				break;
-			case BACKWARD:
-				switch (stat) {
-					case PHYSICAL_ATTACK:
-					case MAGICAL_ATTACK:
-						return value * 0.8f; // verified on 4.6 PTS
-					case SPEED:
-						return value * 0.6f; // verified on 4.6 PTS
-					case PARRY:
-					case BLOCK:
-						return value + 500;
-				}
-				break;
-		}
-		return value;
+	/**
+	 * Movement speed is not part of the modifier table above. It stays a plain per direction factor and is applied instantly, without the activation
+	 * and deactivation delays of the combat modifiers.
+	 */
+	public static float adjustSpeedByMovementModifier(MovementModifierDirection movementDirection, float speed) {
+		return switch (movementDirection) {
+			case SIDEWAYS -> speed * 0.8f;
+			case BACKWARD -> speed * 0.6f;
+			default -> speed;
+		};
 	}
 
 	private static float getNpcLevelDiffMod(Creature target, Creature attacker) {

--- a/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
+++ b/game-server/src/com/aionemu/gameserver/utils/stats/StatFunctions.java
@@ -4,12 +4,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.aionemu.commons.utils.Rnd;
 import com.aionemu.gameserver.configs.main.FallDamageConfig;
 import com.aionemu.gameserver.configs.main.RatesConfig;
 import com.aionemu.gameserver.controllers.attack.AttackResult;
 import com.aionemu.gameserver.controllers.attack.AttackStatus;
+import com.aionemu.gameserver.controllers.movement.MovementModifierDirection;
+import com.aionemu.gameserver.controllers.movement.MovementModifierState;
 import com.aionemu.gameserver.controllers.observer.AttackerCriticalStatus;
 import com.aionemu.gameserver.model.SkillElement;
 import com.aionemu.gameserver.model.gameobjects.*;
@@ -39,6 +43,8 @@ import com.aionemu.gameserver.world.WorldMapInstance;
  * @author ATracer, alexa026, Neon
  */
 public class StatFunctions {
+
+	private static final Logger log = LoggerFactory.getLogger(StatFunctions.class);
 
 	/**
 	 * @param maxLevelInRange
@@ -634,11 +640,22 @@ public class StatFunctions {
 	}
 
 	public static float adjustStatByMovementModifier(Creature creature, StatEnum stat, float value) {
-		if (!(creature instanceof Player player) || stat == null)
+		if (!(creature instanceof Player player))
+			return value;
+		MovementModifierDirection movementDirection = player.getMoveController().getMovementDirection();
+		float adjustedValue = adjustStatByMovementModifier(movementDirection, stat, value);
+		if (MovementModifierState.DEBUG && (stat == StatEnum.PHYSICAL_ATTACK || stat == StatEnum.MAGICAL_ATTACK)) {
+			log.info("MOVEDEBUG damage {}: {} {} => {} (direction {})", player.getName(), stat, value, adjustedValue, movementDirection);
+		}
+		return adjustedValue;
+	}
+
+	public static float adjustStatByMovementModifier(MovementModifierDirection movementDirection, StatEnum stat, float value) {
+		if (stat == null)
 			return value;
 
 		// https://web.archive.org/web/20170429204823/gameguide.na.aiononline.com/aion/Combat
-		switch (player.getMoveController().getMovementDirection()) {
+		switch (movementDirection) {
 			case FORWARD:
 				switch (stat) {
 					case PHYSICAL_ATTACK:

--- a/game-server/test/com/aionemu/gameserver/controllers/movement/MovementDirectionTest.java
+++ b/game-server/test/com/aionemu/gameserver/controllers/movement/MovementDirectionTest.java
@@ -1,0 +1,70 @@
+package com.aionemu.gameserver.controllers.movement;
+
+import static com.aionemu.gameserver.controllers.movement.MovementModifierDirection.*;
+import static com.aionemu.gameserver.controllers.movement.PlayableMoveController.calculateDirection;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the sector classification of the movement direction. Headings are client headings: 120 units of 3° each.
+ */
+class MovementDirectionTest {
+
+	private static final byte UNITS_PER_TURN = 120;
+
+	/**
+	 * @param offset Units to the left (negative) or right (positive) of where the character looks.
+	 */
+	private static MovementModifierDirection directionAt(int ownHeading, int offset) {
+		byte destinationHeading = (byte) (((ownHeading + offset) % UNITS_PER_TURN + UNITS_PER_TURN) % UNITS_PER_TURN);
+		return calculateDirection(destinationHeading, (byte) ownHeading);
+	}
+
+	@Test
+	void testStraightAhead() {
+		for (int ownHeading = 0; ownHeading < UNITS_PER_TURN; ownHeading++)
+			assertEquals(FORWARD, directionAt(ownHeading, 0));
+	}
+
+	@Test
+	void testDiagonalsAreForwardAndSymmetric() {
+		// W+D and W+A are 15 units off in either direction and must both count as forward, from every heading
+		for (int ownHeading = 0; ownHeading < UNITS_PER_TURN; ownHeading++) {
+			assertEquals(FORWARD, directionAt(ownHeading, 15), "right diagonal at heading " + ownHeading);
+			assertEquals(FORWARD, directionAt(ownHeading, -15), "left diagonal at heading " + ownHeading);
+		}
+	}
+
+	@Test
+	void testSectorBoundaries() {
+		assertEquals(FORWARD, directionAt(0, 15)); // 45°, still forward
+		assertEquals(SIDEWAYS, directionAt(0, 16)); // 48°
+		assertEquals(SIDEWAYS, directionAt(0, 44)); // 132°
+		assertEquals(BACKWARD, directionAt(0, 45)); // 135°
+		assertEquals(BACKWARD, directionAt(0, 60)); // 180°
+	}
+
+	@Test
+	void testEveryOffsetIsMirrored() {
+		for (int ownHeading = 0; ownHeading < UNITS_PER_TURN; ownHeading += 7) {
+			for (int offset = 0; offset <= 60; offset++)
+				assertEquals(directionAt(ownHeading, offset), directionAt(ownHeading, -offset),
+					"asymmetric at heading " + ownHeading + ", offset " + offset);
+		}
+	}
+
+	@Test
+	void testStrafingIsSideways() {
+		for (int ownHeading = 0; ownHeading < UNITS_PER_TURN; ownHeading++) {
+			assertEquals(SIDEWAYS, directionAt(ownHeading, 30)); // 90°
+			assertEquals(SIDEWAYS, directionAt(ownHeading, -30));
+		}
+	}
+
+	@Test
+	void testRunningBackwards() {
+		for (int ownHeading = 0; ownHeading < UNITS_PER_TURN; ownHeading++)
+			assertEquals(BACKWARD, directionAt(ownHeading, 60)); // 180°
+	}
+}

--- a/game-server/test/com/aionemu/gameserver/controllers/movement/MovementModifierStateTest.java
+++ b/game-server/test/com/aionemu/gameserver/controllers/movement/MovementModifierStateTest.java
@@ -1,12 +1,12 @@
 package com.aionemu.gameserver.controllers.movement;
 
-import static com.aionemu.gameserver.controllers.movement.MovementModifierState.Direction.*;
+import static com.aionemu.gameserver.controllers.movement.MovementModifierState.MoveState.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests the retail movement modifier timings documented in https://github.com/beyond-aion/aion-server/issues/102
+ * Tests the activation and deactivation timing of the movement modifier state machine.
  */
 class MovementModifierStateTest {
 
@@ -14,175 +14,123 @@ class MovementModifierStateTest {
 
 	@Test
 	void testActivationDelay() {
-		state.onMove(FORWARD, 0);
-		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(0));
-		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(849));
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(850));
+		state.setMoveState(FORWARD, 0);
+		assertEquals(NONE, state.getMoveState(0));
+		assertEquals(NONE, state.getMoveState(666)); // the delay must be exceeded, not just reached
+		assertEquals(FORWARD, state.getMoveState(667));
 	}
 
 	@Test
 	void testModifierStaysActiveWhileMoving() {
 		for (long now = 0; now <= 100_000; now += 500) // the client sends position updates about every 672ms while moving
-			state.onMove(FORWARD, now);
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(100_000));
+			state.setMoveState(FORWARD, now);
+		assertEquals(FORWARD, state.getMoveState(100_000));
 	}
 
 	@Test
-	void testMovementEndsWithoutUpdates() {
-		// we never learn about the end of the movement (e.g. connection loss), so it must not stay active forever
-		state.onMove(FORWARD, 0);
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(2000)); // movement assumed to have ended at 1000
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(2349));
-		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(2350));
+	void testContinuedMovementDoesNotRestartTheTimer() {
+		state.setMoveState(FORWARD, 0);
+		state.setMoveState(FORWARD, 600); // same direction, so the activation timer keeps running
+		assertEquals(FORWARD, state.getMoveState(667));
 	}
 
 	@Test
 	void testDeactivationDelay() {
-		state.onMove(BACKWARD, 0);
-		state.onStop(1000);
-		assertEquals(MovementModifierDirection.BACKWARD, state.getModifierDirection(1000));
-		assertEquals(MovementModifierDirection.BACKWARD, state.getModifierDirection(2349));
-		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(2350));
+		state.setMoveState(BACKWARD, 0);
+		state.setMoveState(NONE, 1000); // activated, so it starts fading out
+		assertEquals(BACKWARD, state.getMoveState(1000));
+		assertEquals(BACKWARD, state.getMoveState(2331));
+		assertEquals(NONE, state.getMoveState(2332));
+	}
+
+	@Test
+	void testMovementTooShortToActivateIsDiscarded() {
+		state.setMoveState(FORWARD, 0);
+		state.setMoveState(NONE, 666); // interrupted before activation, so nothing is carried over
+		assertEquals(NONE, state.getMoveState(666));
+		assertEquals(NONE, state.getMoveState(5000));
 	}
 
 	@Test
 	void testActivationProgressDoesNotAccumulate() {
-		state.onMove(FORWARD, 0);
-		state.onStop(700); // interrupted before activation
-		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(700));
-		state.onMove(FORWARD, 800);
-		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(1450)); // 650 ms of the new attempt
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(1650)); // 850 ms of the new attempt
+		state.setMoveState(FORWARD, 0);
+		state.setMoveState(NONE, 600); // interrupted before activation
+		state.setMoveState(FORWARD, 700);
+		assertEquals(NONE, state.getMoveState(1300)); // 600 ms of the new attempt
+		assertEquals(FORWARD, state.getMoveState(1367)); // 667 ms of the new attempt
 	}
 
 	@Test
 	void testActiveModifierFadesOutWhileMovingIntoAnotherDirection() {
-		state.onMove(FORWARD, 0);
-		state.onMove(LEFT, 1000); // forward is active and starts fading out
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(1800)); // forward active, sideways still pending
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(2000)); // both active, forward has priority
-		assertEquals(MovementModifierDirection.SIDEWAYS, state.getModifierDirection(2350)); // forward faded out after 1350 ms
+		state.setMoveState(FORWARD, 0);
+		state.setMoveState(SIDEWAYS, 1000); // forward was active and starts fading out
+		assertEquals(FORWARD, state.getMoveState(1500)); // sideways still pending
+		assertEquals(FORWARD | SIDEWAYS, state.getMoveState(1667)); // both apply
+		assertEquals(SIDEWAYS, state.getMoveState(2332)); // forward faded out after 1332 ms
 	}
 
 	@Test
-	void testForwardHasPriorityOverAlreadyActiveSideways() {
-		state.onMove(RIGHT, 0);
-		state.onMove(FORWARD, 1000);
-		assertEquals(MovementModifierDirection.SIDEWAYS, state.getModifierDirection(1500)); // forward still pending
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(1850)); // forward activated, sideways still fading
+	void testAtMostTwoDirectionsApply() {
+		state.setMoveState(FORWARD, 0);
+		state.setMoveState(BACKWARD, 700); // forward fades out until 2032
+		state.setMoveState(SIDEWAYS, 1400); // backward fades out until 2732, replacing forward as the confirmed one
+		assertEquals(BACKWARD | SIDEWAYS, state.getMoveState(2100)); // forward is gone although its fade would still be running
+		assertEquals(SIDEWAYS, state.getMoveState(2732));
 	}
 
 	@Test
-	void testSidewaysHasPriorityOverBackward() {
-		state.onMove(BACKWARD, 0);
-		state.onMove(LEFT, 1000); // backward is active and starts fading out
-		assertEquals(MovementModifierDirection.BACKWARD, state.getModifierDirection(1800)); // sideways still pending
-		assertEquals(MovementModifierDirection.SIDEWAYS, state.getModifierDirection(1900)); // both active, sideways has priority
-		assertEquals(MovementModifierDirection.SIDEWAYS, state.getModifierDirection(2400)); // backward faded out
-	}
-
-	@Test
-	void testBackwardDoesNotOverrideActiveForward() {
-		state.onMove(FORWARD, 0);
-		state.onMove(BACKWARD, 1000);
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(1900)); // both active, forward has priority
-		assertEquals(MovementModifierDirection.BACKWARD, state.getModifierDirection(2350)); // forward faded out
+	void testSwitchingBetweenLeftAndRightDoesNotRestartActivation() {
+		// left and right map to the same value, so alternating between them is not a direction change
+		for (long now = 0; now < 3000; now += 300)
+			state.setMoveState(SIDEWAYS, now);
+		assertEquals(SIDEWAYS, state.getMoveState(667));
 	}
 
 	@Test
 	void testIntermittentMovementNeverActivates() {
 		long now = 0;
 		for (int i = 0; i < 10; i++) { // repeatedly moving forward and stopping must not activate anything, no matter for how long
-			state.onMove(FORWARD, now);
+			state.setMoveState(FORWARD, now);
 			now += 600;
-			state.onStop(now);
+			state.setMoveState(NONE, now);
 			now += 100;
-			assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(now));
+			assertEquals(NONE, state.getMoveState(now));
 		}
 	}
 
 	@Test
-	void testActivationDelayIsNotResetByMovementContinuations() {
-		// the client keeps sending movement packets without a destination (mask IMMEDIATE) while running, they must count as continued movement
-		state.onMove(FORWARD, 0);
-		state.onMove(FORWARD, 672);
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(850));
+	void testResumedMovementRestartsActivationButKeepsTheFadeOut() {
+		state.setMoveState(FORWARD, 0);
+		state.setMoveState(NONE, 1000); // forward is active and fades out until 2332
+		state.setMoveState(FORWARD, 1200); // resuming does not reactivate it, the pending timer starts over
+		assertEquals(FORWARD, state.getMoveState(1500)); // still applied through the fade out
+		assertEquals(FORWARD, state.getMoveState(2332)); // fade ended, but the new attempt has activated by now
+		assertEquals(FORWARD, state.getMoveState(5000)); // still moving
 	}
 
 	@Test
-	void testFrequentSidewaysSwitchingPreventsActivation() {
-		long now = 0;
-		for (int i = 0; i < 10; i++) {
-			state.onMove(i % 2 == 0 ? LEFT : RIGHT, now);
-			now += 500;
-			assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(now));
-		}
-	}
-
-	@Test
-	void testResumedMovementDoesNotCancelFadeOut() {
-		state.onMove(FORWARD, 0);
-		state.onStop(1000); // forward is active and fades out until 2350
-		state.onMove(FORWARD, 1200); // resuming does not reactivate it, but the fade out continues
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(2000));
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(2050)); // reactivated after 850 ms of the new attempt
-		state.onMove(FORWARD, 3000);
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(3000)); // still moving, so it stays active beyond 2350
-	}
-
-	@Test
-	void testStopDoesNotDiscardFadingOutDirections() {
-		state.onMove(FORWARD, 0);
-		state.onMove(LEFT, 1000); // forward starts fading out, sideways is pending
-		state.onStop(1800);
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(1800)); // sideways never activated, forward keeps fading out
-		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(2350));
+	void testStopDoesNotDiscardFadingOutDirection() {
+		state.setMoveState(FORWARD, 0);
+		state.setMoveState(SIDEWAYS, 1000); // forward starts fading out, sideways is pending
+		state.setMoveState(NONE, 1500); // sideways never activated and is discarded
+		assertEquals(FORWARD, state.getMoveState(1500));
+		assertEquals(FORWARD, state.getMoveState(2331));
+		assertEquals(NONE, state.getMoveState(2332));
 	}
 
 	@Test
 	void testRepeatedStopsKeepFadingOut() {
-		state.onMove(FORWARD, 0);
+		state.setMoveState(FORWARD, 0);
 		for (long now = 1000; now < 1050; now += 6) // the client sends several stop packets in a row, they must not cut the fade out short
-			state.onStop(now);
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(2349));
-		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(2350));
+			state.setMoveState(NONE, now);
+		assertEquals(FORWARD, state.getMoveState(2331));
+		assertEquals(NONE, state.getMoveState(2332));
 	}
 
 	@Test
-	void testJumpActivatesDirectionOnLanding() {
-		state.onMove(FORWARD, 0);
-		state.commitCurrentDirection(300); // landed after a short jump forward
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(300));
-		state.onStop(400);
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(1749)); // fades out normally
-		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(1750));
-	}
-
-	@Test
-	void testJumpFromStandstillActivatesOnLandingStopPacket() {
-		// the landing packet is a stop packet, so the direction must be committed before the movement ends
-		state.onMove(FORWARD, 0);
-		state.commitCurrentDirection(748);
-		state.onStop(748);
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(748));
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(2097));
-		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(2098));
-	}
-
-	@Test
-	void testJumpDoesNotShortenAlreadyActiveDirection() {
-		state.onMove(FORWARD, 0);
-		state.commitCurrentDirection(2000); // jumping while the bonus is already active must not affect it
-		state.onStop(2500);
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(3849));
-		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(3850));
-	}
-
-	@Test
-	void testUninterruptedTurningKeepsModifierActive() {
-		state.onMove(FORWARD, 0);
-		for (long now = 100; now < 5000; now += 100)
-			state.onMove(FORWARD, now); // move packets while running straight ahead must not reset the timer
-		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(5000));
+	void testNoIdleTimeout() {
+		// there is no safety net for missing packets: without a stop packet the direction simply stays applied
+		state.setMoveState(FORWARD, 0);
+		assertEquals(FORWARD, state.getMoveState(100_000));
 	}
 }

--- a/game-server/test/com/aionemu/gameserver/controllers/movement/MovementModifierStateTest.java
+++ b/game-server/test/com/aionemu/gameserver/controllers/movement/MovementModifierStateTest.java
@@ -1,0 +1,188 @@
+package com.aionemu.gameserver.controllers.movement;
+
+import static com.aionemu.gameserver.controllers.movement.MovementModifierState.Direction.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the retail movement modifier timings documented in https://github.com/beyond-aion/aion-server/issues/102
+ */
+class MovementModifierStateTest {
+
+	private final MovementModifierState state = new MovementModifierState();
+
+	@Test
+	void testActivationDelay() {
+		state.onMove(FORWARD, 0);
+		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(0));
+		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(849));
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(850));
+	}
+
+	@Test
+	void testModifierStaysActiveWhileMoving() {
+		for (long now = 0; now <= 100_000; now += 500) // the client sends position updates about every 672ms while moving
+			state.onMove(FORWARD, now);
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(100_000));
+	}
+
+	@Test
+	void testMovementEndsWithoutUpdates() {
+		// we never learn about the end of the movement (e.g. connection loss), so it must not stay active forever
+		state.onMove(FORWARD, 0);
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(2000)); // movement assumed to have ended at 1000
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(2349));
+		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(2350));
+	}
+
+	@Test
+	void testDeactivationDelay() {
+		state.onMove(BACKWARD, 0);
+		state.onStop(1000);
+		assertEquals(MovementModifierDirection.BACKWARD, state.getModifierDirection(1000));
+		assertEquals(MovementModifierDirection.BACKWARD, state.getModifierDirection(2349));
+		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(2350));
+	}
+
+	@Test
+	void testActivationProgressDoesNotAccumulate() {
+		state.onMove(FORWARD, 0);
+		state.onStop(700); // interrupted before activation
+		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(700));
+		state.onMove(FORWARD, 800);
+		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(1450)); // 650 ms of the new attempt
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(1650)); // 850 ms of the new attempt
+	}
+
+	@Test
+	void testActiveModifierFadesOutWhileMovingIntoAnotherDirection() {
+		state.onMove(FORWARD, 0);
+		state.onMove(LEFT, 1000); // forward is active and starts fading out
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(1800)); // forward active, sideways still pending
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(2000)); // both active, forward has priority
+		assertEquals(MovementModifierDirection.SIDEWAYS, state.getModifierDirection(2350)); // forward faded out after 1350 ms
+	}
+
+	@Test
+	void testForwardHasPriorityOverAlreadyActiveSideways() {
+		state.onMove(RIGHT, 0);
+		state.onMove(FORWARD, 1000);
+		assertEquals(MovementModifierDirection.SIDEWAYS, state.getModifierDirection(1500)); // forward still pending
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(1850)); // forward activated, sideways still fading
+	}
+
+	@Test
+	void testSidewaysHasPriorityOverBackward() {
+		state.onMove(BACKWARD, 0);
+		state.onMove(LEFT, 1000); // backward is active and starts fading out
+		assertEquals(MovementModifierDirection.BACKWARD, state.getModifierDirection(1800)); // sideways still pending
+		assertEquals(MovementModifierDirection.SIDEWAYS, state.getModifierDirection(1900)); // both active, sideways has priority
+		assertEquals(MovementModifierDirection.SIDEWAYS, state.getModifierDirection(2400)); // backward faded out
+	}
+
+	@Test
+	void testBackwardDoesNotOverrideActiveForward() {
+		state.onMove(FORWARD, 0);
+		state.onMove(BACKWARD, 1000);
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(1900)); // both active, forward has priority
+		assertEquals(MovementModifierDirection.BACKWARD, state.getModifierDirection(2350)); // forward faded out
+	}
+
+	@Test
+	void testIntermittentMovementNeverActivates() {
+		long now = 0;
+		for (int i = 0; i < 10; i++) { // repeatedly moving forward and stopping must not activate anything, no matter for how long
+			state.onMove(FORWARD, now);
+			now += 600;
+			state.onStop(now);
+			now += 100;
+			assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(now));
+		}
+	}
+
+	@Test
+	void testActivationDelayIsNotResetByMovementContinuations() {
+		// the client keeps sending movement packets without a destination (mask IMMEDIATE) while running, they must count as continued movement
+		state.onMove(FORWARD, 0);
+		state.onMove(FORWARD, 672);
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(850));
+	}
+
+	@Test
+	void testFrequentSidewaysSwitchingPreventsActivation() {
+		long now = 0;
+		for (int i = 0; i < 10; i++) {
+			state.onMove(i % 2 == 0 ? LEFT : RIGHT, now);
+			now += 500;
+			assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(now));
+		}
+	}
+
+	@Test
+	void testResumedMovementDoesNotCancelFadeOut() {
+		state.onMove(FORWARD, 0);
+		state.onStop(1000); // forward is active and fades out until 2350
+		state.onMove(FORWARD, 1200); // resuming does not reactivate it, but the fade out continues
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(2000));
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(2050)); // reactivated after 850 ms of the new attempt
+		state.onMove(FORWARD, 3000);
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(3000)); // still moving, so it stays active beyond 2350
+	}
+
+	@Test
+	void testStopDoesNotDiscardFadingOutDirections() {
+		state.onMove(FORWARD, 0);
+		state.onMove(LEFT, 1000); // forward starts fading out, sideways is pending
+		state.onStop(1800);
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(1800)); // sideways never activated, forward keeps fading out
+		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(2350));
+	}
+
+	@Test
+	void testRepeatedStopsKeepFadingOut() {
+		state.onMove(FORWARD, 0);
+		for (long now = 1000; now < 1050; now += 6) // the client sends several stop packets in a row, they must not cut the fade out short
+			state.onStop(now);
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(2349));
+		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(2350));
+	}
+
+	@Test
+	void testJumpActivatesDirectionOnLanding() {
+		state.onMove(FORWARD, 0);
+		state.commitCurrentDirection(300); // landed after a short jump forward
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(300));
+		state.onStop(400);
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(1749)); // fades out normally
+		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(1750));
+	}
+
+	@Test
+	void testJumpFromStandstillActivatesOnLandingStopPacket() {
+		// the landing packet is a stop packet, so the direction must be committed before the movement ends
+		state.onMove(FORWARD, 0);
+		state.commitCurrentDirection(748);
+		state.onStop(748);
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(748));
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(2097));
+		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(2098));
+	}
+
+	@Test
+	void testJumpDoesNotShortenAlreadyActiveDirection() {
+		state.onMove(FORWARD, 0);
+		state.commitCurrentDirection(2000); // jumping while the bonus is already active must not affect it
+		state.onStop(2500);
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(3849));
+		assertEquals(MovementModifierDirection.NONE, state.getModifierDirection(3850));
+	}
+
+	@Test
+	void testUninterruptedTurningKeepsModifierActive() {
+		state.onMove(FORWARD, 0);
+		for (long now = 100; now < 5000; now += 100)
+			state.onMove(FORWARD, now); // move packets while running straight ahead must not reset the timer
+		assertEquals(MovementModifierDirection.FORWARD, state.getModifierDirection(5000));
+	}
+}

--- a/game-server/test/com/aionemu/gameserver/utils/stats/MovementModifierTableTest.java
+++ b/game-server/test/com/aionemu/gameserver/utils/stats/MovementModifierTableTest.java
@@ -1,0 +1,77 @@
+package com.aionemu.gameserver.utils.stats;
+
+import static com.aionemu.gameserver.controllers.movement.MovementModifierState.MoveState.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.aionemu.gameserver.model.stats.container.StatEnum;
+
+/**
+ * Pins the movement modifier table, so that a change to it is deliberate.
+ */
+class MovementModifierTableTest {
+
+	private static void assertModifiers(int moveState, float attackFactor, float defenseFactor, int elementalDefense, int parry, int block,
+										int dodge) {
+		assertEquals(1000 * attackFactor, adjust(moveState, StatEnum.PHYSICAL_ATTACK), 0.01f);
+		assertEquals(1000 * attackFactor, adjust(moveState, StatEnum.MAGICAL_ATTACK), 0.01f);
+		assertEquals(1000 * defenseFactor, adjust(moveState, StatEnum.PHYSICAL_DEFENSE), 0.01f);
+		assertEquals(1000 * defenseFactor, adjust(moveState, StatEnum.MAGICAL_DEFEND), 0.01f);
+		assertEquals(1000 + elementalDefense, adjust(moveState, StatEnum.FIRE_RESISTANCE), 0.01f);
+		assertEquals(1000 + parry, adjust(moveState, StatEnum.PARRY), 0.01f);
+		assertEquals(1000 + block, adjust(moveState, StatEnum.BLOCK), 0.01f);
+		assertEquals(1000 + dodge, adjust(moveState, StatEnum.EVASION), 0.01f);
+	}
+
+	private static float adjust(int moveState, StatEnum stat) {
+		return StatFunctions.adjustStatByMoveState(moveState, stat, 1000);
+	}
+
+	@Test
+	void testNotMoving() {
+		assertModifiers(NONE, 1f, 1f, 0, 0, 0, 0);
+	}
+
+	@Test
+	void testForward() {
+		assertModifiers(FORWARD, 1.1f, 0.8f, -50, 0, 0, 0);
+	}
+
+	@Test
+	void testBackward() {
+		assertModifiers(BACKWARD, 0.8f, 1f, 0, 500, 500, 0);
+	}
+
+	@Test
+	void testSideways() {
+		assertModifiers(SIDEWAYS, 0.8f, 1f, 0, 0, 0, 300);
+	}
+
+	@Test
+	void testForwardAndBackward() { // forward keeps its attack bonus but loses its defense penalties
+		assertModifiers(FORWARD | BACKWARD, 1.1f, 1f, 0, 500, 500, 0);
+	}
+
+	@Test
+	void testForwardAndSideways() {
+		assertModifiers(FORWARD | SIDEWAYS, 1.1f, 1f, 0, 0, 0, 300);
+	}
+
+	@Test
+	void testBackwardAndSideways() {
+		assertModifiers(BACKWARD | SIDEWAYS, 0.8f, 1f, 0, 500, 500, 300);
+	}
+
+	@Test
+	void testAllDirectionsCancelEachOther() {
+		assertModifiers(FORWARD | BACKWARD | SIDEWAYS, 1f, 1f, 0, 0, 0, 0);
+	}
+
+	@Test
+	void testUnaffectedStatsStayUnchanged() {
+		assertEquals(1000, adjust(FORWARD, StatEnum.SPEED), 0.01f); // speed is not part of the table, see adjustSpeedByMovementModifier
+		assertEquals(1000, adjust(FORWARD, StatEnum.PHYSICAL_CRITICAL), 0.01f);
+		assertEquals(1000, adjust(BACKWARD, StatEnum.MAGICAL_CRITICAL), 0.01f);
+	}
+}


### PR DESCRIPTION
Ported from the 4.6 pts instead of guessing from client recordings #102 :

- State machine is two slots (pending + confirmed), activation 666 ms, fade out 1332 ms, both exclusive. Was 850/1350 with per-direction timers (in doc).
- Effective state is confirmed|pending, so at most two directions apply and the all-three table row is unreachable.
- Left and right are one direction, so alternating between them no longer restarts activation.
- Sector check is CalcMoveState's integer arithmetic on client headings: forward is <= 15 units (45 deg), backward >= 45 units (135 deg). Was +/-67.5 / +/-112.5 in degrees, which is not equivalent: only the own heading is quantized there, so diagonals were misclassified on one side (W+D forward, W+A sideways).
- Modifiers come from retail table indexed by the move state, replacing the priority pick. Single-direction values are unchanged.