### PR TITLE
Stop regenerating exceed enchant skill on items above +20

### DIFF
--- a/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_SYSTEM_MESSAGE.java
+++ b/game-server/src/com/aionemu/gameserver/network/aion/serverpackets/SM_SYSTEM_MESSAGE.java
@@ -28217,6 +28217,20 @@ public final class SM_SYSTEM_MESSAGE extends AionServerPacket {
 	}
 
 	/**
+	 * %0 has failed enchantment and the added skill has been lost.
+	 */
+	public static SM_SYSTEM_MESSAGE STR_MSG_EXCEED_SKILL_DELETE(String value0) {
+		return new SM_SYSTEM_MESSAGE(1402663, value0);
+	}
+
+	/**
+	 * You must equip %0 to use %1.
+	 */
+	public static SM_SYSTEM_MESSAGE STR_MSG_SKILL_ABLE_EQUIPED(String value0, String value1) {
+		return new SM_SYSTEM_MESSAGE(1402664, value0, value1);
+	}
+
+	/**
 	 * The price of the entered item exceeds the maximum amount of Kinah.
 	 */
 	public static SM_SYSTEM_MESSAGE STR_MSG_LIMITED_VENDOR_CANT_OVER_GOLD() {

--- a/game-server/src/com/aionemu/gameserver/services/EnchantService.java
+++ b/game-server/src/com/aionemu/gameserver/services/EnchantService.java
@@ -234,8 +234,13 @@ public class EnchantService {
 		item.setEnchantLevel(enchantLevel);
 		int oldBuffId = item.getBuffSkill();
 		int newBuffId = 0;
-		if (enchantLevel >= 20)
-			newBuffId = getEquipBuff(item);
+		if (enchantLevel >= 20) {
+			if (oldBuffId > 0) {
+				newBuffId = oldBuffId;
+			} else {
+				newBuffId = getEquipBuff(item);
+			}
+		}
 		if (newBuffId != oldBuffId) {
 			item.setBuffSkill(newBuffId);
 			if (item.isEquipped()) {

--- a/game-server/src/com/aionemu/gameserver/services/EnchantService.java
+++ b/game-server/src/com/aionemu/gameserver/services/EnchantService.java
@@ -235,11 +235,8 @@ public class EnchantService {
 		int oldBuffId = item.getBuffSkill();
 		int newBuffId = 0;
 		if (enchantLevel >= 20) {
-			if (oldBuffId > 0) {
-				newBuffId = oldBuffId;
-			} else {
-				newBuffId = getEquipBuff(item);
-			}
+			// The breakthrough skill is granted once at +20 and retained through subsequent enchantments.
+			newBuffId = oldBuffId != 0 ? oldBuffId : getEquipBuff(item);
 		}
 		if (newBuffId != oldBuffId) {
 			item.setBuffSkill(newBuffId);
@@ -249,10 +246,15 @@ public class EnchantService {
 				if (newBuffId != 0)
 					SkillLearnService.learnTemporarySkill(player, newBuffId, 1);
 			}
+			if (newBuffId != 0) {
+				String skillName = DataManager.SKILL_DATA.getSkillTemplate(newBuffId).getL10n();
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_EXCEED_SKILL_ENCHANT(item.getL10n(), enchantLevel, skillName));
+				if (!item.isEquipped())
+					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_SKILL_ABLE_EQUIPED(item.getL10n(), skillName));
+			} else {
+				PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_MSG_EXCEED_SKILL_DELETE(item.getL10n()));
+			}
 		}
-		if (newBuffId != 0)
-			PacketSendUtility.sendPacket(player,
-				SM_SYSTEM_MESSAGE.STR_MSG_EXCEED_SKILL_ENCHANT(item.getL10n(), enchantLevel, DataManager.SKILL_DATA.getSkillTemplate(newBuffId).getL10n()));
 		if (item.getEnchantEffect() != null) {
 			item.getEnchantEffect().endEffect(player);
 			item.setEnchantEffect(null);


### PR DESCRIPTION
Fixes a retail bug where the EnchantService continuously regenerates a random exceed enchant skill upon every successful enchantment above +20. Now, the skill generates strictly once at +20.