### PR TITLE
Fix players being disconnected instead of logged out during shutdown countdown.

### DIFF
--- a/game-server/src/com/aionemu/gameserver/ShutdownHook.java
+++ b/game-server/src/com/aionemu/gameserver/ShutdownHook.java
@@ -14,6 +14,7 @@ import com.aionemu.gameserver.services.GameTimeService;
 import com.aionemu.gameserver.services.PeriodicSaveService;
 import com.aionemu.gameserver.services.cron.CronService;
 import com.aionemu.gameserver.services.cron.CurrentThreadRunnableRunner;
+import com.aionemu.gameserver.services.player.PlayerLeaveWorldService;
 import com.aionemu.gameserver.utils.PacketSendUtility;
 import com.aionemu.gameserver.utils.ThreadPoolManager;
 import com.aionemu.gameserver.world.World;
@@ -27,6 +28,8 @@ public class ShutdownHook extends Thread {
 
 	private static final Logger log = LoggerFactory.getLogger(ShutdownHook.class);
 	private static final int UNSET_DELAY = Integer.MIN_VALUE;
+	private static final long PENDING_LEAVES_TIMEOUT_MILLIS = 5000;
+	private static final long FINAL_PACKET_FLUSH_MILLIS = 1000;
 	private final AtomicInteger remainingSeconds = new AtomicInteger(UNSET_DELAY);
 
 	public static ShutdownHook getInstance() {
@@ -47,8 +50,10 @@ public class ShutdownHook extends Thread {
 		remainingSeconds.compareAndSet(UNSET_DELAY, ShutdownConfig.DELAY);
 		for (int announceInterval = 1, expectedSeconds = remainingSeconds.get(); remainingSeconds.get() > 0;) {
 			try {
-				if (World.getInstance().getAllPlayers().isEmpty())
-					break; // fast exit
+				//An empty world does not mean everyone is gone: players vanish from it in the middle of the leave world procedure.
+				if (World.getInstance().getAllPlayers().isEmpty() && !PlayerLeaveWorldService.hasPendingLeaves()) {
+					break; //Fast exit.
+				}
 
 				if (remainingSeconds.get() % announceInterval == 0) {
 					log.info("Runtime is shutting down in " + remainingSeconds + " seconds.");
@@ -69,7 +74,11 @@ public class ShutdownHook extends Thread {
 			}
 		}
 
+		remainingSeconds.set(0);
+		awaitPendingLeaves();
+
 		GameServer.shutdownNioServer(); // shuts down network, disconnects cs/ls/all players and saves them
+		saveRemainingPlayers();
 
 		RunnableStatsManager.dumpClassStats(SortBy.AVG);
 		PeriodicSaveService.getInstance().onShutdown();
@@ -80,6 +89,38 @@ public class ShutdownHook extends Thread {
 
 		// shut down logger factory to flush all pending log messages
 		((LoggerContext) LoggerFactory.getILoggerFactory()).stop();
+	}
+
+	//Awaits leave world procedures which already started, so clients receive their quit response instead of a broken connection.
+	private void awaitPendingLeaves() {
+		long timeoutAt = System.currentTimeMillis() + PENDING_LEAVES_TIMEOUT_MILLIS;
+		while (PlayerLeaveWorldService.hasPendingLeaves() && System.currentTimeMillis() < timeoutAt) {
+			try {
+				sleep(100);
+			} catch (InterruptedException ignored) {
+				Thread.currentThread().interrupt();
+				return;
+			}
+		}
+		if (PlayerLeaveWorldService.hasPendingLeaves())
+			log.warn("Some players are still leaving the world, shutting down anyway.");
+		try {
+			sleep(FINAL_PACKET_FLUSH_MILLIS); //The quit response is sent after the procedure, so let it leave the send queue.
+		} catch (InterruptedException ignored) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	//Players without a connection (e.g. with a pending delayed leave after a crash) are not affected by closing the sockets, so they are saved here.
+	private void saveRemainingPlayers() {
+		World.getInstance().forEachPlayer(player -> {
+			try {
+				log.warn("{} was still in the world during shutdown, saving him now.", player);
+				PlayerLeaveWorldService.leaveWorld(player);
+			} catch (Exception e) {
+				log.error("Error saving {} during shutdown.", player, e);
+			}
+		});
 	}
 
 	protected void initShutdown(int exitCode, int delaySeconds) {

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Player.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Player.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.aionemu.gameserver.configs.administration.AdminConfig;
 import com.aionemu.gameserver.configs.main.SecurityConfig;
@@ -102,6 +103,7 @@ public class Player extends Creature {
 	private List<House> houses;
 
 	private ResponseRequester requester;
+	private final AtomicBoolean leavingWorld = new AtomicBoolean();
 	private boolean lookingForGroup = false;
 	private final Equipment equipment;
 	private final Storage inventory;
@@ -411,6 +413,11 @@ public class Player extends Creature {
 
 	public boolean isOnline() {
 		return getClientConnection() != null;
+	}
+
+	//Leaving the world is triggered by the quit packet, by a lost connection and by the server shutdown, but must run exactly once per session.
+	public boolean startLeavingWorld() {
+		return leavingWorld.compareAndSet(false, true);
 	}
 
 	public int getQuestExpands() {

--- a/game-server/src/com/aionemu/gameserver/network/aion/AionConnection.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/AionConnection.java
@@ -237,8 +237,9 @@ public class AionConnection extends AConnection<AionServerPacket> {
 	@Override
 	protected final void onDisconnect() {
 		connectionAliveChecker.stop();
-		if (GameServer.isShuttingDownSoon()) { // client crashing during last seconds of countdown
+		if (GameServer.isShutdownScheduled()) { //Client leaving or crashing during the countdown.
 			safeLogout(); // instant synchronized leaveWorld to ensure completion before onServerClose
+			LoginServer.getInstance().onDisconnect(this); //The login server must drop the account too, or the next login counts as a duplicate.
 			return;
 		}
 

--- a/game-server/src/com/aionemu/gameserver/services/player/PlayerLeaveWorldService.java
+++ b/game-server/src/com/aionemu/gameserver/services/player/PlayerLeaveWorldService.java
@@ -2,6 +2,7 @@ package com.aionemu.gameserver.services.player;
 
 import java.sql.Timestamp;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +42,7 @@ import com.aionemu.gameserver.world.WorldPosition;
 public class PlayerLeaveWorldService {
 
 	private static final Logger log = LoggerFactory.getLogger(PlayerLeaveWorldService.class);
+	private static final AtomicInteger pendingLeaves = new AtomicInteger();
 
 	/**
 	 * This method is called when a player loses client connection, e.g. when killing the process, or due to bad network connectivity.<br>
@@ -61,6 +63,23 @@ public class PlayerLeaveWorldService {
 	 * <b><font color='red'>NOTICE:</font> This method is called only from {@link CM_QUIT} and must not be called from anywhere else</b>
 	 */
 	public static void leaveWorld(Player player) {
+		if (!player.startLeavingWorld()) {
+			return; //Already leaving or gone, calling it twice would save him from two threads at once.
+		}
+		pendingLeaves.incrementAndGet();
+		try {
+			removeFromWorldAndSave(player);
+		} finally {
+			pendingLeaves.decrementAndGet();
+		}
+	}
+
+	//Players vanish from the world in the middle of the leave world procedure, so the shutdown hook uses this to await unfinished ones.
+	public static boolean hasPendingLeaves() {
+		return pendingLeaves.get() > 0;
+	}
+
+	private static void removeFromWorldAndSave(Player player) {
 		AionConnection con = player.getClientConnection();
 		player.setClientConnection(null); // this sets the player semi-offline, PacketSendUtility will not send packets anymore
 


### PR DESCRIPTION
Players who log out during the shutdown countdown can end up with a "Reconnect" dialog instead of a clean logout, and after the server comes back up their client is stuck: no movement, no skills, only a client restart helps. It does not happen every time — it is a race, and I hit it repeatedly on your server.

Two independent issues, one PR.

## Part 1 — the shutdown hook races the leave world procedure

`PlayerLeaveWorldService.leaveWorld` removes the player from the world in the *middle* of the procedure: `player.getController().delete()` happens on line 149, while `PlayerService.storePlayer` and the DAO calls follow on line 142 and below. The quit response is sent even later, back in `CM_QUIT`, as `con.close(new SM_QUIT_RESPONSE(...))`.

Meanwhile the hook loops on:

    if (World.getInstance().getAllPlayers().isEmpty())
        break; // fast exit

So a hook tick landing in the window between `delete()` and the actual DB write ends the countdown early and calls `shutdownNioServer()`, which closes the sockets before `SM_QUIT_RESPONSE` was ever sent. The client sees a dropped connection rather than a logout.

The same path also breaks going back to char selection (`stayConnected = true`): the player leaves the world, but his connection must stay alive — and the hook kills it.

There was also no guard against running the procedure twice: `leaveWorld` is reachable from `CM_QUIT`, from `safeLogout()` (both `onDisconnect` and `onServerClose`) and from the delayed task, so two threads could save the same player at once.
Changes:
- `Player.startLeavingWorld()` — an atomic flag making the procedure run exactly once per session.
  A fresh `Player` object is created on every login (`PlayerService.getPlayer`), so the flag is always clean and a returning player is unaffected.
- `PlayerLeaveWorldService.hasPendingLeaves()` — a counter of unfinished procedures, incremented and decremented around the (now private) body.
- The hook only exits early when the world is empty *and* nothing is still leaving, then awaits pending procedures (5s cap) plus a 1s flush pause. The pause is required because the quit response is sent after the procedure returns, so the counter alone does not cover it.
- `saveRemainingPlayers()` after `shutdownNioServer()`: a player without a connection (e.g. one with a pending delayed leave after a crash) is not affected by closing sockets, so nobody would have saved him — `ThreadPoolManager.shutdown()` would just cancel his task.

## Part 2 — onDisconnect during the countdown

`onDisconnect` checks `isShuttingDownSoon()`, which is only true for the last 30 seconds. With the default `gameserver.shutdown.delay = 120` that means the first 90 seconds of a shutdown are treated as an ordinary crash: the player gets `leaveWorldDelayed(player, up to 10s)` and lingers in the world without a connection. 
On top of that, `remainingSeconds` freezes at whatever value the loop broke at and is never reset, so `isShuttingDownSoon()` can stay false even while the sockets are already being closed.
That branch also skipped `LoginServer.onDisconnect(this)`, so the account stayed in `loggedInAccounts` and the login server never received `SM_ACCOUNT_DISCONNECTED` — the most likely reason for the broken client state on the next login.

Changes:
- `isShutdownScheduled()` instead of `isShuttingDownSoon()` — true from the first second of the countdown. `isShuttingDownSoon()` semantics are untouched, it still gates crafting, disassembly and item movement where "soon" is the right meaning.
- `LoginServer.onDisconnect(this)` is now called in that branch as well.
- `remainingSeconds` is reset to 0 when the loop ends.

## Testing

Shut the server down with players online, then log out during the countdown:
- quit to login screen — clean logout, no "Reconnect" dialog (repeat a few times, it is a race)
- back to char selection — the selection screen stays alive
- log in again after the restart — the client works normally
- the log no longer shows "Player logged out ... Account: disconnected" together with "client crash or connection loss" for a normal logout
- crash disconnects outside of a shutdown are unchanged, `leaveWorldDelayed` still applies.

P.S. If something looks wrong, it's probably my English, not the code 😄