### PR TITLE
Signet System: Retail Alignment.

### DIFF
--- a/game-server/data/static_data/skills/signet_data_templates.xml
+++ b/game-server/data/static_data/skills/signet_data_templates.xml
@@ -9,27 +9,27 @@
 		<signet_data lvl="5" add_effect_prob="100" dmg_multi="1.5"/>
 	</signet_data_template>
 	<signet_data_template signet_skill="SIGNET2">
-		<signet_data lvl="0" dmg_multi="0.12"/>
-		<signet_data lvl="1" dmg_multi="0.3"/>
-		<signet_data lvl="2" dmg_multi="0.5"/>
-		<signet_data lvl="3" dmg_multi="0.7"/>
-		<signet_data lvl="4" dmg_multi="0.9"/>
-		<signet_data lvl="5" dmg_multi="1.1"/>
+		<signet_data lvl="0" add_effect_prob="1" dmg_multi="0.12"/>
+		<signet_data lvl="1" add_effect_prob="1" dmg_multi="0.3"/>
+		<signet_data lvl="2" add_effect_prob="1" dmg_multi="0.5"/>
+		<signet_data lvl="3" add_effect_prob="1" dmg_multi="0.7"/>
+		<signet_data lvl="4" add_effect_prob="1" dmg_multi="0.9"/>
+		<signet_data lvl="5" add_effect_prob="1" dmg_multi="1.1"/>
 	</signet_data_template>
 	<signet_data_template signet_skill="SIGNET3">
-		<signet_data lvl="0" dmg_multi="0.12"/>
-		<signet_data lvl="1" dmg_multi="0.5"/>
-		<signet_data lvl="2" dmg_multi="0.9"/>
-		<signet_data lvl="3" dmg_multi="1.1"/>
-		<signet_data lvl="4" dmg_multi="1.3"/>
-		<signet_data lvl="5" dmg_multi="1.5"/>
+		<signet_data lvl="0" add_effect_prob="1" dmg_multi="0.12"/>
+		<signet_data lvl="1" add_effect_prob="1" dmg_multi="0.5"/>
+		<signet_data lvl="2" add_effect_prob="1" dmg_multi="0.9"/>
+		<signet_data lvl="3" add_effect_prob="1" dmg_multi="1.1"/>
+		<signet_data lvl="4" add_effect_prob="1" dmg_multi="1.3"/>
+		<signet_data lvl="5" add_effect_prob="1" dmg_multi="1.5"/>
 	</signet_data_template>
 	<signet_data_template signet_skill="SIGNET4">
