### PR TITLE
FIX: Target change on Hide

### DIFF
--- a/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
@@ -553,7 +553,7 @@ public class AttackUtil {
 	public static void cancelCastOn(Creature target) {
 		target.getKnownList().forEachObject(visibleObject -> {
 			if (visibleObject instanceof Creature creature && visibleObject.getTarget() == target) {
-				if (creature.getCastingSkill() != null && creature.getCastingSkill().getFirstTarget().equals(target)) {
+				if (creature.getCastingSkill() != null && target.equals(creature.getCastingSkill().getFirstTarget())) {
 					if (isHostileTo(creature, target)) {
 						creature.getController().cancelCurrentSkill(null);
 					}

--- a/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/attack/AttackUtil.java
@@ -547,14 +547,27 @@ public class AttackUtil {
 
 		return AttackStatus.NORMALHIT;
 	}
-
+	
+	//If the target is an enemy and goes into hide, interrupt the cast.
+	//Do not interrupt casts on allies (heals/buffs in the group).
 	public static void cancelCastOn(Creature target) {
 		target.getKnownList().forEachObject(visibleObject -> {
 			if (visibleObject instanceof Creature creature && visibleObject.getTarget() == target) {
-				if (creature.getCastingSkill() != null && creature.getCastingSkill().getFirstTarget().equals(target))
-					creature.getController().cancelCurrentSkill(null);
+				if (creature.getCastingSkill() != null && creature.getCastingSkill().getFirstTarget().equals(target)) {
+					if (isHostileTo(creature, target)) {
+						creature.getController().cancelCurrentSkill(null);
+					}
+				}
 			}
 		});
+	}
+
+	private static boolean isHostileTo(Creature caster, Creature target) {
+		return switch (target) {
+			case Player p -> caster.isEnemyFrom(p);
+			case Npc n -> caster.isEnemyFrom(n);
+			default -> caster.isEnemyFrom(target);
+		};
 	}
 
 	/**


### PR DESCRIPTION
### Problem
When a target went Hide, casting was interrupted for *every* creature targeting it, including allies. As a result, heals and buffs on a group member who used Hide were cancelled along with hostile casts.

### Cause
`cancelCastOn` did not distinguish between hostile and friendly casters — any creature with the vanishing target as its first target had its skill
cancelled.

### Solution
Added a hostility check before cancelling. Only casts from creatures that are actually enemies of the target are interrupted; friendly casts (heals/buffs) continue as normal.

`isHostileTo` uses a switch over the target type so the correct `isEnemyFrom` overload is resolved for `Player` and `Npc`.

### Testing
- Ally casts a heal on a group member → member uses Hide → cast completes.
- Enemy casts an attack skill on a player → player uses Hide → cast is cancelled.