### PR TITLE
Fixed the tick count of periodic effects

### DIFF
--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/AbstractOverTimeEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/AbstractOverTimeEffect.java
@@ -1,6 +1,7 @@
 package com.aionemu.gameserver.skillengine.effect;
 
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -49,10 +50,12 @@ public abstract class AbstractOverTimeEffect extends EffectTemplate {
 		// TODO figure out what to do with such cases
 		if (checktime == 0)
 			return;
-		// Some skills have an effective duration of 2000 (see getDuration2) and a checktime of 1000 (e.g. Ripple of Purification).
-		// On retail, these skills are applied once instead of twice, so we slightly increase the initialDelay to prevent this from happening.
-		long initialDelay = 300 + checktime;
-		Future<?> task = ThreadPoolManager.getInstance().scheduleAtFixedRate(() -> onPeriodicAction(effect), initialDelay, checktime);
+		// effects without a duration (like toggle skills) tick until they get removed
+		AtomicInteger remainingTicks = new AtomicInteger(effect.getDuration() > 0 ? getTickCount(effect.getDuration()) : Integer.MAX_VALUE);
+		Future<?> task = ThreadPoolManager.getInstance().scheduleAtFixedRate(() -> {
+			if (remainingTicks.getAndDecrement() > 0)
+				onPeriodicAction(effect);
+		}, checktime, checktime);
 		effect.setPeriodicTask(task, position);
 	}
 
@@ -61,8 +64,26 @@ public abstract class AbstractOverTimeEffect extends EffectTemplate {
 			effect.getEffected().getEffectController().unsetAbnormal(abnormal);
 	}
 