-		<signet_data lvl="0" dmg_multi="0.12"/>
-		<signet_data lvl="1" dmg_multi="0.5"/>
-		<signet_data lvl="2" dmg_multi="0.9"/>
-		<signet_data lvl="3" dmg_multi="1.1"/>
-		<signet_data lvl="4" dmg_multi="1.3"/>
-		<signet_data lvl="5" dmg_multi="1.5"/>
+		<signet_data lvl="0" add_effect_prob="1" dmg_multi="0.12"/>
+		<signet_data lvl="1" add_effect_prob="1" dmg_multi="0.5"/>
+		<signet_data lvl="2" add_effect_prob="1" dmg_multi="0.9"/>
+		<signet_data lvl="3" add_effect_prob="1" dmg_multi="1.1"/>
+		<signet_data lvl="4" add_effect_prob="1" dmg_multi="1.3"/>
+		<signet_data lvl="5" add_effect_prob="1" dmg_multi="1.5"/>
 	</signet_data_template>
 </signet_data_templates>

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/CarveSignetEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/CarveSignetEffect.java
@@ -10,12 +10,11 @@ import com.aionemu.gameserver.skillengine.SkillEngine;
 import com.aionemu.gameserver.skillengine.model.Effect;
 
 /**
- * @author ATracer
+ * @author ATracer, SVDNESS
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "CarveSignetEffect")
 public class CarveSignetEffect extends DamageEffect {
-
 	@XmlAttribute(name = "signet_increment", required = true)
 	protected int signetIncrement = 1;
 	@XmlAttribute(name = "signet_cap", required = true)
@@ -28,19 +27,33 @@ public class CarveSignetEffect extends DamageEffect {
 	protected int prob = 100;
 
 	@Override
+	public void calculate(Effect effect) {
+		if (!super.calculate(effect, null, null)) {
+			return;
+		}
+		Effect activeSignet = effect.getEffected().getEffectController().getAbnormalEffect(signet);
+		int currentLevel = activeSignet == null ? 0 : activeSignet.getSkillLevel();
+		int nextSignetLevel = currentLevel;
+		// Retail: no roll is performed at cap; the signet is simply refreshed.
+		if (currentLevel < signetCap && Rnd.chance() < prob) {
+			nextSignetLevel = Math.min(currentLevel + signetIncrement, signetCap);
+		}
+		// Retail: the client receives the new signet level, while a simple refresh sends zero.
+		effect.setCarvedSignet(nextSignetLevel == currentLevel ? 0 : nextSignetLevel);
+	}
+
+	@Override
 	public void applyEffect(Effect effect) {
 		super.applyEffect(effect);
-
-		if (Rnd.chance() >= prob)
-			return;
-
-		int nextSignetLevel = signetIncrement;
 		Effect activeSignet = effect.getEffected().getEffectController().getAbnormalEffect(signet);
+		int currentLevel = activeSignet == null ? 0 : activeSignet.getSkillLevel();
+		int nextSignetLevel = Math.max(currentLevel, effect.getCarvedSignet());
+		if (nextSignetLevel == 0) {
+			return;
+		}
 		if (activeSignet != null) {
 			activeSignet.endEffect();
-			nextSignetLevel = Math.min(activeSignet.getCarvedSignet() + signetIncrement, Math.max(signetCap, activeSignet.getCarvedSignet()));
 		}
-		Effect signet = SkillEngine.getInstance().applyEffect(signetId + nextSignetLevel - 1, effect.getEffector(), effect.getEffected());
-		signet.setCarvedSignet(nextSignetLevel);
+		SkillEngine.getInstance().applyEffect(signetId + nextSignetLevel - 1, effect.getEffector(), effect.getEffected());
 	}
 }

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/EffectTemplate.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/EffectTemplate.java
@@ -385,13 +385,11 @@ public abstract class EffectTemplate {
 			effect.setReflectedSkillId(attackResult.getReflectedSkillId());
 		}
 	}
-
-	/**
-	 * @param effect
-	 */
+	
 	public void calculateSubEffect(Effect effect) {
-		if (subEffect == null)
+		if (subEffect == null) {
 			return;
+		}
 		ActionModifiers mod = this.getModifiers();
 		if (mod != null) {
 			ActionModifier modifier = this.getActionModifiers(effect);
@@ -399,32 +397,40 @@ public abstract class EffectTemplate {
 				return;
 			}
 		}
-		// Pre-Check for sub effect conditions
+		// Pre-Check for sub effect conditions.
 		if (!effectSubConditionsCheck(effect)) {
 			effect.setSubEffectAborted(true);
 			return;
 		}
-
-		// chance to trigger subeffect
-		if (Rnd.chance() >= subEffect.getChance())
+		// Chance to trigger subeffect.
+		if (Rnd.chance() >= subEffect.getChance()) {
 			return;
+		}
+		Effect newEffect = createSubEffectInstance(effect);
+		if (newEffect.getSpellStatus() != SpellStatus.DODGE && newEffect.getSpellStatus() != SpellStatus.RESIST) {
+			effect.setSpellStatus(newEffect.getSpellStatus());
+		}
+		effect.setSubEffect(newEffect);
+		effect.setSubEffectType(newEffect.getSubEffectType());
+		effect.setTargetLoc(newEffect.getTargetX(), newEffect.getTargetY(), newEffect.getTargetZ());
+	}
 
