### PR TITLE
Item cast cancel on target switch

### DIFF
--- a/game-server/config/main/custom.properties
+++ b/game-server/config/main/custom.properties
@@ -200,6 +200,11 @@ character.deletion.time.minutes = 5
 # Default: false
 gameserver.items.ignore_potions_at_full_health = false
 
+# Cancel a running item use when the player selects another target, as the retail server does.
+# Disable it to let item uses like mounting survive a target change.
+# Default: true
+gameserver.items.cancel_use_on_target_change = true
+
 # ----------------------------
 # Starter Kit:
 # ----------------------------

--- a/game-server/src/com/aionemu/gameserver/configs/main/CustomConfig.java
+++ b/game-server/src/com/aionemu/gameserver/configs/main/CustomConfig.java
@@ -244,6 +244,12 @@ public class CustomConfig {
 	public static boolean IGNORE_POTIONS_AT_FULL_HEALTH;
 
 	/**
+	 * Cancel a running item use when the player selects another target, as the retail server does
+	 */
+	@Property(key = "gameserver.items.cancel_use_on_target_change", defaultValue = "true")
+	public static boolean CANCEL_ITEM_USE_ON_TARGET_CHANGE;
+
+	/**
 	 * Custom Reward Packages
 	 */
 	@Property(key = "gameserver.custom.starter_kit.enable", defaultValue = "false")

--- a/game-server/src/com/aionemu/gameserver/controllers/ObserveController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/ObserveController.java
@@ -175,6 +175,28 @@ public class ObserveController {
 		notifyObservers(ObserverType.UNEQUIP, item, owner);
 	}
 
+	/**
+	 * Aborts every attached {@link ItemUseObserver}, so each of them cancels its own item use and tells the player about it.
+	 */
+	public void abortItemUseObservers() {
+		List<ItemUseObserver> itemUseObservers = Collections.emptyList();
+		synchronized (observers) {
+			for (Iterator<ActionObserver> iterator = observers.iterator(); iterator.hasNext();) {
+				if (iterator.next() instanceof ItemUseObserver itemUseObserver) {
+					if (itemUseObservers.isEmpty())
+						itemUseObservers = new ArrayList<>();
+					itemUseObservers.add(itemUseObserver);
+					iterator.remove();
+				}
+			}
+		}
+
+		for (ItemUseObserver itemUseObserver : itemUseObservers) {
+			itemUseObserver.onRemoved();
+			itemUseObserver.abort();
+		}
+	}
+
 	public void notifyItemuseObservers(Item item) {
 		notifyObservers(ObserverType.ITEMUSE, item);
 	}

--- a/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
@@ -553,17 +553,8 @@ public class PlayerController extends CreatureController<Player> {
 
 	@Override
 	public void cancelUseItem() {
-		cancelUseItem(true);
-	}
-
-	public void cancelUseItem(boolean sendCancelAnimation) {
-		Player player = getOwner();
-		Item usingItem = player.getUsingItem();
-		player.setUsingItem(null);
-		if (cancelTask(TaskId.ITEM_USE) != null && sendCancelAnimation) {
-			PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), usingItem == null ? 0 : usingItem.getObjectId(),
-				usingItem == null ? 0 : usingItem.getItemTemplate().getTemplateId(), 0, 3, 0), true);
-		}
+		getOwner().getObserveController().abortItemUseObservers(); // each observer knows its item, so it sends the matching message and animation
+		cancelTask(TaskId.ITEM_USE);
 	}
 
 	@Override

