### PR TITLE
Fix missing cast time for item skills without casting_delay.

### DIFF
--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
@@ -379,8 +379,10 @@ public class Skill {
 	}
 
 	private int calculateCastDuration() {
-		if (getItemTemplate() != null)
-			return getItemTemplate().getCastingDelay();
+		if (itemTemplate != null) {
+			// If the item has no custom cast time, the cast time is taken from the associated skill.
+			return itemTemplate.getCastingDelay() > 0 ? itemTemplate.getCastingDelay() : baseCastDuration;
+		}
 		//2nd+ time of multicast-skill activation
 		if (getMultiCastCount() > 0)
 			return 0;


### PR DESCRIPTION
This fixes a regression introduced in PR #153.
Fixed item casting when `casting_delay` is not defined. The server now falls back to the associated skill's duration instead of casting the item instantly.
This restores the cast bar and animation for resurrection stones, teleport scrolls.