### PR TITLE
Fixed the player restriction messages

### DIFF
--- a/game-server/src/com/aionemu/gameserver/model/ActionState.java
+++ b/game-server/src/com/aionemu/gameserver/model/ActionState.java
@@ -1,0 +1,37 @@
+package com.aionemu.gameserver.model;
+
+import com.aionemu.gameserver.model.templates.L10n;
+
+/**
+ * States the client puts into messages which name one, like STR_SKILL_CANT_CAST ("You cannot do that while you are %0.") or
+ * STR_MSG_CANNOT_USE_ITEM_DURING_PATH_FLYING ("You cannot use an item while %0."). The comments show what each one reads as.
+ */
+public enum ActionState implements L10n {
+
+	STANDING(1400053), // standing
+	PATH_FLYING(1400054), // flying
+	FREE_FLYING(1400055), // flying
+	RIDING(1400056), // riding
+	RESTING(1400057), // resting
+	SITTING(1400058), // sitting
+	DEAD(1400059), // dead
+	FLY_DEAD(1400060), // dead
+	PERSONAL_SHOP(1400061), // running a Private Store
+	LOOTING(1400062), // looting
+	FLY_LOOTING(1400063), // looting
+	CURRENT_STATUS(1400064), // in your current status
+	COMBAT(1400079), // in combat
+	GLIDING(1400082), // gliding
+	POLYMORPH(1401212); // Transformation Mode
+
+	private final int l10nId;
+
+	private ActionState(int l10nId) {
+		this.l10nId = l10nId;
+	}
+
+	@Override
+	public int getL10nId() {
+		return l10nId;
+	}
+}

--- a/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Equipment.java
+++ b/game-server/src/com/aionemu/gameserver/model/gameobjects/player/Equipment.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 
 import com.aionemu.gameserver.controllers.observer.ItemUseObserver;
 import com.aionemu.gameserver.dao.InventoryDAO;
+import com.aionemu.gameserver.model.ActionState;
 import com.aionemu.gameserver.model.EmotionType;
 import com.aionemu.gameserver.model.Race;
 import com.aionemu.gameserver.model.TaskId;
@@ -32,7 +33,6 @@ import com.aionemu.gameserver.services.StigmaService;
 import com.aionemu.gameserver.services.item.ItemPacketService;
 import com.aionemu.gameserver.services.item.ItemPacketService.ItemUpdateType;
 import com.aionemu.gameserver.skillengine.effect.WeaponDualEffect;
-import com.aionemu.gameserver.utils.ChatUtil;
 import com.aionemu.gameserver.utils.PacketSendUtility;
 import com.aionemu.gameserver.utils.ThreadPoolManager;
 import com.aionemu.gameserver.utils.audit.AuditLogger;
