### PR TITLE
Fix effect ordering

### DIFF
--- a/game-server/src/com/aionemu/gameserver/controllers/effect/EffectController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/effect/EffectController.java
@@ -93,11 +93,33 @@ public class EffectController {
 				chants.getFirst().endEffect();
 		}
 		put(mapToUpdate, nextEffect);
+		nextEffect.setSlotStarted();
 
 		nextEffect.startEffect();
 
 		if (!nextEffect.isPassive())
 			broadCastEffects(nextEffect);
+	}
+
+	/**
+	 * Takes the place an effect will occupy once it lands, so that the list follows the order casts ended.
+	 */
+	public void reserveSlot(Effect effect) {
+		long stamp = lock.writeLock();
+		try {
+			abnormalEffectMap.putIfAbsent(effect.getStack(), effect);
+		} finally {
+			lock.unlockWrite(stamp);
+		}
+	}
+
+	public void releaseSlot(Effect effect) {
+		long stamp = lock.writeLock();
+		try {
+			abnormalEffectMap.remove(effect.getStack(), effect);
+		} finally {
+			lock.unlockWrite(stamp);
+		}
 	}
 
 	protected final void put(Effect nextEffect) {
@@ -130,7 +152,7 @@ public class EffectController {
 		try {
 			mainLoop:
 			for (Effect effect : mapToUpdate.values()) {
-				if (!canConflict(effect, nextEffect))
+				if (effect.isSlotReserved() || !canConflict(effect, nextEffect))
 					continue;
 				for (EffectTemplate et : effect.getEffectTemplates()) {
 					if (et.getEffectId() == 0)
@@ -167,7 +189,7 @@ public class EffectController {
 		long stamp = lock.readLock();
 		try {
 			for (Effect currentEffect : mapForEffect.values()) {
-				if (!canConflict(currentEffect, newEffect))
+				if (currentEffect.isSlotReserved() || !canConflict(currentEffect, newEffect))
 					continue;
 				for (EffectTemplate newEffectTemplate : newEffect.getEffectTemplates()) {
 					if (newEffectTemplate.getEffectId() == 0)
@@ -387,7 +409,7 @@ public class EffectController {
 		long stamp = lock.readLock();
 		try {
 			for (Effect effect : effectMap.values()) {
-				if (filter.test(effect))
+				if (!effect.isSlotReserved() && filter.test(effect))
 					return effect;
 			}
 		} finally {
@@ -412,7 +434,7 @@ public class EffectController {
 		long stamp = lock.readLock();
 		try {
 			for (Effect effect : effectMap.values()) {
-				if (filter.test(effect))
+				if (!effect.isSlotReserved() && filter.test(effect))
 					effects.add(effect);
 			}
 		} finally {
@@ -456,6 +478,8 @@ public class EffectController {
 				// check count
 				if (count == 0)
 					break;
+				if (effect.isSlotReserved())
+					continue;
 				if (effectType != null) {
 					if (!effect.getSkillTemplate().hasAnyEffect(effectType))
 						continue;
@@ -602,6 +626,8 @@ public class EffectController {
 	}
 
 	private boolean isDispellable(Effect effect) {
+		if (effect.isSlotReserved()) // only holds its place, nothing to dispel yet
+			return false;
 		if (isNoShowToggle(effect))
 			return false;
 		if (effect.isSanctuaryEffect())

--- a/game-server/src/com/aionemu/gameserver/controllers/effect/EffectController.java
+++ b/game-server/src/com/aionemu/gameserver/controllers/effect/EffectController.java
@@ -642,10 +642,10 @@ public class EffectController {
 		return true;
 	}
 
-	public void dispelBuffCounterAtkEffect(Effect effect) {
+	public void dispelBuffCounterAtkEffect(Effect effect, boolean broadcast) {
 		List<Effect> effectsToEnd = filterEffects(abnormalEffectMap, e -> effect.equals(e.getDesignatedDispelEffect()));
 		for (Effect ef : effectsToEnd) {
-			ef.endEffect();
+			ef.endEffect(broadcast);
 		}
 	}
 

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/DispelBuffCounterAtkEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/DispelBuffCounterAtkEffect.java
@@ -32,7 +32,7 @@ public class DispelBuffCounterAtkEffect extends DamageEffect {
 	@Override
 	public void applyEffect(Effect effect) {
 		super.applyEffect(effect);
-		effect.getEffected().getEffectController().dispelBuffCounterAtkEffect(effect);
+		effect.requestEffectListBroadcast();
 	}
 
 	@Override
@@ -42,6 +42,7 @@ public class DispelBuffCounterAtkEffect extends DamageEffect {
 		int finalPower = power + dpower * effect.getSkillLevel();
 
 		int dispelledEffectCount = effected.getEffectController().calculateBuffsOrEffectorDebuffsToRemove(effect, count, dispelLevel, finalPower);
+		effected.getEffectController().dispelBuffCounterAtkEffect(effect, false);
 		int valueWithDelta = dispelledEffectCount > 0 ? hitvalue + ((hitvalue / 2) * (dispelledEffectCount - 1)) + hitdelta * effect.getSkillLevel() : 0;
 		AttackUtil.calculateSkillResult(effect, valueWithDelta, this, false);
 	}

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/SkillLauncherEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/SkillLauncherEffect.java
@@ -7,6 +7,7 @@ import javax.xml.bind.annotation.XmlType;
 
 import com.aionemu.gameserver.skillengine.SkillEngine;
 import com.aionemu.gameserver.skillengine.model.Effect;
+import com.aionemu.gameserver.utils.ThreadPoolManager;
 
 /**
  * @author ATracer
@@ -20,7 +21,10 @@ public class SkillLauncherEffect extends EffectTemplate {
 
 	@Override
 	public void applyEffect(Effect effect) {
-		SkillEngine.getInstance().applyEffect(skillId, effect.getEffector(), effect.getEffected());
+		ThreadPoolManager.getInstance().schedule(() -> {
+			if (effect.getEffector().isSpawned() && !effect.getEffector().isDead())
+				SkillEngine.getInstance().applyEffect(skillId, effect.getEffector(), effect.getEffected());
+		}, 50);
 	}
 
 	@Override

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
@@ -70,6 +70,7 @@ public class Effect implements StatOwner {
 	private int mpShieldSkillId = 0;
 
 	private boolean addedToController;
+	private boolean effectListBroadcastRequested;
 	private final List<Runnable> observerRemoveTasks = new ArrayList<>();
 	private boolean launchSubEffect = true;
 	private Effect subEffect;
@@ -605,6 +606,8 @@ public class Effect implements StatOwner {
 			}
 			if (applyCriticalEffect && subEffect != null)
 				subEffect.applyEffect();
+			if (effectListBroadcastRequested && !addedToController && effected != null)
+				effected.getEffectController().broadCastEffects(null); // nothing was added to the controller, which would have broadcasted on its own
 			if (effected != null)
 				effected.getAi().onEffectApplied(this);
 		} catch (Exception e) {
@@ -790,6 +793,14 @@ public class Effect implements StatOwner {
 
 	public ItemTemplate getItemTemplate() {
 		return skill == null ? null : skill.getItemTemplate();
+	}
+
+	/**
+	 * Makes this effect broadcast the effect list of the effected creature once all its templates were applied, for templates which change the list
+	 * without adding anything to it.
+	 */
+	public void requestEffectListBroadcast() {
+		effectListBroadcastRequested = true;
 	}
 
 	/**

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Effect.java
@@ -42,6 +42,7 @@ public class Effect implements StatOwner {
 	private Skill skill;
 	private int skillLevel;
 	private Integer duration;
+	private volatile boolean slotReserved;
 	private long endTime;
 	private SubEffectType subEffectType = SubEffectType.NONE;
 	private Future<?> endTask = null;
@@ -549,6 +550,38 @@ public class Effect implements StatOwner {
 			effectHate += template.calculateHate(this);
 		}
 		return effectHate == 0 ? 0 : StatFunctions.calculateHate(getEffector(), effectHate);
+	}
+
+	/**
+	 * Holds this effects place in the effected creatures effect list from the moment the cast ends, so a skill with a long hit time keeps the position
+	 * it took when it was cast. While reserved the effect is invisible to packets, dispels, conflict searches and counters.
+	 */
+	public void reserveEffectSlot() {
+		Creature target = getEffected();
+		if (target == null || successEffects.isEmpty() || isPassive() || getTargetSlot() == SkillTargetSlot.NONE)
+			return;
+		slotReserved = true;
+		target.getEffectController().reserveSlot(this);
+	}
+
+	/**
+	 * Frees a reserved place which never became an effect, for example after a resist or when the target died meanwhile.
+	 */
+	public void releaseUnusedEffectSlot() {
+		if (!slotReserved)
+			return;
+		slotReserved = false;
+		Creature target = getEffected();
+		if (target != null)
+			target.getEffectController().releaseSlot(this);
+	}
+
+	public boolean isSlotReserved() {
+		return slotReserved;
+	}
+
+	public void setSlotStarted() {
+		slotReserved = false;
 	}
 
 	/**

--- a/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/model/Skill.java
@@ -666,10 +666,20 @@ public class Skill {
 			sentCastSpellResultPacket = sendCastSpellEnd(dashStatus, effects);
 
 		// item skills apply their effects immediately, hitTime only tells the client when to display the hit
-		if (isInstantSkill() || isItemSkill)
+		boolean appliesNow = isInstantSkill() || isItemSkill;
+		if (appliesNow) {
 			applyEffect(effects);
-		else
-			ThreadPoolManager.getInstance().schedule(() -> applyEffect(effects), hitTime);
+		} else {
+			// the place in the effect list is taken now, so a long hit time does not push this skill behind ones cast after it
+			effects.forEach(Effect::reserveEffectSlot);
+			ThreadPoolManager.getInstance().schedule(() -> {
+				try {
+					applyEffect(effects);
+				} finally {
+					effects.forEach(Effect::releaseUnusedEffectSlot);
+				}
+			}, hitTime);
+		}
 
 		if (skillMethod == SkillMethod.PENALTY || skillMethod == SkillMethod.CAST || isItemSkill) {
 			if (!isItemSkill)


### PR DESCRIPTION
The list order decides which effect a dispel takes off first, and it follows the order casts ended, not the order effects land. An effect now reserves its place at the end of the cast and starts on the hit time as before, staying invisible to packets, dispels and conflict checks until then.

Also:
1) Remove dispellable buffs before rolling counter attack damage, with the removal broadcast synced to hit time.
2) Delay launched skills by 50 ms (on retail, the delay is also controlled by the `reserved3/reserved4` params, but they are 0 in all 4.8 skills, so this case was skipped. The minimum delay is always 50 ms)

Аfftected behavior:
Cast Body Root (3571) and instantly cast Root (1328): 3571 now stays ahead of Root in the effect list, even though it lands later.

Cast Magic Implosion (3555) -> Aegis Breaker (3740): the Aegis Breaker debuff appears earlier because the server reserves its effect slot before activating the `SkillLauncher`.