-	@Override
-	public int getDuration2() {
-		return duration2 + 1000; // on retail these effects last one sec more than their template value of duration2
+	public int getChecktime() {
+		return checktime;
+	}
+
+	/**
+	 * Rounds the duration down to a whole number of ticks and adds one second on top. Ticking runs while more than one interval is left, so this is what
+	 * decides the tick count: a duration of 10000 with a checktime of 1000 yields ten ticks, and one of 1000 yields a single one.
+	 *
+	 * @param duration The duration after all multipliers have been applied.
+	 */
+	public long roundDurationToTicks(long duration) {
+		if (duration <= 0 || checktime <= 0)
+			return duration;
+		return duration + 1000 - duration % checktime;
+	}
+
+	/**
+	 * @return The number of ticks over the given duration: one per interval, minus the last one, since the effect ends before it can run.
+	 */
+	public int getTickCount(int duration) {
+		return duration <= 0 || checktime <= 0 ? 0 : (duration - 1) / checktime;
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
@@ -617,6 +617,16 @@ public class Effect implements StatOwner {
 			if (successEffects.isEmpty())
 				return;
 
+			if (duration == null) {
+				if (isToggle()) {
+					if (effector instanceof Player)
+						activateToggleSkill();
+					duration = skillTemplate.getToggleTimer();
+				} else {
+					duration = calculateEffectsDuration();
+				}
+			}
+
 			schedulePeriodicActions();
 
 			if (!successEffects.isEmpty()) {
@@ -627,15 +637,6 @@ public class Effect implements StatOwner {
 
 			broadcastHate();
 
-			if (duration == null) {
-				if (isToggle()) {
-					if (effector instanceof Player)
-						activateToggleSkill();
-					duration = skillTemplate.getToggleTimer();
-				} else {
-					duration = calculateEffectsDuration();
-				}
-			}
 			if (duration == 0)
 				return;
 			endTime = System.currentTimeMillis() + duration;
@@ -843,7 +844,17 @@ public class Effect implements StatOwner {
 	}
 
 	private int calculateEffectsDuration() {
-		long duration = calculateTemplateDuration();
+		EffectTemplate durationTemplate = null;
+		long duration = 0;
+		// the first effect with a duration > 0 sets the skill duration, longer durations of other effects are ignored (see 620 Armor of Attrition)
+		for (EffectTemplate et : successEffects.values()) {
+			long templateDuration = et.getDuration2() + ((long) et.getDuration1()) * getSkillLevel(); // some event skills would produce an int overflow
+			if (templateDuration > 0) {
+				durationTemplate = et;
+				duration = et.getRandomTime() > 0 ? templateDuration - Rnd.get(0, et.getRandomTime()) : templateDuration;
+				break;
+			}
+		}
 
 		if (getEffected() instanceof Player effectedPlayer) {
 			boolean isEffectorPlayer = (CustomConfig.COUNT_SUMMON_EFFECTS_FOR_CUMULATIVE_RESIST ? effector.getMaster() : effector) instanceof Player;
@@ -854,20 +865,9 @@ public class Effect implements StatOwner {
 				duration = duration * skillTemplate.getPvpDuration() / 100;
 			}
 		}
+		if (durationTemplate instanceof AbstractOverTimeEffect overTimeEffect)
+			duration = overTimeEffect.roundDurationToTicks(duration);
 		return (int) Math.min(Integer.MAX_VALUE, duration);
-	}
-
-	private long calculateTemplateDuration() {
-		// retail sets the first effect duration > 0 as the skill duration, ignoring longer durations of other effects (see 620 Armor of Attrition)
-		for (EffectTemplate et : successEffects.values()) {
-			long effectDuration = et.getDuration2() + ((long) et.getDuration1()) * getSkillLevel(); // some event skills would produce an int overflow
-			if (effectDuration > 0) {
-				if (et.getRandomTime() > 0)
-					effectDuration -= Rnd.get(0, et.getRandomTime());
-				return effectDuration;
-			}
-		}
-		return 0;
 	}
 
 	private long applyCumulativeResistDurationMultiplier(long duration, Player effected) {

--- a/game-server/test/com/aionemu/gameserver/skillengine/effect/OverTimeTickCountTest.java
+++ b/game-server/test/com/aionemu/gameserver/skillengine/effect/OverTimeTickCountTest.java
@@ -1,0 +1,68 @@
+package com.aionemu.gameserver.skillengine.effect;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.aionemu.gameserver.skillengine.model.Effect;
+
+/**
+ * Pins the tick count of periodic effects: the duration is rounded down to a whole number of intervals plus one second, and ticking then runs while
+ * more than one interval is left.
+ */
+class OverTimeTickCountTest {
+
+	private static AbstractOverTimeEffect effectWithChecktime(int checktime) {
+		AbstractOverTimeEffect effect = new AbstractOverTimeEffect() {
+
+			@Override
+			public void onPeriodicAction(Effect effect) {
+			}
+		};
+		effect.checktime = checktime;
+		return effect;
+	}
+
+	/** The number of ticks an effect with the given template duration ends up with, see {@link AbstractOverTimeEffect#startEffect}. */
+	private static int tickCount(int duration, int checktime) {
+		AbstractOverTimeEffect effect = effectWithChecktime(checktime);
+		return effect.getTickCount((int) effect.roundDurationToTicks(duration));
+	}
+
+	@Test
+	void testDurationIsRoundedDownToWholeTicksPlusOneSecond() {
+		assertEquals(11000, effectWithChecktime(1000).roundDurationToTicks(10000));
+		assertEquals(11000, effectWithChecktime(1000).roundDurationToTicks(10500)); // floored to 10000 first
+		assertEquals(3000, effectWithChecktime(2000).roundDurationToTicks(3500)); // floored to 2000, so this one shrinks
+		assertEquals(2000, effectWithChecktime(1000).roundDurationToTicks(1000));
+	}
+
+	@Test
+	void testDurationIsUntouchedWithoutAnInterval() {
+		assertEquals(10000, effectWithChecktime(0).roundDurationToTicks(10000));
+		assertEquals(0, effectWithChecktime(1000).roundDurationToTicks(0));
+		assertEquals(-5, effectWithChecktime(1000).roundDurationToTicks(-5));
+	}
+
+	@Test
+	void testTickCounts() {
+		assertEquals(1, tickCount(1000, 1000)); // Ripple of Purification: applied once, not twice
+		assertEquals(2, tickCount(2000, 1000));
+		assertEquals(10, tickCount(10000, 1000));
+		assertEquals(5, tickCount(10000, 2000));
+		assertEquals(21, tickCount(10000, 500));
+		assertEquals(3, tickCount(9000, 3000));
+	}
+
+	@Test
+	void testTickCountIgnoresTheRemainderOfAPartialInterval() {
+		assertEquals(10, tickCount(10500, 1000)); // not 11
+		assertEquals(1, tickCount(3500, 2000)); // not 2
+	}
+
+	@Test
+	void testEffectsWithoutADurationOrIntervalDontTick() {
+		assertEquals(0, effectWithChecktime(1000).getTickCount(0));
+		assertEquals(0, effectWithChecktime(0).getTickCount(10000));
+	}
+}


### PR DESCRIPTION
The duration has to be rounded down to a whole number of ticks with one second on top, and that has to happen after the resist and pvp multipliers, not before. We added a flat 1000 in `AbstractOverTimeEffect.getDuration2()` instead, which only matched when the duration was a multiple of `checktime` (10500/1000 ticked 11 times instead of 10, 3500/2000 twice instead of once).

Rounding properly also removes the need for the 300 ms nudge on the initial delay, which existed to stop a 1000/1000 effect from ticking twice.