--- a/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/PlayerController.java
@@ -553,8 +553,7 @@ public class PlayerController extends CreatureController<Player> {
 
 	@Override
 	public void cancelUseItem() {
-		getOwner().getObserveController().abortItemUseObservers(); // each observer knows its item, so it sends the matching message and animation
-		cancelTask(TaskId.ITEM_USE);
+		getOwner().getObserveController().abortItemUseObservers(); // each observer knows its item and cancels its own task, message and animation
 	}
 
 	@Override

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/Creature.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/Creature.java
@@ -144,6 +144,10 @@ public abstract class Creature extends VisibleObject {
 		return castingSkill;
 	}
 
+	public boolean isCastingItemSkill() {
+		return castingSkill != null && castingSkill.getItemTemplate() != null;
+	}
+
 	/**
 	 * @return The factor (in percent) scaling the chance to have the current cast interrupted by incoming damage. Players are always at 100, npcs take it
 	 *         from their template.

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Equipment.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Equipment.java
@@ -734,7 +734,7 @@ public class Equipment implements Persistable {
 
 					@Override
 					public void abort() {
-						responder.getController().cancelUseItem(false);
+						responder.getController().cancelTask(TaskId.ITEM_USE);
 						PacketSendUtility.sendPacket(responder, STR_SOUL_BOUND_ITEM_CANCELED(item.getL10n()));
 						PacketSendUtility.broadcastPacket(responder,
 							new SM_ITEM_USAGE_ANIMATION(responder.getObjectId(), item.getObjectId(), item.getItemId(), 0, 8), true);

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Player.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Player.java
@@ -108,7 +108,6 @@ public class Player extends Creature {
 	private final Storage regularWarehouse;
 	private final Storage[] petBags = new Storage[StorageType.PET_BAG_MAX - StorageType.PET_BAG_MIN + 1];
 	private final Storage[] cabinets = new Storage[StorageType.HOUSE_WH_MAX - StorageType.HOUSE_WH_MIN + 1];
-	private Item usingItem;
 
 	private PlayerSettings playerSettings;
 
@@ -459,14 +458,6 @@ public class Player extends Creature {
 
 	public Equipment getEquipment() {
 		return equipment;
-	}
-
-	public Item getUsingItem() {
-		return usingItem;
-	}
-
-	public void setUsingItem(Item usingItem) {
-		this.usingItem = usingItem;
 	}
 
 	/**

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AnimationAddAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AnimationAddAction.java
@@ -53,8 +53,10 @@ public class AnimationAddAction extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem();
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
+				PacketSendUtility.sendPacket(player,
+					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 3, 0));
 				player.getObserveController().removeObserver(this);
 			}
 

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ApExtractAction.java
@@ -133,7 +133,7 @@ public class ApExtractAction extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem(false);
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_AP_DECOMPOSE_ITEM_CANCELED(targetItem.getL10n()));
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 2, 0), true);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AssemblyItemAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/AssemblyItemAction.java
@@ -57,7 +57,7 @@ public class AssemblyItemAction extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem(false);
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ASSEMBLY_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem
 					.getItemTemplate().getTemplateId(), 0, 2, 0), true);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ChargeAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ChargeAction.java
@@ -78,7 +78,7 @@ public class ChargeAction extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem(false);
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				if (chargeWay == 1)
 					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_CHARGE_CANCELED());
 				else

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/DecomposeAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/DecomposeAction.java
@@ -142,7 +142,7 @@ public class DecomposeAction extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem(false);
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_UNCOMPRESS_COMPRESSED_ITEM_CANCELED(parentItem.getL10n()));
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0), true);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/EnchantItemAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/EnchantItemAction.java
@@ -93,9 +93,11 @@ public class EnchantItemAction extends AbstractItemAction {
 		final ItemUseObserver observer = new ItemUseObserver() {
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem();
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				PacketSendUtility.sendPacket(player, isEnchantmentStone ? SM_SYSTEM_MESSAGE.STR_ENCHANT_ITEM_CANCELED(targetItem.getL10n())
 					: SM_SYSTEM_MESSAGE.STR_GIVE_ITEM_OPTION_CANCELED(targetItem.getL10n()));
+				PacketSendUtility.broadcastPacketAndReceive(player,
+					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 3, 0));
 				player.getObserveController().removeObserver(this);
 			}
 		};

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExpExtractAction.java
@@ -59,7 +59,7 @@ public class ExpExtractAction extends AbstractItemAction {
 		final ItemUseObserver observer = new ItemUseObserver() {
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem(false);
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_CANCELED(parentItem.getL10n()));
 				PacketSendUtility.sendPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0));
@@ -80,7 +80,6 @@ public class ExpExtractAction extends AbstractItemAction {
 		long requiredExp = getRequiredExp(cd);
 		long newExp = cd.getExp() - requiredExp;
 		if (!canExtractExp(player, newExp) || !player.getInventory().decreaseByItemId(parentItem.getItemId(), 1)) {
-			player.getController().cancelUseItem(false);
 			PacketSendUtility.sendPacket(player,
 				new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0));
 			return;

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExtractAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ExtractAction.java
@@ -47,7 +47,7 @@ public class ExtractAction extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem(false);
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_DECOMPOSE_ITEM_CANCELED(targetItem.getL10n()));
 				PacketSendUtility.sendPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate()
 					.getTemplateId(), 0, 2, 0));

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/InstanceTimeClear.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/InstanceTimeClear.java
@@ -55,7 +55,7 @@ public class InstanceTimeClear extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem(false);
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0), true);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/MultiReturnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/MultiReturnAction.java
@@ -43,7 +43,7 @@ public class MultiReturnAction extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem(false);
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), item.getObjectId(), item.getItemId(), 0, 2, 0),
 					true);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/PolishAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/PolishAction.java
@@ -51,7 +51,7 @@ public class PolishAction extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem(false);
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_POLISH_CANCELED(targetItem.getL10n()));
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 2, 0), true);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/QuestStartAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/QuestStartAction.java
@@ -50,7 +50,7 @@ public class QuestStartAction extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem(false);
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0), true);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ReadAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ReadAction.java
@@ -41,7 +41,7 @@ public class ReadAction extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem(false);
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0),

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
@@ -83,7 +83,7 @@ public class RideAction extends AbstractItemAction {
 			final ItemUseObserver observer = new ItemUseObserver() {
 				@Override
 				public void abort() {
-					player.getController().cancelUseItem(false);
+					player.getController().cancelTask(TaskId.ITEM_USE);
 					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 					PacketSendUtility.broadcastPacket(player,
 						new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemId(), 0, 3, 0), true);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TamperingAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TamperingAction.java
@@ -48,8 +48,10 @@ public class TamperingAction extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem();
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_AUTHORIZE_CANCEL(targetItem.getL10n()));
+				PacketSendUtility.broadcastPacketAndReceive(player,
+					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parntObjectId, parentItemId, 0, 3, 0));
 				player.getObserveController().removeObserver(this);
 			}
 		};

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ToyPetSpawnAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/ToyPetSpawnAction.java
@@ -80,7 +80,7 @@ public class ToyPetSpawnAction extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem(false);
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentItem.getObjectId(), parentItem.getItemTemplate().getTemplateId(), 0, 2, 0), true);

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TuningAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/TuningAction.java
@@ -68,7 +68,7 @@ public class TuningAction extends AbstractItemAction {
 
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem(false);
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_REIDENTIFY_CANCELED(targetItem.getL10n()));
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), tuningScrollObjectId, tuningScrollItemId, 0, 14, 0), true);

--- a/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_EMOTION.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_EMOTION.java
@@ -5,12 +5,11 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.aionemu.gameserver.configs.main.CustomConfig;
 import com.aionemu.gameserver.model.EmotionType;
 import com.aionemu.gameserver.model.actions.PlayerMode;
-import com.aionemu.gameserver.model.gameobjects.Item;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.model.gameobjects.state.CreatureState;
-import com.aionemu.gameserver.model.templates.item.actions.ItemActions;
 import com.aionemu.gameserver.network.aion.AionClientPacket;
 import com.aionemu.gameserver.network.aion.AionConnection.State;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_EMOTION;
@@ -119,12 +118,16 @@ public class CM_EMOTION extends AionClientPacket {
 			&& (emotionType == EmotionType.CHAIR_SIT || emotionType == EmotionType.JUMP))
 			return;
 
-		Item usingItem = player.getUsingItem();
-		if (usingItem == null || !hasRideAction(usingItem)) // don't cancel getting on mount
-			player.getController().cancelUseItem();
-		if (emotionType == EmotionType.SELECT_TARGET)
+		if (emotionType == EmotionType.SELECT_TARGET) {
+			if (CustomConfig.CANCEL_ITEM_USE_ON_TARGET_CHANGE) {
+				player.getController().cancelUseItem();
+				if (player.isCastingItemSkill()) // selecting a target interrupts item casts, but not skill casts
+					player.getController().cancelCurrentSkill(null);
+			}
 			return;
+		}
 
+		player.getController().cancelUseItem();
 		player.getController().cancelCurrentSkill(null);
 
 		// check for stance
@@ -224,11 +227,6 @@ public class CM_EMOTION extends AionClientPacket {
 
 		if (player.isProtectionActive())
 			player.getController().stopProtectionActiveTask();
-	}
-
-	private boolean hasRideAction(Item item) {
-		ItemActions actions = item.getItemTemplate().getActions();
-		return actions != null && actions.getRideAction() != null;
 	}
 
 	private int getTargetObjectId(Player player) {

--- a/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_ITEM_USAGE_ANIMATION.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_ITEM_USAGE_ANIMATION.java
@@ -1,10 +1,7 @@
 package com.aionemu.gameserver.network.aion.serverpackets;
 
-import com.aionemu.gameserver.model.gameobjects.Item;
-import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.AionConnection;
 import com.aionemu.gameserver.network.aion.AionServerPacket;
-import com.aionemu.gameserver.world.World;
 
 /**
  * @author ATracer
@@ -76,12 +73,6 @@ public class SM_ITEM_USAGE_ANIMATION extends AionServerPacket {
 
 	@Override
 	protected void writeImpl(AionConnection con) {
-		if (time > 0) {
-			final Player player = World.getInstance().getPlayer(playerObjId);
-			final Item item = player.getInventory().getItemByObjId(itemObjId);
-			player.setUsingItem(item);
-		}
-
 		writeD(playerObjId); // player obj id
 		writeD(targetObjId); // target obj id
 

--- a/game-server/src/com/aionemu/gameserver/services/StigmaService.java
+++ b/game-server/src/com/aionemu/gameserver/services/StigmaService.java
@@ -378,7 +378,7 @@ public class StigmaService {
 
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem(false);
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_ITEM_CANCELED());
 				PacketSendUtility.broadcastPacket(player,
 					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), parentObjectId, chargeStone.getObjectId(), parentItemId, 0, 2, 0), true);

--- a/game-server/src/com/aionemu/gameserver/services/item/ItemActionService.java
+++ b/game-server/src/com/aionemu/gameserver/services/item/ItemActionService.java
@@ -27,7 +27,7 @@ public class ItemActionService {
 
 			@Override
 			public void abort() {
-				player.getController().cancelUseItem(false);
+				player.getController().cancelTask(TaskId.ITEM_USE);
 				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_ITEM_IDENTIFY_CANCELED(item.getL10n()));
 				PacketSendUtility.broadcastPacket(player, new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), item.getObjectId(), itemId, 0, 11, 0), true);
 				player.getObserveController().removeObserver(this);

--- a/game-server/src/com/aionemu/gameserver/services/item/ItemSocketService.java
+++ b/game-server/src/com/aionemu/gameserver/services/item/ItemSocketService.java
@@ -162,17 +162,6 @@ public class ItemSocketService {
 			return;
 		}
 
-		final ItemUseObserver observer = new ItemUseObserver() {
-			@Override
-			public void abort() {
-				player.getObserveController().removeObserver(this);
-				player.getController().cancelUseItem();
-				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_GIVE_PROC_CANCEL(weapon.getL10n()));
-			}
-		};
-
-		player.getObserveController().attach(observer);
-
 		Item godstone = player.getInventory().getItemByObjId(stoneId);
 		if (godstone == null) {
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_GIVE_ITEM_PROC_NO_PROC_GIVE_ITEM());
@@ -184,6 +173,19 @@ public class ItemSocketService {
 			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_GIVE_ITEM_PROC_NO_PROC_GIVE_ITEM());
 			return;
 		}
+
+		final ItemUseObserver observer = new ItemUseObserver() {
+			@Override
+			public void abort() {
+				player.getObserveController().removeObserver(this);
+				player.getController().cancelTask(TaskId.ITEM_USE);
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_GIVE_PROC_CANCEL(weapon.getL10n()));
+				PacketSendUtility.broadcastPacketAndReceive(player,
+					new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), stoneId, itemTemplate.getTemplateId(), 0, 3, 0));
+			}
+		};
+
+		player.getObserveController().attach(observer);
 
 		PacketSendUtility.broadcastPacketAndReceive(player,
 			new SM_ITEM_USAGE_ANIMATION(player.getObjectId(), stoneId, itemTemplate.getTemplateId(), 2000, 0, 0));


### PR DESCRIPTION
Selecting another target now cancels a running item use the way retail does, mounts and teleport scrolls included, while ordinary skill casts are left alone. The mount exception this replaces came from https://beyond-aion.com/forum/thread/1864-reitpet-cast-abbruch/ and was the only reason `Player.usingItem` existed, so the field is gone. Servers that want to keep the old behavior can set the new gameserver.items.cancel_use_on_target_change to false, which then applies to every item use and not just mounts.

`cancelUseItem()` no longer kills the scheduled task behind the observer's back, it aborts the item use observers instead, so each of them sends the message and animation that belong to its own item. That fixes two bugs: starting an identification or a soul bind and then selecting another target cancelled the task but showed nothing at all, because the client ignores the generic cancel animation once one of those bars is running, and the observer stayed attached until the next step reported the cancel out of nowhere.

Socketing a godstone attached its observer before the checks that can still bail out, which left it behind with no running task. Fixed on the way.