### PR TITLE
SM_INVINCIBLE_TIME: implement retail packet.

### DIFF
--- a/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
@@ -646,6 +646,7 @@ public class PlayerController extends CreatureController<Player> {
 			AttackUtil.cancelCastOn(getOwner());
 			AttackUtil.removeTargetFrom(getOwner());
 			PacketSendUtility.broadcastToSightedPlayers(getOwner(), new SM_PLAYER_STATE(getOwner()), true);
+			PacketSendUtility.sendPacket(getOwner(), new SM_INVINCIBLE_TIME(60_000));
 			addTask(TaskId.PROTECTION_ACTIVE, ThreadPoolManager.getInstance().schedule(this::stopProtectionActiveTask, 60000));
 		}
 	}
@@ -659,6 +660,7 @@ public class PlayerController extends CreatureController<Player> {
 		if (player.isSpawned()) {
 			player.unsetVisualState(CreatureVisualState.BLINKING);
 			PacketSendUtility.broadcastToSightedPlayers(player, new SM_PLAYER_STATE(player), true);
+			PacketSendUtility.sendPacket(player, new SM_INVINCIBLE_TIME(0));
 			notifyAIOnMove();
 		}
 	}

--- a/game-server/src/com/aionemu/gameserver/network/aion/ServerPacketsOpcodes.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/ServerPacketsOpcodes.java
@@ -269,7 +269,7 @@ public class ServerPacketsOpcodes {
 		// addPacketOpcode(251, ); // [S_CHAR_BM_PACK_LIST] first c or h must be size or type since nonzero leads to a client crash, because of incorrect following data
 		addPacketOpcode(252, SM_PRICES.class); // [S_TAX_INFO]
 		addPacketOpcode(253, SM_TRADELIST.class); // [S_STORE_SALE_INFO]
-		// addPacketOpcode(254, ); // [S_INVINCIBLE_TIME]
+		addPacketOpcode(254, SM_INVINCIBLE_TIME.class);
 		addPacketOpcode(255, SM_RECONNECT_KEY.class); // [S_RECONNECT_KEY]
 		addPacketOpcode(256, SM_HOUSE_BIDS.class); // [S_AUCTION_LIST]
 		// addPacketOpcode(257, ); // [S_AUCTION_REGISTER] TODO: Format: d "Unknown Error d"

--- a/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_INVINCIBLE_TIME.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_INVINCIBLE_TIME.java
@@ -1,0 +1,20 @@
+package com.aionemu.gameserver.network.aion.serverpackets;
+
+import com.aionemu.gameserver.network.aion.AionConnection;
+import com.aionemu.gameserver.network.aion.AionServerPacket;
+
+/**
+ * @author SVDNESS
+ */
+public class SM_INVINCIBLE_TIME extends AionServerPacket {
+	private final int timeMs;
+
+	public SM_INVINCIBLE_TIME(int timeMs) {
+		this.timeMs = timeMs;
+	}
+
+	@Override
+	protected void writeImpl(AionConnection con) {
+		writeD(timeMs);
+	}
+}


### PR DESCRIPTION
## Summary

Implemented the `SM_INVINCIBLE_TIME` packet used when the player enters and leaves the `BLINKING` state.

## Changes

* Send `SM_INVINCIBLE_TIME(60_000)` when the protection task starts and `BLINKING` is applied.
* Send `SM_INVINCIBLE_TIME(0)` when the protection task ends and `BLINKING` is removed.
* The packet is sent to the player directly, while `SM_PLAYER_STATE` is broadcast to nearby players to update the visual state.

## Behavior

The packet keeps the client synchronized with the server-side protection timer and informs it when the temporary invincibility period starts and ends.