@@ -699,25 +699,25 @@ public class Equipment implements Persistable {
 		if (player.getInventory().getItemByObjId(item.getObjectId()) == null)
 			return false;
 		if (player.isDead()) {
-			PacketSendUtility.sendPacket(player, STR_SOUL_BOUND_INVALID_STANCE(ChatUtil.l10n(1400059)));
+			PacketSendUtility.sendPacket(player, STR_SOUL_BOUND_INVALID_STANCE(ActionState.DEAD.getL10n()));
 			return false;
 		} else if (player.isInPlayerMode(PlayerMode.RIDE)) {
-			PacketSendUtility.sendPacket(player, STR_SOUL_BOUND_INVALID_STANCE(ChatUtil.l10n(1400056)));
+			PacketSendUtility.sendPacket(player, STR_SOUL_BOUND_INVALID_STANCE(ActionState.RIDING.getL10n()));
 			return false;
 		} else if (player.isInState(CreatureState.CHAIR)) {
-			PacketSendUtility.sendPacket(player, STR_SOUL_BOUND_INVALID_STANCE(ChatUtil.l10n(1400058)));
+			PacketSendUtility.sendPacket(player, STR_SOUL_BOUND_INVALID_STANCE(ActionState.SITTING.getL10n()));
 			return false;
 		} else if (player.isInState(CreatureState.RESTING)) {
-			PacketSendUtility.sendPacket(player, STR_SOUL_BOUND_INVALID_STANCE(ChatUtil.l10n(1400057)));
+			PacketSendUtility.sendPacket(player, STR_SOUL_BOUND_INVALID_STANCE(ActionState.RESTING.getL10n()));
 			return false;
 		} else if (player.isInState(CreatureState.GLIDING)) {
-			PacketSendUtility.sendPacket(player, STR_SOUL_BOUND_INVALID_STANCE(ChatUtil.l10n(1400082)));
+			PacketSendUtility.sendPacket(player, STR_SOUL_BOUND_INVALID_STANCE(ActionState.GLIDING.getL10n()));
 			return false;
 		} else if (player.isInState(CreatureState.FLYING)) {
-			PacketSendUtility.sendPacket(player, STR_SOUL_BOUND_INVALID_STANCE(ChatUtil.l10n(1400055)));
+			PacketSendUtility.sendPacket(player, STR_SOUL_BOUND_INVALID_STANCE(ActionState.FREE_FLYING.getL10n()));
 			return false;
 		} else if (player.isInState(CreatureState.WEAPON_EQUIPPED)) {
-			PacketSendUtility.sendPacket(player, STR_SOUL_BOUND_INVALID_STANCE(ChatUtil.l10n(1400079)));
+			PacketSendUtility.sendPacket(player, STR_SOUL_BOUND_INVALID_STANCE(ActionState.COMBAT.getL10n()));
 			return false;
 		}
 

--- a/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
+++ b/game-server/src/com/aionemu/gameserver/model/templates/item/actions/RideAction.java
@@ -11,6 +11,7 @@ import com.aionemu.gameserver.controllers.observer.ActionObserver;
 import com.aionemu.gameserver.controllers.observer.ItemUseObserver;
 import com.aionemu.gameserver.controllers.observer.ObserverType;
 import com.aionemu.gameserver.dataholders.DataManager;
+import com.aionemu.gameserver.model.ActionState;
 import com.aionemu.gameserver.model.EmotionType;
 import com.aionemu.gameserver.model.TaskId;
 import com.aionemu.gameserver.model.actions.PlayerMode;
@@ -27,7 +28,6 @@ import com.aionemu.gameserver.questEngine.QuestEngine;
 import com.aionemu.gameserver.questEngine.model.QuestEnv;
 import com.aionemu.gameserver.skillengine.effect.AbnormalState;
 import com.aionemu.gameserver.skillengine.model.Effect;
-import com.aionemu.gameserver.utils.ChatUtil;
 import com.aionemu.gameserver.utils.PacketSendUtility;
 import com.aionemu.gameserver.utils.ThreadPoolManager;
 import com.aionemu.gameserver.world.zone.ZoneInstance;
@@ -57,7 +57,7 @@ public class RideAction extends AbstractItemAction {
 				}
 			}
 			if (player.isInState(CreatureState.RESTING)) {
-				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_CANT_RIDE(ChatUtil.l10n(1400057)));
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_CANT_RIDE(ActionState.RESTING.getL10n()));
 				return false;
 			}
 			if (player.getEffectController().isInAnyAbnormalState(AbnormalState.DISMOUNT_RIDE)) {

--- a/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_CASTSPELL.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/clientpackets/CM_CASTSPELL.java
@@ -3,12 +3,12 @@ package com.aionemu.gameserver.network.aion.clientpackets;
 import java.util.Set;
 
 import com.aionemu.gameserver.dataholders.DataManager;
+import com.aionemu.gameserver.model.ActionState;
 import com.aionemu.gameserver.model.gameobjects.player.Player;
 import com.aionemu.gameserver.network.aion.AionClientPacket;
 import com.aionemu.gameserver.network.aion.AionConnection.State;
 import com.aionemu.gameserver.network.aion.serverpackets.SM_SYSTEM_MESSAGE;
 import com.aionemu.gameserver.skillengine.model.SkillTemplate;
-import com.aionemu.gameserver.utils.ChatUtil;
 import com.aionemu.gameserver.utils.audit.AuditLogger;
 
 /**
@@ -75,7 +75,7 @@ public class CM_CASTSPELL extends AionClientPacket {
 		Player player = getConnection().getActivePlayer();
 
 		if (player.isDead()) {
-			sendPacket(SM_SYSTEM_MESSAGE.STR_SKILL_CANT_CAST(ChatUtil.l10n(1400059)));
+			sendPacket(SM_SYSTEM_MESSAGE.STR_SKILL_CANT_CAST(ActionState.DEAD.getL10n()));
 			return;
 		}
 

--- a/game-server/src/com/aionemu/gameserver/restrictions/PlayerRestrictions.java
+++ b/game-server/src/com/aionemu/gameserver/restrictions/PlayerRestrictions.java
@@ -3,6 +3,7 @@ package com.aionemu.gameserver.restrictions;
 import com.aionemu.gameserver.GameServer;
 import com.aionemu.gameserver.configs.main.GroupConfig;
 import com.aionemu.gameserver.dataholders.DataManager;
+import com.aionemu.gameserver.model.ActionState;
 import com.aionemu.gameserver.model.Race;
 import com.aionemu.gameserver.model.TaskId;
 import com.aionemu.gameserver.model.gameobjects.Creature;
@@ -29,7 +30,6 @@ import com.aionemu.gameserver.skillengine.model.Skill;
 import com.aionemu.gameserver.skillengine.model.SkillTemplate;
 import com.aionemu.gameserver.skillengine.model.SkillType;
 import com.aionemu.gameserver.skillengine.model.TransformType;
-import com.aionemu.gameserver.utils.ChatUtil;
 import com.aionemu.gameserver.utils.PacketSendUtility;
 import com.aionemu.gameserver.utils.audit.AuditLogger;
 import com.aionemu.gameserver.world.zone.ZoneName;
@@ -39,13 +39,9 @@ import com.aionemu.gameserver.world.zone.ZoneName;
  */
 public class PlayerRestrictions {
 
-	private static boolean checkFly(Player player, VisibleObject target) {
+	private static boolean checkFly(Player player) {
 		if (player.isUsingFlightTransporterOrWindstream()) {
-			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_RESTRICTION_NO_FLY());
-			return false;
-		}
-
-		if (target instanceof Player playerTarget && playerTarget.isUsingFlightTransporterOrWindstream()) {
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_CANT_CAST(ActionState.PATH_FLYING.getL10n()));
 			return false;
 		}
 		return true;
@@ -59,8 +55,12 @@ public class PlayerRestrictions {
 		VisibleObject target = player.getTarget();
 		SkillTemplate template = skill.getSkillTemplate();
 
-		// TODO check if its ok
-		if (!checkFly(player, target) || player.getLifeStats().isAboutToDie() || player.isDead()) {
+		if (!checkFly(player) || player.getLifeStats().isAboutToDie() || player.isDead()) {
+			return false;
+		}
+
+		if (player.getStore() != null) { // You cannot do that while you are running a Private Store.
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_SKILL_CANT_CAST(ActionState.PERSONAL_SHOP.getL10n()));
 			return false;
 		}
 		// item casts are interruptible (PlayerController cancels them), skill casts are not
@@ -208,7 +208,10 @@ public class PlayerRestrictions {
 			return false;
 		}
 
-		if (!player.isSpawned() || target == null || !checkFly(player, target) || player.getLifeStats().isAboutToDie() || player.isDead())
+		if (!player.isSpawned() || target == null || !checkFly(player) || player.getLifeStats().isAboutToDie() || player.isDead())
+			return false;
+
+		if (target instanceof Player targetPlayer && targetPlayer.isUsingFlightTransporterOrWindstream())
 			return false;
 
 		if (!player.canAttack()) {
@@ -298,7 +301,7 @@ public class PlayerRestrictions {
 		}
 
 		if (player.getStore() != null) { // You cannot use an item while running a Private Store.
-			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_CANNOT_USE_ITEM_DURING_PATH_FLYING(ChatUtil.l10n(1400061)));
+			PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_CANNOT_USE_ITEM_DURING_PATH_FLYING(ActionState.PERSONAL_SHOP.getL10n()));
 			return false;
 		}
 


### PR DESCRIPTION
Only the messages change, to the ones retail sends, except that an area skill aimed at a player on a flight transporter is no longer refused and simply does not affect him.