### PR TITLE
CM_MOVE: remove double multiplication of movement vector by speed.

### DIFF
--- a/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_MOVE.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_MOVE.java
@@ -115,8 +115,8 @@ public class CM_MOVE extends AionClientPacket {
 				}
 			} else {
 				if ((type & MovementMask.ABSOLUTE) == 0) {
-					float speed = player.getGameStats().getMovementSpeedFloat();
-					m.setNewDirection(x + m.vectorX * speed, y + m.vectorY * speed, player.isFlying() ? z + m.vectorZ * speed : z + m.vectorZ, heading);
+					//The movement vector from the client already accounts for movement speed, so multiplying it by speed again overestimates the distance several times.
+					m.setNewDirection(x + m.vectorX, y + m.vectorY, z + m.vectorZ, heading);
 				} else if (heading != player.getHeading())
 					m.setNewDirection(m.getTargetX2(), m.getTargetY2(), m.getTargetZ2(), heading);
 			}


### PR DESCRIPTION
## Problem

In `CM_MOVE`, the branch for packets without the `MANUAL` flag (periodic position updates while running, falling, and gliding) calculated the movement target like this:

```java
float speed = player.getGameStats().getMovementSpeedFloat();
m.setNewDirection(x + m.vectorX * speed, y + m.vectorY * speed, player.isFlying() ? z + m.vectorZ * speed : z + m.vectorZ, heading);
```

However, the movement vector sent by the client is already scaled by the current movement speed. It represents the distance the player moves in one second, not a normalized direction vector.

Multiplying it by `speed` again caused the server to place the movement target roughly six times farther than the player actually moves.

Example from the log: a player at `(1797.80, 1857.28)` with a movement speed of `6.3` received a target at `(1775.71, 1890.25)` — about 39 meters away instead of 6.3.

## Evidence

The length of the movement vector from the packet matches the current movement speed:

```text
vec = (3.325994, -4.9937725), |vec| = 6.000, speed = 6.0
vec = (0.20020175, 6.2968183), |vec| = 6.300, speed = 6.3
```

This was also confirmed with a retail client sniff: the movement speed in `SM_PLAYER_INFO` was `7.62`, and the movement vector in the movement packet had a length of `7.62`.

The same unit is used in `SM_PLAYER_INFO`, where the vector is built from a normalized direction multiplied by the movement speed.

## Fix

The movement target now uses the vector directly:

```java
m.setNewDirection(x + m.vectorX, y + m.vectorY, z + m.vectorZ, heading);
```

This also removes the previous Z-axis asymmetry, where the vector was multiplied by `speed` only for flying players.

## Impact

The calculated movement target is used by `AntiHackService.canMove` to measure movement distance and by the AI movement logic. The incorrectly extended target therefore affected both checks.

## Testing

* Tested running, direction changes, falling, flying, and gliding in-game.
* No movement jumps, position corrections, or false `AntiHackService` triggers were observed.