### PR TITLE
Check skill costs before the cast and cancel it when they cannot be paid

### DIFF
--- a/game-server/data/static_data/skills/skills.xsd
+++ b/game-server/data/static_data/skills/skills.xsd
@@ -340,6 +340,7 @@
 			<xs:extension base="Action">
 				<xs:attribute name="itemid" type="xs:int" use="required" />
 				<xs:attribute name="count" type="xs:int" use="required" />
+				<xs:attribute name="expendable" type="xs:boolean" default="true" />
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>

--- a/game-server/src/com/aionemu/gameserver/model/stats/container/CreatureLifeStats.java
+++ b/game-server/src/com/aionemu/gameserver/model/stats/container/CreatureLifeStats.java
@@ -94,7 +94,8 @@ public abstract class CreatureLifeStats<T extends Creature> {
 				return 0;
 
 			previousHp = currentHp;
-			currentHp = newHp = Math.min(currentHp, Math.max(currentHp - value, 0));
+			int minHp = type == TYPE.USED_HP ? 1 : 0; // a skill cost drains its caster down to 1 hp, it never kills him
+			currentHp = newHp = Math.clamp(currentHp - value, minHp, currentHp);
 			if (isDead()) {
 				currentMp = 0;
 				unsetIsAboutToDie();

--- a/game-server/src/com/aionemu/gameserver/skillengine/action/Action.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/action/Action.java
@@ -23,4 +23,13 @@ public abstract class Action {
 	 */
 	public abstract boolean act(Skill skill);
 
+	/**
+	 * Checks whether {@link #act(Skill)} could be performed, without performing it.
+	 *
+	 * @return True, if the action can be performed
+	 */
+	public boolean canAct(Skill skill) {
+		return true;
+	}
+
 }

--- a/game-server/src/com/aionemu/gameserver/skillengine/action/Action.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/action/Action.java
@@ -18,8 +18,6 @@ public abstract class Action {
 
 	/**
 	 * Perform action specified in template
-	 * 
-	 * @param env
 	 */
 	public abstract boolean act(Skill skill);
 

--- a/game-server/src/com/aionemu/gameserver/skillengine/action/DpUseAction.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/action/DpUseAction.java
@@ -22,14 +22,25 @@ public class DpUseAction extends Action {
 
 	@Override
 	public boolean act(Skill skill) {
-		Player effector = (Player) skill.getEffector();
-		int currentDp = effector.getCommonData().getDp();
-
+		if (!(skill.getEffector() instanceof Player player))
+			return true;
+		int currentDp = player.getCommonData().getDp(); // read once, setDp has no lower bound
 		if (currentDp <= 0 || currentDp < value) {
-			PacketSendUtility.sendPacket(effector, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_DP());
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_DP());
 			return false;
 		}
-		effector.getCommonData().setDp(currentDp - value);
+		player.getCommonData().setDp(currentDp - value);
 		return true;
+	}
+
+	@Override
+	public boolean canAct(Skill skill) {
+		if (!(skill.getEffector() instanceof Player player))
+			return true;
+		int currentDp = player.getCommonData().getDp();
+		if (currentDp > 0 && currentDp >= value)
+			return true;
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_DP());
+		return false;
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/skillengine/action/HpUseAction.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/action/HpUseAction.java
@@ -28,19 +28,30 @@ public class HpUseAction extends Action {
 
 	@Override
 	public boolean act(Skill skill) {
+		if (!canAct(skill))
+			return false;
 		Creature effector = skill.getEffector();
+		// npcs pass the check even when they cannot afford it and then pay what they have, down to 1 hp
+		effector.getLifeStats().reduceHp(SM_ATTACK_STATUS.TYPE.USED_HP, getCost(skill), 0, SM_ATTACK_STATUS.LOG.REGULAR, effector);
+		return true;
+	}
+
+	@Override
+	public boolean canAct(Skill skill) {
+		Creature effector = skill.getEffector();
+		if (!(effector instanceof Player player))
+			return true;
+		if (effector.getLifeStats().getCurrentHp() > getCost(skill)) // the cast may never be lethal
+			return true;
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_HP());
+		return false;
+	}
+
+	private int getCost(Skill skill) {
 		int valueWithDelta = value + delta * skill.getSkillLevel();
-		int currentHp = effector.getLifeStats().getCurrentHp();
 		if (ratio)
 			valueWithDelta = (int) (valueWithDelta / 100f * skill.getEffector().getLifeStats().getMaxHp());
-		if (effector instanceof Player) {
-			if (currentHp <= 0 || currentHp < valueWithDelta) {
-				PacketSendUtility.sendPacket((Player) effector, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_HP());
-				return false;
-			}
-		}
-		effector.getLifeStats().reduceHp(SM_ATTACK_STATUS.TYPE.USED_HP, valueWithDelta, 0, SM_ATTACK_STATUS.LOG.REGULAR, effector);
-		return true;
+		return valueWithDelta;
 	}
 
 }

--- a/game-server/src/com/aionemu/gameserver/skillengine/action/HpUseAction.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/action/HpUseAction.java
@@ -38,13 +38,12 @@ public class HpUseAction extends Action {
 
 	@Override
 	public boolean canAct(Skill skill) {
-		Creature effector = skill.getEffector();
-		if (!(effector instanceof Player player))
-			return true;
-		if (effector.getLifeStats().getCurrentHp() > getCost(skill)) // the cast may never be lethal
-			return true;
-		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_HP());
-		return false;
+		// npcs are never blocked by an hp cost, they pay what they have, see validate()
+		if (skill.getEffector() instanceof Player player && player.getLifeStats().getCurrentHp() <= getCost(skill)) { // the cast may never be lethal
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_HP());
+			return false;
+		}
+		return true;
 	}
 
 	private int getCost(Skill skill) {

--- a/game-server/src/com/aionemu/gameserver/skillengine/action/ItemUseAction.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/action/ItemUseAction.java
@@ -29,22 +29,19 @@ public class ItemUseAction extends Action {
 	protected boolean expendable = true;
 
 	@Override
-	public boolean canAct(Skill skill) {
-		if (!(skill.getEffector() instanceof Player player))
-			return true;
-		if (player.getInventory().getItemCountByItemId(itemid) >= count)
-			return true;
-		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_ITEM(DataManager.ITEM_DATA.getItemTemplate(itemid).getL10n()));
-		return false;
+	public boolean act(Skill skill) {
+		if (!expendable)
+			return canAct(skill);
+		if (skill.getEffector() instanceof Player player && !player.getInventory().decreaseByItemId(itemid, count)) {
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_ITEM(DataManager.ITEM_DATA.getItemTemplate(itemid).getL10n()));
+			return false;
+		}
+		return true;
 	}
 
 	@Override
-	public boolean act(Skill skill) {
-		if (!(skill.getEffector() instanceof Player player))
-			return true;
-		if (!expendable)
-			return canAct(skill);
-		if (!player.getInventory().decreaseByItemId(itemid, count)) {
+	public boolean canAct(Skill skill) {
+		if (skill.getEffector() instanceof Player player && player.getInventory().getItemCountByItemId(itemid) < count) {
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_ITEM(DataManager.ITEM_DATA.getItemTemplate(itemid).getL10n()));
 			return false;
 		}

--- a/game-server/src/com/aionemu/gameserver/skillengine/action/ItemUseAction.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/action/ItemUseAction.java
@@ -7,8 +7,6 @@ import javax.xml.bind.annotation.XmlType;
 
 import com.aionemu.gameserver.dataholders.DataManager;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
-import com.aionemu.gameserver.model.items.storage.Storage;
-import com.aionemu.gameserver.model.templates.item.ItemTemplate;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.skillengine.model.Skill;
 import com.aionemu.gameserver.utils.PacketSendUtility;
@@ -26,16 +24,29 @@ public class ItemUseAction extends Action {
 	@XmlAttribute(required = true)
 	protected int count;
 
+	/** False, if the item is required but not consumed. */
+	@XmlAttribute
+	protected boolean expendable = true;
+
+	@Override
+	public boolean canAct(Skill skill) {
+		if (!(skill.getEffector() instanceof Player player))
+			return true;
+		if (player.getInventory().getItemCountByItemId(itemid) >= count)
+			return true;
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_ITEM(DataManager.ITEM_DATA.getItemTemplate(itemid).getL10n()));
+		return false;
+	}
+
 	@Override
 	public boolean act(Skill skill) {
-		if (skill.getEffector() instanceof Player) {
-			ItemTemplate item = DataManager.ITEM_DATA.getItemTemplate(itemid);
-			Player player = (Player) skill.getEffector();
-			Storage inventory = player.getInventory();
-			if (!inventory.decreaseByItemId(itemid, count)) {
-				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_ITEM(item.getL10n()));
-				return false;
-			}
+		if (!(skill.getEffector() instanceof Player player))
+			return true;
+		if (!expendable)
+			return canAct(skill);
+		if (!player.getInventory().decreaseByItemId(itemid, count)) {
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_ITEM(DataManager.ITEM_DATA.getItemTemplate(itemid).getL10n()));
+			return false;
 		}
 		return true;
 	}

--- a/game-server/src/com/aionemu/gameserver/skillengine/action/MpUseAction.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/action/MpUseAction.java
@@ -5,7 +5,6 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 
-import com.aionemu.gameserver.model.gameobjects.Creature;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ATTACK_STATUS;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
@@ -38,13 +37,12 @@ public class MpUseAction extends Action {
 
 	@Override
 	public boolean canAct(Skill skill) {
-		Creature effector = skill.getEffector();
-		if (!(effector instanceof Player player))
-			return true;
-		if (effector.getLifeStats().getCurrentMp() >= getCost(skill))
-			return true;
-		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_MP());
-		return false;
+		// npcs have no mp, so they must not be blocked by an mp cost
+		if (skill.getEffector() instanceof Player player && player.getLifeStats().getCurrentMp() < getCost(skill)) {
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_MP());
+			return false;
+		}
+		return true;
 	}
 
 	private int getCost(Skill skill) {

--- a/game-server/src/com/aionemu/gameserver/skillengine/action/MpUseAction.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/action/MpUseAction.java
@@ -30,8 +30,24 @@ public class MpUseAction extends Action {
 
 	@Override
 	public boolean act(Skill skill) {
+		if (!canAct(skill))
+			return false;
+		skill.getEffector().getLifeStats().reduceMp(SM_ATTACK_STATUS.TYPE.USED_MP, getCost(skill), 0, SM_ATTACK_STATUS.LOG.REGULAR);
+		return true;
+	}
+
+	@Override
+	public boolean canAct(Skill skill) {
 		Creature effector = skill.getEffector();
-		int currentMp = effector.getLifeStats().getCurrentMp();
+		if (!(effector instanceof Player player))
+			return true;
+		if (effector.getLifeStats().getCurrentMp() >= getCost(skill))
+			return true;
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_MP());
+		return false;
+	}
+
+	private int getCost(Skill skill) {
 		int valueWithDelta = value + delta * skill.getSkillLevel();
 		if (ratio)
 			valueWithDelta = skill.getEffector().getLifeStats().getMaxMp() * valueWithDelta / 100;
@@ -40,16 +56,7 @@ public class MpUseAction extends Action {
 			// changeMpPercent is negative
 			valueWithDelta = valueWithDelta - ((valueWithDelta / ((100 / changeMpPercent))));
 		}
-
-		if (effector instanceof Player) {
-			if (currentMp <= 0 || currentMp < valueWithDelta) {
-				PacketSendUtility.sendPacket((Player) effector, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_MP());
-				return false;
-			}
-		}
-
-		effector.getLifeStats().reduceMp(SM_ATTACK_STATUS.TYPE.USED_MP, valueWithDelta, 0, SM_ATTACK_STATUS.LOG.REGULAR);
-		return true;
+		return valueWithDelta;
 	}
 
 }

--- a/game-server/src/com/aionemu/gameserver/skillengine/condition/Condition.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/condition/Condition.java
@@ -25,6 +25,15 @@ public abstract class Condition implements StatCondition {
 	 */
 	public abstract boolean validate(Skill env);
 
+	/**
+	 * Checks whether {@link #validate(Skill)} would succeed, without paying anything.
+	 *
+	 * @return True, if the condition is met
+	 */
+	public boolean canValidate(Skill skill) {
+		return true;
+	}
+
 	@Override
 	public boolean validate(Stat2 stat, IStatFunction statFunction) {
 		return true;

--- a/game-server/src/com/aionemu/gameserver/skillengine/condition/Conditions.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/condition/Conditions.java
@@ -1,13 +1,9 @@
 package com.aionemu.gameserver.skillengine.condition;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.*;
 
 import com.aionemu.gameserver.model.stats.calc.Stat2;
 import com.aionemu.gameserver.model.stats.calc.functions.IStatFunction;
@@ -38,64 +34,41 @@ public class Conditions {
 	})
 	protected List<Condition> conditions;
 
-	/**
-	 * Gets the value of the conditions property.
-	 * <p>
-	 * This accessor method returns a reference to the live list, not a snapshot. Therefore any modification you make to the returned list will be
-	 * present inside the JAXB object. This is why there is not a <CODE>set</CODE> method for the conditions property.
-	 * <p>
-	 * For example, to add a new item, do as follows:
-	 * 
-	 * <pre>
-	 * getConditions().add(newItem);
-	 * </pre>
-	 */
 	public List<Condition> getConditions() {
-		if (conditions == null) {
-			conditions = new ArrayList<>();
-		}
-		return this.conditions;
+		return conditions == null ? Collections.emptyList() : conditions;
 	}
 
 	public boolean validate(Skill skill) {
-		if (conditions != null) {
-			for (Condition condition : getConditions()) {
-				if (!condition.validate(skill)) {
-					return false;
-				}
+		for (Condition condition : getConditions()) {
+			if (!condition.validate(skill)) {
+				return false;
 			}
 		}
 		return true;
 	}
 
 	public boolean canValidate(Skill skill) {
-		if (conditions != null) {
-			for (Condition condition : getConditions()) {
-				if (!condition.canValidate(skill)) {
-					return false;
-				}
+		for (Condition condition : getConditions()) {
+			if (!condition.canValidate(skill)) {
+				return false;
 			}
 		}
 		return true;
 	}
 
 	public boolean validate(Stat2 stat, IStatFunction statFunction) {
-		if (conditions != null) {
-			for (Condition condition : getConditions()) {
-				if (!condition.validate(stat, statFunction)) {
-					return false;
-				}
+		for (Condition condition : getConditions()) {
+			if (!condition.validate(stat, statFunction)) {
+				return false;
 			}
 		}
 		return true;
 	}
 
 	public boolean validate(Effect effect) {
-		if (conditions != null) {
-			for (Condition condition : getConditions()) {
-				if (!condition.validate(effect)) {
-					return false;
-				}
+		for (Condition condition : getConditions()) {
+			if (!condition.validate(effect)) {
+				return false;
 			}
 		}
 		return true;

--- a/game-server/src/com/aionemu/gameserver/skillengine/condition/Conditions.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/condition/Conditions.java
@@ -68,6 +68,17 @@ public class Conditions {
 		return true;
 	}
 
+	public boolean canValidate(Skill skill) {
+		if (conditions != null) {
+			for (Condition condition : getConditions()) {
+				if (!condition.canValidate(skill)) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
 	public boolean validate(Stat2 stat, IStatFunction statFunction) {
 		if (conditions != null) {
 			for (Condition condition : getConditions()) {

--- a/game-server/src/com/aionemu/gameserver/skillengine/condition/HpCondition.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/condition/HpCondition.java
@@ -5,8 +5,11 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 
+import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ATTACK_STATUS;
+import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.skillengine.model.Skill;
+import com.aionemu.gameserver.utils.PacketSendUtility;
 
 /**
  * @author Tomate
@@ -24,14 +27,29 @@ public class HpCondition extends Condition {
 
 	@Override
 	public boolean validate(Skill skill) {
+		if (!canValidate(skill))
+			return false;
+		// npcs pass the check even when they cannot afford it and then pay what they have, down to 1 hp (example: skillId 18304)
+		skill.getEffector().getLifeStats().reduceHp(SM_ATTACK_STATUS.TYPE.USED_HP, getCost(skill), 0, SM_ATTACK_STATUS.LOG.REGULAR,
+			skill.getEffector());
+		return true;
+	}
 
+	@Override
+	public boolean canValidate(Skill skill) {
+		if (!(skill.getEffector() instanceof Player player)) // npcs are never blocked by an hp cost, they pay what they have, see validate()
+			return true;
+		if (player.getLifeStats().getCurrentHp() > getCost(skill)) // the cast may never be lethal
+			return true;
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_HP());
+		return false;
+	}
+
+	private int getCost(Skill skill) {
 		int valueWithDelta = value + delta * skill.getSkillLevel();
 		if (ratio)
 			valueWithDelta = (skill.getEffector().getLifeStats().getMaxHp() * valueWithDelta) / 100;
-		if (skill.getEffector().getLifeStats().getCurrentHp() > valueWithDelta)
-			skill.getEffector().getLifeStats()
-				.reduceHp(SM_ATTACK_STATUS.TYPE.USED_HP, valueWithDelta, 0, SM_ATTACK_STATUS.LOG.REGULAR, skill.getEffector());
-		return skill.getEffector().getLifeStats().getCurrentHp() >= valueWithDelta;
+		return valueWithDelta;
 	}
 
 	public int getHpValue() {

--- a/game-server/src/com/aionemu/gameserver/skillengine/condition/HpCondition.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/condition/HpCondition.java
@@ -5,6 +5,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 
+import com.aionemu.gameserver.model.gameobjects.Creature;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ATTACK_STATUS;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
@@ -29,20 +30,20 @@ public class HpCondition extends Condition {
 	public boolean validate(Skill skill) {
 		if (!canValidate(skill))
 			return false;
+		Creature effector = skill.getEffector();
 		// npcs pass the check even when they cannot afford it and then pay what they have, down to 1 hp (example: skillId 18304)
-		skill.getEffector().getLifeStats().reduceHp(SM_ATTACK_STATUS.TYPE.USED_HP, getCost(skill), 0, SM_ATTACK_STATUS.LOG.REGULAR,
-			skill.getEffector());
+		effector.getLifeStats().reduceHp(SM_ATTACK_STATUS.TYPE.USED_HP, getCost(skill), 0, SM_ATTACK_STATUS.LOG.REGULAR, effector);
 		return true;
 	}
 
 	@Override
 	public boolean canValidate(Skill skill) {
-		if (!(skill.getEffector() instanceof Player player)) // npcs are never blocked by an hp cost, they pay what they have, see validate()
-			return true;
-		if (player.getLifeStats().getCurrentHp() > getCost(skill)) // the cast may never be lethal
-			return true;
-		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_HP());
-		return false;
+		// npcs are never blocked by an hp cost, they pay what they have, see validate()
+		if (skill.getEffector() instanceof Player player && player.getLifeStats().getCurrentHp() <= getCost(skill)) { // the cast may never be lethal
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_HP());
+			return false;
+		}
+		return true;
 	}
 
 	private int getCost(Skill skill) {

--- a/game-server/src/com/aionemu/gameserver/skillengine/condition/MpCondition.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/condition/MpCondition.java
@@ -31,20 +31,18 @@ public class MpCondition extends Condition {
 	public boolean validate(Skill skill) {
 		if (!canValidate(skill))
 			return false;
-		int cost = getCost(skill);
-		if (skill.getEffector().getLifeStats().getCurrentMp() >= cost) // npcs pass the check even when they cannot afford it
-			skill.getEffector().getLifeStats().reduceMp(SM_ATTACK_STATUS.TYPE.USED_MP, cost, 0, SM_ATTACK_STATUS.LOG.REGULAR);
+		skill.getEffector().getLifeStats().reduceMp(SM_ATTACK_STATUS.TYPE.USED_MP, getCost(skill), 0, SM_ATTACK_STATUS.LOG.REGULAR);
 		return true;
 	}
 
 	@Override
 	public boolean canValidate(Skill skill) {
-		if (!(skill.getEffector() instanceof Player player)) // npc templates carry no mp at all, so they must not be blocked by an mp cost
-			return true;
-		if (player.getLifeStats().getCurrentMp() >= getCost(skill))
-			return true;
-		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_MP());
-		return false;
+		// npcs have no mp, so they must not be blocked by an mp cost
+		if (skill.getEffector() instanceof Player player && player.getLifeStats().getCurrentMp() < getCost(skill)) {
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_MP());
+			return false;
+		}
+		return true;
 	}
 
 	private int getCost(Skill skill) {

--- a/game-server/src/com/aionemu/gameserver/skillengine/condition/MpCondition.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/condition/MpCondition.java
@@ -5,8 +5,11 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 
+import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_ATTACK_STATUS;
+import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.skillengine.model.Skill;
+import com.aionemu.gameserver.utils.PacketSendUtility;
 
 /**
  * @author ATracer
@@ -26,6 +29,25 @@ public class MpCondition extends Condition {
 
 	@Override
 	public boolean validate(Skill skill) {
+		if (!canValidate(skill))
+			return false;
+		int cost = getCost(skill);
+		if (skill.getEffector().getLifeStats().getCurrentMp() >= cost) // npcs pass the check even when they cannot afford it
+			skill.getEffector().getLifeStats().reduceMp(SM_ATTACK_STATUS.TYPE.USED_MP, cost, 0, SM_ATTACK_STATUS.LOG.REGULAR);
+		return true;
+	}
+
+	@Override
+	public boolean canValidate(Skill skill) {
+		if (!(skill.getEffector() instanceof Player player)) // npc templates carry no mp at all, so they must not be blocked by an mp cost
+			return true;
+		if (player.getLifeStats().getCurrentMp() >= getCost(skill))
+			return true;
+		PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_NOT_ENOUGH_MP());
+		return false;
+	}
+
+	private int getCost(Skill skill) {
 		int valueWithDelta = value + delta * skill.getSkillLevel();
 		if (ratio)
 			valueWithDelta = (skill.getEffector().getLifeStats().getMaxMp() * valueWithDelta) / 100;
@@ -34,8 +56,6 @@ public class MpCondition extends Condition {
 			// changeMpPercent is negative
 			valueWithDelta = valueWithDelta - ((valueWithDelta / ((100 / changeMpPercent))));
 		}
-		if (skill.getEffector().getLifeStats().getCurrentMp() > valueWithDelta)
-			skill.getEffector().getLifeStats().reduceMp(SM_ATTACK_STATUS.TYPE.USED_MP, valueWithDelta, 0, SM_ATTACK_STATUS.LOG.REGULAR);
-		return skill.getEffector().getLifeStats().getCurrentMp() > valueWithDelta;
+		return valueWithDelta;
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
@@ -169,7 +169,29 @@ public class Skill {
 			}
 		}
 
+		if (castState == CastState.CAST_START && !canPayCastCosts())
+			return false;
+
 		return validateEffectedList();
+	}
+
+	/**
+	 * Checks the costs the cast will have to pay when it ends, without paying them, so that a cast which cannot be afforded never starts (example:
+	 * Dimensional Fragments for Summon Group Member, skillId: 3777).
+	 *
+	 * @return True, if all costs can be paid
+	 */
+	private boolean canPayCastCosts() {
+		Conditions endConditions = skillTemplate.getEndConditions();
+		if (endConditions != null && !endConditions.canValidate(this))
+			return false;
+		Actions skillActions = skillTemplate.getActions();
+		if (skillActions == null)
+			return true;
+		for (Action action : skillActions.getActions())
+			if (!action.canAct(this))
+				return false;
+		return true;
 	}
 
 	private boolean validateEffectedList() {
@@ -546,30 +568,11 @@ public class Skill {
 			effector.getController().cancelCurrentSkill(null); // calls effector.setCasting(null) and sends skill cancel packet
 			return;
 		}
+		if (!payCastCosts()) {
+			effector.getController().cancelCurrentSkill(null, null); // the unpaid cost already told the player what is missing
+			return;
+		}
 		effector.setCasting(null);
-
-		// try removing item, if its not possible return to prevent exploits
-		if (skillMethod == SkillMethod.ITEM && effector instanceof Player itemUser) {
-			Item item = itemUser.getInventory().getItemByObjId(itemObjectId);
-			if (item == null)
-				return;
-			if (item.getActivationCount() > 1)
-				item.setActivationCount(item.getActivationCount() - 1);
-			else if (!itemUser.getInventory().decreaseByObjectId(item.getObjectId(), 1, ItemUpdateType.DEC_ITEM_USE))
-				return;
-			itemUser.startCooldown(item);
-		}
-
-		endCondCheck();
-
-		// Perform necessary actions (use mp,dp items etc)
-		Actions skillActions = skillTemplate.getActions();
-		if (skillActions != null) {
-			for (Action action : skillActions.getActions()) {
-				if (!action.act(this))
-					return;
-			}
-		}
 
 		// Create effects and precalculate result
 		int dashStatus = 0;
@@ -765,6 +768,41 @@ public class Skill {
 	}
 
 	/**
+	 * Consumes everything the cast costs: the used item, the skill conditions and the skill actions (mp, dp, items).
+	 *
+	 * @return False, if any of them could not be paid, in which case the cast must be cancelled
+	 */
+	private boolean payCastCosts() {
+		if (!canPayCastCosts()) // nothing may be paid before it is certain that everything can be paid
+			return false;
+
+		// try removing item, if its not possible return to prevent exploits
+		if (skillMethod == SkillMethod.ITEM && effector instanceof Player itemUser) {
+			Item item = itemUser.getInventory().getItemByObjId(itemObjectId);
+			if (item == null)
+				return false;
+			if (item.getActivationCount() > 1)
+				item.setActivationCount(item.getActivationCount() - 1);
+			else if (!itemUser.getInventory().decreaseByObjectId(item.getObjectId(), 1, ItemUpdateType.DEC_ITEM_USE))
+				return false;
+			itemUser.startCooldown(item);
+		}
+
+		if (!endCondCheck())
+			return false;
+
+		// Perform necessary actions (use mp,dp items etc)
+		Actions skillActions = skillTemplate.getActions();
+		if (skillActions != null) {
+			for (Action action : skillActions.getActions()) {
+				if (!action.act(this))
+					return false;
+			}
+		}
+		return true;
+	}
+
+	/**
 	 * Check all conditions before starting cast
 	 */
 	private boolean preCastCheck() {
@@ -781,7 +819,9 @@ public class Skill {
 	}
 
 	/**
-	 * Check all conditions after using skill
+	 * Pays the conditions the skill costs when it ends (mp, hp, item and stone charges).
+	 *
+	 * @return False, if one of them could not be paid
 	 */
 	private boolean endCondCheck() {
 		Conditions skillConditions = skillTemplate.getEndConditions();


### PR DESCRIPTION
Costs are now checked when the use skill packet arrives and paid when the cast ends, the way retail splits them, so a cast nobody can afford never starts and one which fails at the end is cancelled instead of being dropped silently, which left the client displaying the cast bar of a skill that had already failed until the player moved.

Fixed the end conditions, whose result was evaluated and then discarded, so a skill fired even when its mp or hp cost could not be paid. Both conditions also re-read the already reduced value and therefore reported failure after every successful payment, and mp compared with greater instead of greater or equal. Npcs stay exempt from mp costs, since no npc template carries mp at all, and an hp cost they cannot afford drains them to 1 hp instead of killing them, which is how the elemental self destruct skills work.

Item costs can now be required without being consumed, which is what `component_expendable` 2 means in the client skill data. All 86 skills carrying a component in 4.8 use 1, so nothing changes yet.