+	private Effect createSubEffectInstance(Effect effect) {
 		SkillTemplate template = DataManager.SKILL_DATA.getSkillTemplate(subEffect.getSkillId());
 		int level = 1;
 		int accBoost = effect.getAccModBoost();
-		if (subEffect.isAddEffect()) { // Only used by signet bursts
-			level = effect.getSignetBurstedCount();
-			accBoost = Short.MAX_VALUE; // sub effects cannot be resisted by magic resist in case of signet bursts
+		// Only used by signet bursts.
+		if (subEffect.isAddEffect()) {
+			// Retail: sub-effect level = its base level (always 1) + the level of the bursted signet.
+			level = effect.getSignetBurstedCount() + 1;
+			// Sub effects cannot be resisted by magic resist in case of signet bursts.
+			accBoost = Short.MAX_VALUE;
 		}
 		Effect newEffect = new Effect(effect.getEffector(), effect.getOriginalEffected(), template, level, null, effect.getForceType(), true);
 		newEffect.setShieldDefense(effect.getShieldDefense());
 		newEffect.setAccModBoost(accBoost);
 		newEffect.initialize();
-		if (newEffect.getSpellStatus() != SpellStatus.DODGE && newEffect.getSpellStatus() != SpellStatus.RESIST)
-			effect.setSpellStatus(newEffect.getSpellStatus());
-		effect.setSubEffect(newEffect);
-		effect.setSubEffectType(newEffect.getSubEffectType());
-		effect.setTargetLoc(newEffect.getTargetX(), newEffect.getTargetY(), newEffect.getTargetZ());
+		return newEffect;
 	}
 
 	/**

--- a/game-server/src/com/aionemu/gameserver/skillengine/effect/SignetBurstEffect.java
+++ b/game-server/src/com/aionemu/gameserver/skillengine/effect/SignetBurstEffect.java
@@ -19,7 +19,6 @@ import com.aionemu.gameserver.skillengine.model.SignetEnum;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "SignetBurstEffect")
 public class SignetBurstEffect extends DamageEffect {
-
 	@XmlAttribute
 	protected int signetlvl;
 	@XmlAttribute
@@ -32,9 +31,9 @@ public class SignetBurstEffect extends DamageEffect {
 	public void calculateDamage(Effect effect) {
 		Effect signetEffect = effect.getEffected().getEffectController().getAbnormalEffect(signet);
 		int valueWithDelta = calculateBaseValue(effect);
-		if (element != SkillElement.NONE)
+		if (element != SkillElement.NONE) {
 			valueWithDelta *= effect.getEffector().getGameStats().getKnowledge().getCurrent() / 100f;
-
+		}
 		int effectProb = 0;
 		int signetLvl = Math.min(signetlvl, signetEffect == null ? 0 : signetEffect.getSkillLevel());
 		SignetData signetData = DataManager.SIGNET_DATA_TEMPLATES.getSignetData(SignetEnum.valueOf(signet), signetLvl);
@@ -45,8 +44,9 @@ public class SignetBurstEffect extends DamageEffect {
 		effect.setSignetBurstedCount(signetLvl);
 		AttackUtil.calculateSkillResult(effect, valueWithDelta, this, false);
 		effect.setLaunchSubEffect(Rnd.chance() < effectProb);
-		if (signetEffect != null)
+		if (signetEffect != null) {
 			signetEffect.endEffect();
+		}
 	}
 
 	@Override
@@ -59,12 +59,7 @@ public class SignetBurstEffect extends DamageEffect {
 		}
 	}
 
-	public int getSignetlvl() {
-		return signetlvl;
-	}
-
 	public String getSignet() {
 		return signet;
 	}
-
 }


### PR DESCRIPTION
The Assassin signet system (carve / burst) was verified against PTS 4.6 retail server (build 450319) behavior and the 4.8 client_skills.xml data.

The data itself was clean — no discrepancies were found across all 178 related skills. All required fixes were limited to the server implementation.

### Changes

- `CarveSignetEffect` — signet application logic was aligned with retail behavior. The signet level is now taken from `getSkillLevel()`, no roll is performed when the signet cap is reached, and existing signets are refreshed when the roll fails or the cap is already reached (previously the code silently returned).
- `carvedSignet` in `S_SKILL_SUCCEEDED` — the field is now populated the retail way: the value comes from the effect of the casting skill rather than from the signet effect itself (previously the packet always contained zero). The roll logic was moved to `calculate()` because for non-instant skills `applyEffect()` is executed through `schedule(..., hitTime)` after the packet has already been sent. This has no visible impact in 4.8, since the `STR_SKILL_SUCC_CarveSignet_*` strings only use `%num0` for damage display.
- `EffectTemplate.createSubEffectInstance` — the burst sub-effect level is now calculated as `getSignetBurstedCount() + 1`, matching retail.
- `signet_data_templates.xml` — SIGNET2/3/4 now explicitly define `add_effect_prob="1"` instead of relying on the implicit Java field initializer default.

### Known retail deviation

Signet removal in `SignetBurstEffect` was intentionally left in `calculateDamage()`, although retail performs the removal during the application phase.

Matching retail behavior exactly introduces a regression for `AS_ReSignetAssault` (3242/3243/3244), the only skills that contain both carve and burst effects. In that case, carve reaches the signet cap and returns `carvedSignet = 0`, while the existing signet has already been removed before the application phase, preventing a new signet from being applied.

### Testing

Verified in-game, all tests passed:

- correct signet count in chat messages;
- signet refresh at cap (Assassin, cap 3);
- signet refresh on failed roll for NPC carve effects;
- stun from `AS_SignetBurst_G1_AddEffect` (8383);
- application of a new level 2 signet after burst with `AS_ReSignetAssault`.